### PR TITLE
Configuration of the schema test suites based on the annotations

### DIFF
--- a/examples/RunAllExamples.sql
+++ b/examples/RunAllExamples.sql
@@ -13,3 +13,5 @@ prompt RunExampleTestThroughBaseClass
 @@RunExampleTestThroughBaseClass.sql
 prompt RunExampleTestSuiteWithCompositeReporter
 @@RunExampleTestSuiteWithCompositeReporter.sql
+prompt RunExampleTestAnnotationBasedForCurrentSchema
+@@RunExampleTestAnnotationBasedForCurrentSchema.sql

--- a/examples/RunExampleTestAnnotationBasedForCurrentSchema.sql
+++ b/examples/RunExampleTestAnnotationBasedForCurrentSchema.sql
@@ -1,0 +1,20 @@
+--Shows how to create a test suite with the default reporter which is dbms_output
+--No tables are used for this.   
+--Suite Management packages are when developed will make this easier.
+--Clear Screen
+Set Serveroutput On Size Unlimited format truncated
+set echo off
+--install the example unit test packages
+@@test_pkg1.pck
+@@test_pkg2.pck
+@@ut_custom_reporter.tps
+@@ut_custom_reporter.tpb
+
+begin  
+  ut_suite_manager.run_cur_schema_suites_static(ut_custom_reporter(a_tab_size => 2));
+end;
+/
+
+drop type ut_custom_reporter;
+drop package test_pkg1;
+drop package test_pkg2;

--- a/examples/test_pkg1.pck
+++ b/examples/test_pkg1.pck
@@ -1,0 +1,107 @@
+create or replace package test_pkg1 is
+
+  /*
+  This is the correct annotation
+  */
+  -- %suite(Name of suite on test_pkg1)
+  -- %suitepackage(all.globaltests)
+
+  /* 
+  Such comments are skipped
+  
+  test name
+  %test1
+  %test2(name=123)
+    %test3(name2=123,tete=123) 
+  %test4(name2=123,tete)
+  */
+  /*
+  This procedure is annotated incorrectly as no correct annotations specified
+  Procedure is skipped while suite configuration
+  */
+  --test name
+  --%test1
+  --%test2(name=123)
+  ----  %test3(name2=123,tete=123) 
+  ---- asd %test4(name2=123,tete)
+  --  t3 t4
+  procedure foo;
+
+  -- %test(Name of test1)
+  -- %testsetup(setup_test1)
+  -- %testteardown(teardown_test1)
+  procedure test1;
+
+  -- %test(Name of test2)
+  procedure test2;
+
+  -- %suitesetup
+  procedure global_setup;
+
+  procedure setup_test1;
+
+  procedure teardown_test1;
+
+  -- %setup
+  procedure def_setup;
+
+  -- %teardown
+  procedure def_teardown;
+
+  --%suiteteardown
+  procedure global_teardown;
+
+end;
+/
+create or replace package body test_pkg1 is
+
+  g_val1 number;
+  g_val2 number;
+
+  procedure foo is
+  begin
+    null;
+  end;
+
+  procedure test1 is
+  begin
+    ut_assert.are_equal(a_msg => '1 equals 1 check', a_expected => 1, a_actual => g_val1);
+  end;
+
+  procedure test2 is
+  begin
+    --ut_assert.are_equal(a_msg => 'null equals null check', a_expected => to_number(null), a_actual => g_val1);
+    ut_assert.are_equal(a_msg => '2 equals 2 check', a_expected => 2, a_actual => g_val2);
+  end;
+
+  procedure global_setup is
+  begin
+    dbms_output.put_line('setup procedure of test_pkb1');
+  end;
+
+  procedure setup_test1 is
+  begin
+    g_val1 := 1;
+  end;
+
+  procedure teardown_test1 is
+  begin
+    g_val1 := null;
+  end;
+
+  procedure def_setup is
+  begin
+    g_val2 := 2;
+  end;
+
+  procedure def_teardown is
+  begin
+    g_val2 := null;
+  end;
+
+  procedure global_teardown is
+  begin
+    dbms_output.put_line('global teardown procedure of test_pkb1');
+  end;
+end test_pkg1;
+/

--- a/examples/test_pkg2.pck
+++ b/examples/test_pkg2.pck
@@ -1,0 +1,30 @@
+create or replace package test_pkg2 is
+
+  /*
+  This is the correct annotation
+  */
+  -- %suite(Name of suite on test_pkg2)
+  -- %suitepackage(all)
+
+  -- %test(Name of test1)
+  procedure test1;
+
+  -- %test(Name of test2)
+  procedure test2;
+
+end;
+/
+create or replace package body test_pkg2 is
+
+  procedure test1 is
+  begin
+    ut_assert.are_equal(a_msg => '1 equals 1 check', a_expected => 1, a_actual => 1);
+  end;
+
+  procedure test2 is
+  begin
+    ut_assert.are_equal(a_msg => '2 equals 2 check', a_expected => 2, a_actual => 2);
+  end;
+
+end test_pkg2;
+/

--- a/source/install.sql
+++ b/source/install.sql
@@ -3,7 +3,6 @@
 @@types/ut_composite_object.tps
 @@types/ut_executable.tps
 @@types/ut_assert_result.tps
-@@ut_metadata.pks
 @@ut_assert.pks
 @@types/ut_suite_reporter.tps
 @@types/ut_reporters_list.tps
@@ -14,6 +13,8 @@
 @@types/ut_reporter_decorator.tps
 @@types/ut_dbms_output_suite_reporter.tps
 @@ut_utils.pks
+@@ut_metadata.pks
+@@ut_suite_manager.pks
 
 @@ut_utils.pkb
 @@types/ut_assert_result.tpb
@@ -28,4 +29,5 @@
 @@types/ut_dbms_output_suite_reporter.tpb
 @@ut_metadata.pkb
 @@ut_assert.pkb
+@@ut_suite_manager.pkb
 

--- a/source/test_pkgs.sql
+++ b/source/test_pkgs.sql
@@ -1,0 +1,94 @@
+CREATE OR REPLACE PACKAGE test_tt AS
+
+  -- %suite(Name of suite)
+	-- %suitepackage(all.globaltests)
+
+  /* 
+  test name
+  %test1
+  %test2(name=123)
+    %test3(name2=123,tete=123) 
+  %test4(name2=123,tete)
+  */
+  --test name
+  --%test1
+  --%test2(name=123)
+  ----  %test3(name2=123,tete=123) 
+  ---- asd %test4(name2=123,tete)
+  --  t3 t4
+  PROCEDURE foo;
+
+  -- %test(Name of test1)
+  -- %testsetup(setup_test1)
+  -- %testteardown(teardown_test1)
+  PROCEDURE test1;
+
+  -- %test(Name of test2)
+  PROCEDURE test2;
+
+  -- %suitesetup
+  PROCEDURE setup;
+
+  PROCEDURE setup_test1;
+
+  PROCEDURE teardown_test1;
+  
+  -- %setup
+  procedure def_setup;
+  
+  -- %teardown
+  procedure def_teardown;
+
+  --%suiteteardown
+  PROCEDURE global_teardown;
+
+END;
+/
+
+CREATE OR REPLACE PACKAGE test_tt2 AS
+
+  -- %suite(Name of suite)
+	-- %suitepackage(all.globaltests)
+
+
+  -- %test(Name of test2)
+  PROCEDURE test2;
+
+  -- %suitesetup
+  PROCEDURE setup;
+  
+  -- %setup
+  procedure def_setup;
+  
+  -- %teardown
+  procedure def_teardown;
+
+  --%suiteteardown
+  PROCEDURE global_teardown;
+
+END;
+/
+
+CREATE OR REPLACE PACKAGE test_tt3 AS
+
+  -- %suite(Name of suite)
+	-- %suitepackage(all)
+
+
+  -- %test(Name of test2)
+  PROCEDURE test2;
+
+  -- %suitesetup
+  PROCEDURE setup;
+  
+  -- %setup
+  procedure def_setup;
+  
+  -- %teardown
+  procedure def_teardown;
+
+  --%suiteteardown
+  PROCEDURE global_teardown;
+
+END;
+/

--- a/source/test_tt.spc
+++ b/source/test_tt.spc
@@ -1,0 +1,46 @@
+CREATE OR REPLACE PACKAGE test_tt AS
+
+  -- %suite(Name of suite)
+	-- %suitepackage(all.globaltests)
+
+  /* 
+  test name
+  %test1
+  %test2(name=123)
+    %test3(name2=123,tete=123) 
+  %test4(name2=123,tete)
+  */
+  --test name
+  --%test1
+  --%test2(name=123)
+  ----  %test3(name2=123,tete=123) 
+  ---- asd %test4(name2=123,tete)
+  --  t3 t4
+  PROCEDURE foo;
+
+  -- %test(Name of test1)
+  -- %testsetup(setup_test1)
+  -- %testteardown(teardown_test1)
+  PROCEDURE test1;
+
+  -- %test(Name of test2)
+  PROCEDURE test2;
+
+  -- %suitesetup
+  PROCEDURE setup;
+
+  PROCEDURE setup_test1;
+
+  PROCEDURE teardown_test1;
+  
+  -- %setup
+  procedure def_setup;
+  
+  -- %teardown
+  procedure def_teardown;
+
+  --%suiteteardown
+  PROCEDURE global_teardown;
+
+END;
+/

--- a/source/uninstall.sql
+++ b/source/uninstall.sql
@@ -1,3 +1,5 @@
+drop package ut_suite_manager;
+
 drop package ut_assert;
 
 drop package ut_metadata;

--- a/source/ut_metadata.pkb
+++ b/source/ut_metadata.pkb
@@ -1,5 +1,7 @@
 create or replace package body ut_metadata as
 
+  gc_print_debug constant boolean := false;
+
   procedure do_resolve(a_owner in out varchar2, a_object in out varchar2, a_procedure_name in out varchar2) is
     l_name          varchar2(200);
     l_context       integer;
@@ -37,14 +39,13 @@ create or replace package body ut_metadata as
 
   function package_valid(a_owner_name varchar2, a_package_name in varchar2) return boolean as
     l_cnt            number;
-    l_name           varchar2(200);
     l_schema         varchar2(200);
     l_package_name   varchar2(200);
     l_procedure_name varchar2(200);
   begin
   
-    l_schema        := a_owner_name;
-    l_package_name  := a_package_name;
+    l_schema       := a_owner_name;
+    l_package_name := a_package_name;
   
     do_resolve(l_schema, l_package_name, l_procedure_name);
   
@@ -65,7 +66,6 @@ create or replace package body ut_metadata as
   function procedure_exists(a_owner_name varchar2, a_package_name in varchar2, a_procedure_name in varchar2)
     return boolean as
     l_cnt            number;
-    l_name           varchar2(200);
     l_schema         varchar2(200);
     l_package_name   varchar2(200);
     l_procedure_name varchar2(200);
@@ -74,7 +74,7 @@ create or replace package body ut_metadata as
     l_schema         := a_owner_name;
     l_package_name   := a_package_name;
     l_procedure_name := a_procedure_name;
-
+  
     do_resolve(l_schema, l_package_name, l_procedure_name);
   
     select count(*)
@@ -105,5 +105,242 @@ create or replace package body ut_metadata as
     when others then
       return false;
   end resolvable;
+
+  procedure parse_package_annotations(a_owner_name varchar2, a_name varchar2, a_annotated_pkg out typ_annotated_package) is
+    l_pkg_spec         clob;
+    l_package_comments varchar2(32767);
+    l_proc_comments    varchar2(32767);
+    l_proc_name        t_annotation_name;
+    type tt_comment_list is table of varchar2(32767) index by pls_integer;
+    l_comments tt_comment_list;
+  
+    l_comment varchar2(32767);
+  
+    c_multiline_comment_pattern   constant varchar2(50) := '/\*.*?\*/';
+    c_singleline_comment_pattern  constant varchar2(20) := ' *-{2,}(.*?)$';
+    c_comment_replacer_patter     constant varchar2(50) := '{COMMENT#%N%}';
+    c_comment_replacer_regex_ptrn constant varchar2(25) := '{COMMENT#(\d+)}';
+    c_rgexp_identifier            constant varchar2(50) := '[a-z][a-z0-9#_$]*';
+    l_comment_replacer varchar2(50);
+  
+    --v_annotated_pkg typ_annotated_package;
+  
+    function get_annotations(a_source varchar2) return tt_annotations is
+      l_loop_index            pls_integer;
+      l_comment_index         pls_integer;
+      l_comment               varchar2(32767);
+      l_annotation_str        varchar2(32767);
+      l_annotation_params_str varchar2(32767);
+      l_annotation_name       varchar2(1000);
+      --v_annotation            typ_annotation;
+      l_annotation_params tt_annotation_params;
+      l_annotations_list  tt_annotations;
+    
+      c_annotation_pattern constant varchar2(50) := '%' || c_rgexp_identifier || '(\(.*?\))?';
+    begin
+      l_loop_index := 1;
+      while 0 != nvl(regexp_instr(srcstr        => a_source
+                                 ,pattern       => c_comment_replacer_regex_ptrn
+                                 ,occurrence    => l_loop_index
+                                 ,subexpression => 1)
+                    ,0) loop
+        l_comment_index := to_number(regexp_substr(a_source
+                                                  ,c_comment_replacer_regex_ptrn
+                                                  ,1
+                                                  ,l_loop_index
+                                                  ,subexpression => 1));
+      
+        l_comment := l_comments(l_comment_index);
+      
+        l_annotation_str := regexp_substr(l_comment, c_annotation_pattern, 1, 1, modifier => 'i');
+        if l_annotation_str is not null then
+        
+          l_annotation_params.delete;
+        
+          l_annotation_name       := lower(regexp_substr(l_annotation_str
+                                                        ,'%(' || c_rgexp_identifier || ')'
+                                                        ,modifier => 'i'
+                                                        ,subexpression => 1));
+          l_annotation_params_str := trim(regexp_substr(l_annotation_str, '\((.*?)\)', subexpression => 1));
+        
+          if l_annotation_params_str is not null then
+            for param_ind in 1 .. regexp_count(l_annotation_params_str, '(.+?)(,|$)') loop
+              declare
+                l_param_str  varchar2(32767);
+                l_param_item typ_annotation_param;
+              begin
+                l_param_str := regexp_substr(srcstr        => l_annotation_params_str
+                                            ,pattern       => '(.+?)(,|$)'
+                                            ,occurrence    => param_ind
+                                            ,subexpression => 1);
+              
+                l_param_item.key   := regexp_substr(srcstr        => l_param_str
+                                                   ,pattern       => '(' || c_rgexp_identifier || ')\s*='
+                                                   ,modifier      => 'i'
+                                                   ,subexpression => 1);
+                l_param_item.value := regexp_substr(l_param_str, '(.+?=)?(.*$)', subexpression => 2);
+              
+                l_annotation_params(l_annotation_params.count + 1) := l_param_item;
+              end;
+            end loop;
+          end if;
+        
+          l_annotations_list(l_annotation_name) := l_annotation_params;
+        end if;
+        l_loop_index := l_loop_index + 1;
+      end loop;
+    
+      return l_annotations_list;
+    
+    end;
+  begin
+    l_pkg_spec := dbms_metadata.get_ddl(object_type => 'PACKAGE_SPEC', name => a_name, schema => a_owner_name);
+  
+    /*LOOP
+    
+      v_comment := TRIM(regexp_substr(srcstr     => v_pkg_spec
+                                     ,pattern    => c_multiline_comment_pattern
+                                     ,occurrence => 1
+                                     ,modifier   => 'n'));
+    
+      EXIT WHEN v_comment IS NULL;
+      v_comments(v_comments.count + 1) := v_comment;
+    
+      v_comment_replacer := REPLACE(c_comment_replacer_patter, '%N%', v_comments.count);
+      v_pkg_spec         := regexp_replace(srcstr     => v_pkg_spec
+                                          ,pattern    => c_multiline_comment_pattern
+                                          ,replacestr => v_comment_replacer
+                                          ,occurrence => 1
+                                          ,modifier   => 'n');
+    
+    END LOOP;*/
+  
+    -- delete multiline comments
+    l_pkg_spec := regexp_replace(srcstr => l_pkg_spec, pattern => c_multiline_comment_pattern, modifier => 'n');
+  
+    loop
+      l_comment := trim(regexp_substr(srcstr        => l_pkg_spec
+                                     ,pattern       => c_singleline_comment_pattern
+                                     ,occurrence    => 1
+                                     ,modifier      => 'm'
+                                     ,subexpression => 1));
+    
+      exit when l_comment is null;
+      l_comments(l_comments.count + 1) := l_comment;
+      l_comment_replacer := replace(c_comment_replacer_patter, '%N%', l_comments.count);
+    
+      l_pkg_spec := regexp_replace(srcstr     => l_pkg_spec
+                                  ,pattern    => c_singleline_comment_pattern
+                                  ,replacestr => l_comment_replacer
+                                  ,occurrence => 1
+                                  ,modifier   => 'm');
+    
+    end loop;
+  
+    if gc_print_debug then
+      dbms_output.put_line(l_pkg_spec);
+    end if;
+  
+    l_package_comments := regexp_substr(srcstr        => l_pkg_spec
+                                       ,pattern       => 'CREATE\s+(OR\s+REPLACE) PACKAGE .*?(AS|IS)\s+((.*?{COMMENT#\d+}\s?)+)'
+                                       ,modifier      => 'i'
+                                       ,subexpression => 3);
+  
+    -- parsing for package annotations
+    --v_annotated_pkg.name := pkg_name;
+    if l_package_comments is not null then
+      a_annotated_pkg.annotations := get_annotations(l_package_comments);
+    end if;
+  
+    for annot_proc_ind in 1 .. regexp_count(srcstr   => l_pkg_spec
+                                           ,pattern  => '((.*?{COMMENT#\d+}\s?)+)\s*(procedure|function)\s+(' ||
+                                                        c_rgexp_identifier || ')'
+                                           ,modifier => 'i') loop
+    
+      l_proc_comments := trim(regexp_substr(srcstr        => l_pkg_spec
+                                           ,pattern       => '((.*?{COMMENT#\d+}\s?)+)\s*(procedure|function)\s+(' ||
+                                                             c_rgexp_identifier || ')'
+                                           ,occurrence    => annot_proc_ind
+                                           ,modifier      => 'i'
+                                           ,subexpression => 1));
+      l_proc_name     := trim(regexp_substr(srcstr        => l_pkg_spec
+                                           ,pattern       => '((.*?{COMMENT#\d+}\s?)+)\s*(procedure|function)\s+(' ||
+                                                             c_rgexp_identifier || ')'
+                                           ,occurrence    => annot_proc_ind
+                                           ,modifier      => 'i'
+                                           ,subexpression => 4));
+    
+      a_annotated_pkg.procedures(l_proc_name) := get_annotations(l_proc_comments);
+    
+    end loop;
+  
+    if gc_print_debug then
+    
+      dbms_output.put_line('package: ' || a_name);
+      dbms_output.put_line('Annotations count: ' || a_annotated_pkg.annotations.count);
+    
+      declare
+        l_name      t_annotation_name := a_annotated_pkg.annotations.first;
+        l_proc_name t_annotation_name := a_annotated_pkg.procedures.first;
+      begin
+        while l_name is not null loop
+          dbms_output.put_line('  @' || l_name);
+          if a_annotated_pkg.annotations(l_name).count > 0 then
+            dbms_output.put_line('    Parameters:');
+          
+            for j in 1 .. a_annotated_pkg.annotations(l_name).count loop
+              dbms_output.put_line('    ' || nvl(a_annotated_pkg.annotations(l_name)(j).key, '<Anonimous>') || ' = ' ||
+                                   nvl(a_annotated_pkg.annotations(l_name)(j).value, 'NULL'));
+            end loop;
+          else
+            dbms_output.put_line('    No parameters.');
+          end if;
+        
+          l_name := a_annotated_pkg.annotations.next(l_name);
+        
+        end loop;
+      
+        dbms_output.put_line('Procedures count: ' || a_annotated_pkg.procedures.count);
+      
+        while l_proc_name is not null loop
+          dbms_output.put_line(rpad('-', 80, '-'));
+          dbms_output.put_line('  Procedure: ' || l_proc_name);
+          dbms_output.put_line('  Annotations count: ' || a_annotated_pkg.procedures(l_proc_name).count);
+        
+          l_name := a_annotated_pkg.procedures(l_proc_name).first;
+          while l_name is not null loop
+            dbms_output.put_line('    @' || l_name);
+            if a_annotated_pkg.procedures(l_proc_name)(l_name).count > 0 then
+              dbms_output.put_line('      Parameters:');
+            
+              for j in 1 .. a_annotated_pkg.procedures(l_proc_name)(l_name).count loop
+                dbms_output.put_line('      ' ||
+                                     nvl(a_annotated_pkg.procedures(l_proc_name) (l_name)(j).key, '<Anonymous>') ||
+                                     ' = ' || nvl(a_annotated_pkg.procedures(l_proc_name) (l_name)(j).value, 'NULL'));
+              end loop;
+            else
+              dbms_output.put_line('      No parameters.');
+            end if;
+          
+            l_name := a_annotated_pkg.procedures(l_proc_name).next(l_name);
+          end loop;
+        
+          l_proc_name := a_annotated_pkg.procedures.next(l_proc_name);
+        end loop;
+      
+      end;
+    
+    end if;
+  
+  end parse_package_annotations;
+
+  function get_annotation_param(a_param_list tt_annotation_params, a_def_index pls_integer) return varchar2 is
+    l_result varchar2(32767);
+  begin
+    if a_param_list.exists(a_def_index) then
+      l_result := a_param_list(a_def_index).value;
+    end if;
+    return l_result;
+  end get_annotation_param;
 end;
 /

--- a/source/ut_metadata.pkb
+++ b/source/ut_metadata.pkb
@@ -242,9 +242,9 @@ create or replace package body ut_metadata as
     end if;
   
     l_package_comments := regexp_substr(srcstr        => l_pkg_spec
-                                       ,pattern       => 'CREATE\s+(OR\s+REPLACE) PACKAGE .*?(AS|IS)\s+((.*?{COMMENT#\d+}\s?)+)'
+                                       ,pattern       => 'CREATE\s+(OR\s+REPLACE)(\s+(NON)?EDITIONABLE)?\s+PACKAGE .*?(AS|IS)\s+((.*?{COMMENT#\d+}\s?)+)'
                                        ,modifier      => 'i'
-                                       ,subexpression => 3);
+                                       ,subexpression => 5);
   
     -- parsing for package annotations
     --v_annotated_pkg.name := pkg_name;

--- a/source/ut_metadata.pks
+++ b/source/ut_metadata.pks
@@ -5,21 +5,40 @@ create or replace package ut_metadata as
     Common place for all code that reads from the system tables.
   
   */
-	
-	/*
-	  function form_name
-			
-		forms correct object/subprogram name to call as owner.object[.subprogram]
-		
-  */
-	
-	function form_name(a_owner_name varchar2, a_object varchar2, a_subprogram varchar2 default null) return varchar2;
-	
+
+  subtype t_annotation_name is varchar2(1000);
+
+  type typ_annotation_param is record(
+     key   varchar2(255)
+    ,value varchar2(4000));
+  type tt_annotation_params is table of typ_annotation_param index by pls_integer;
+
+  type tt_annotations is table of tt_annotation_params index by t_annotation_name;
+
+  type tt_anoteded_procs is table of tt_annotations index by t_annotation_name;
+
+  type typ_annotated_package is record(
+     procedures  tt_anoteded_procs
+    ,annotations tt_annotations);
+
+  type t_suite_with_path is record(
+     path  varchar2(4000 char)
+    ,suite ut_test_suite);
+
   /*
-	  function: resolvable
-		
-		tries to resolve full subprogram name using dbms_utility.name_resolve
-	*/
+    function form_name
+      
+    forms correct object/subprogram name to call as owner.object[.subprogram]
+    
+  */
+
+  function form_name(a_owner_name varchar2, a_object varchar2, a_subprogram varchar2 default null) return varchar2;
+
+  /*
+    function: resolvable
+    
+    tries to resolve full subprogram name using dbms_utility.name_resolve
+  */
   function resolvable(a_owner in varchar2, a_object in varchar2, a_procedurename in varchar2) return boolean;
 
   /*
@@ -39,14 +58,22 @@ create or replace package ut_metadata as
   function procedure_exists(a_owner_name varchar2, a_package_name in varchar2, a_procedure_name in varchar2)
     return boolean;
 
+  /*
+    procedure: do_resolve
+    
+    resolves [owner.]object[.procedure] using dbms_utility.name_resolve and returnes resolved parts 
+    
+  */
+  procedure do_resolve(a_owner in out varchar2, a_object in out varchar2, a_procedure_name in out varchar2);
 
-	/*
-	  procedure: do_resolve
-		
-		resolves [owner.]object[.procedure] using dbms_utility.name_resolve and returnes resolved parts 
-		
-	*/
-	procedure do_resolve(a_owner in out varchar2, a_object in out varchar2, a_procedure_name in out varchar2);
+  function get_annotation_param(a_param_list tt_annotation_params, a_def_index pls_integer) return varchar2;
+
+  /*
+    procedure: parse_package_annotations
+    
+    parse package specification for annotations and return its annotated schema
+  */
+  procedure parse_package_annotations(a_owner_name varchar2, a_name varchar2, a_annotated_pkg out typ_annotated_package);
 
 end ut_metadata;
 /

--- a/source/ut_suite_manager.pkb
+++ b/source/ut_suite_manager.pkb
@@ -1,0 +1,276 @@
+create or replace package body ut_suite_manager is
+
+  type tt_schema_suits is table of ut_test_suite index by varchar2(4000 char);
+  type tt_schena_suits_list is table of tt_schema_suits index by varchar2(32 char);
+
+  g_schema_suites tt_schena_suits_list;
+
+  gc_print_debug constant boolean := false;
+
+  procedure config_package(a_owner_name varchar2, a_object_name varchar2, a_object_suite out ut_test_suite, a_suite_package out varchar2) is
+    l_annotation_data    ut_metadata.typ_annotated_package;
+    l_suite_name         ut_metadata.t_annotation_name;
+    l_suite_annot_params ut_metadata.tt_annotation_params;
+    l_test               ut_test;
+    l_proc_annotations   ut_metadata.tt_annotations;
+  
+    l_default_setup_proc    varchar2(32 char);
+    l_default_teardown_proc varchar2(32 char);
+    l_suite_setup_proc      varchar2(32 char);
+    l_suite_teardown_proc   varchar2(32 char);
+  
+    l_proc_index ut_metadata.t_annotation_name;
+  
+    l_owner_name  varchar2(32 char);
+    l_object_name varchar2(32 char);
+    l_dummy       varchar2(32 char);
+  
+  begin
+    l_owner_name  := a_owner_name;
+    l_object_name := a_object_name;
+  
+    ut_metadata.do_resolve(a_owner => l_owner_name, a_object => l_object_name, a_procedure_name => l_dummy);
+    ut_metadata.parse_package_annotations(a_owner_name    => l_owner_name
+                                         ,a_name          => l_object_name
+                                         ,a_annotated_pkg => l_annotation_data);
+  
+    if l_annotation_data.annotations.exists('suite') then
+      l_suite_annot_params := l_annotation_data.annotations('suite');
+      l_suite_name         := ut_metadata.get_annotation_param(l_suite_annot_params, 1);
+    
+      if l_annotation_data.annotations.exists('suitepackage') then
+        a_suite_package := ut_metadata.get_annotation_param(l_annotation_data.annotations('suitepackage'), 1) || '.' ||
+                           lower(a_object_name);
+      else
+        a_suite_package := lower(a_object_name);
+      end if;
+    
+      a_object_suite := ut_test_suite(l_suite_name, a_suite_package);
+    
+      l_proc_index := l_annotation_data.procedures.first;
+      while (l_default_setup_proc is null or l_default_teardown_proc is null or l_suite_setup_proc is null or
+            l_suite_teardown_proc is null) and l_proc_index is not null loop
+        l_proc_annotations := l_annotation_data.procedures(l_proc_index);
+      
+        if l_proc_annotations.exists('setup') and l_default_setup_proc is null then
+          l_default_setup_proc := l_proc_index;
+        elsif l_proc_annotations.exists('teardown') and l_default_teardown_proc is null then
+          l_default_teardown_proc := l_proc_index;
+        elsif l_proc_annotations.exists('suitesetup') and l_suite_setup_proc is null then
+          l_suite_setup_proc := l_proc_index;
+        elsif l_proc_annotations.exists('suiteteardown') and l_suite_teardown_proc is null then
+          l_suite_teardown_proc := l_proc_index;
+        end if;
+      
+        l_proc_index := l_annotation_data.procedures.next(l_proc_index);
+      end loop;
+    
+      if l_suite_setup_proc is not null then
+        a_object_suite.set_suite_setup(a_object_name => a_object_name
+                                      ,a_proc_name   => l_suite_setup_proc
+                                      ,a_owner_name  => a_owner_name);
+      end if;
+    
+      if l_suite_teardown_proc is not null then
+        a_object_suite.set_suite_teardown(a_object_name => a_object_name
+                                         ,a_proc_name   => l_suite_teardown_proc
+                                         ,a_owner_name  => a_owner_name);
+      end if;
+    
+      l_proc_index := l_annotation_data.procedures.first;
+      while l_proc_index is not null loop
+        declare
+          l_setup_procedure    varchar2(30 char);
+          l_teardown_procedure varchar2(30 char);
+        begin
+          l_proc_annotations := l_annotation_data.procedures(l_proc_index);
+        
+          if l_proc_annotations.exists('test') then
+            if l_proc_annotations.exists('testsetup') then
+              l_setup_procedure := ut_metadata.get_annotation_param(l_proc_annotations('testsetup'), 1);
+            end if;
+          
+            if l_proc_annotations.exists('testteardown') then
+              l_teardown_procedure := ut_metadata.get_annotation_param(l_proc_annotations('testteardown'), 1);
+            end if;
+          
+            l_test := ut_test(a_object_name        => a_object_name
+                             ,a_test_procedure     => l_proc_index
+                             ,a_test_name          => ut_metadata.get_annotation_param(l_proc_annotations('test'), 1)
+                             ,a_owner_name         => a_owner_name
+                             ,a_setup_procedure    => nvl(l_setup_procedure, l_default_setup_proc)
+                             ,a_teardown_procedure => nvl(l_teardown_procedure, l_default_teardown_proc));
+          
+            a_object_suite.add_item(l_test);
+          end if;
+        
+        end;
+        l_proc_index := l_annotation_data.procedures.next(l_proc_index);
+      end loop;
+    end if;
+  
+  end config_package;
+
+  procedure config_schema(a_owner_name varchar2) is
+    l_suite      ut_test_suite;
+    l_suite_path varchar2(4000);
+  
+    l_all_suites tt_schema_suits;
+    l_ind        varchar2(4000 char);
+    l_path       varchar2(4000 char);
+    l_root       varchar2(4000 char);
+    l_root_suite ut_test_suite;
+  
+    l_schema_suites tt_schema_suits;
+  
+    procedure put(a_root_suite in out nocopy ut_test_suite, a_path varchar2, a_suite ut_test_suite) is
+      l_temp_root varchar2(4000 char);
+      l_cur_item  ut_test_suite;
+      l_ind       pls_integer;
+    begin
+      if a_path like '%.%' then
+        l_temp_root := regexp_substr(a_path, '^[^.]+');
+      
+        if a_root_suite is not null then
+        
+          l_ind := a_root_suite.item_index(l_temp_root);
+        
+          if l_ind is null then
+            l_cur_item := ut_test_suite(null, l_temp_root);
+          else
+            l_cur_item := treat(a_root_suite.items(l_ind) as ut_test_suite);
+          end if;
+        
+          put(l_cur_item, ltrim(a_path, l_temp_root || '.'), a_suite);
+        
+          if l_ind is null then
+            a_root_suite.add_item(l_cur_item);
+          else
+            a_root_suite.items(l_ind) := l_cur_item;
+          end if;
+        
+        else
+          a_root_suite := ut_test_suite(null, l_temp_root);
+          put(a_root_suite, ltrim(a_path, l_temp_root || '.'), a_suite);
+        end if;
+      else
+        if a_root_suite is not null then
+          a_root_suite.add_item(a_suite);
+        else
+          a_root_suite := a_suite;
+        end if;
+      end if;
+    end;
+  
+    procedure print(a_suite ut_test_suite, a_pad pls_integer) is
+      l_test ut_test;
+    begin
+      dbms_output.put_line(lpad(' ', a_pad, ' ') || 'Suite: ' || a_suite.object_name);
+      dbms_output.put_line(lpad(' ', a_pad, ' ') || 'Items: ');
+      for i in 1 .. a_suite.items.count loop
+        if a_suite.items(i) is of(ut_test_suite) then
+          print(treat(a_suite.items(i) as ut_test_suite), a_pad + 2);
+        else
+        
+          l_test := treat(a_suite.items(i) as ut_test);
+          dbms_output.put_line(lpad(' ', a_pad + 2, ' ') || 'Test: ' || l_test.object_name);
+        end if;
+      end loop;
+    end;
+  
+  begin
+  
+    for rec in (select t.owner
+                      ,t.object_name
+                  from all_objects t
+                 where t.owner = a_owner_name
+                   and t.object_type in ('PACKAGE')
+                   and t.object_name not like 'UT\_%' escape '\') loop
+      config_package(rec.owner, rec.object_name, l_suite, l_suite_path);
+    
+      l_all_suites(l_suite_path) := l_suite;
+    
+    end loop;
+  
+    l_schema_suites.delete;
+  
+    l_ind := l_all_suites.first;
+    while l_ind is not null loop
+    
+      l_root := regexp_substr(l_ind, '^[^.]+');
+    
+      if l_schema_suites.exists(l_root) then
+        l_root_suite := l_schema_suites(l_root);
+        l_path       := ltrim(l_ind, l_root || '.');
+      else
+        l_root_suite := null;
+        l_path       := l_ind;
+      end if;
+      put(l_root_suite, l_path, l_all_suites(l_ind));
+    
+      l_schema_suites(l_root) := l_root_suite;
+    
+      l_ind := l_all_suites.next(l_ind);
+    end loop;
+  
+    if l_schema_suites.count > 0 then
+      g_schema_suites(a_owner_name) := l_schema_suites;
+    elsif g_schema_suites.exists(a_owner_name) then
+      g_schema_suites.delete(a_owner_name);
+    end if;
+  
+    -- printing results
+    if gc_print_debug then
+      l_ind := l_schema_suites.first;
+      while l_ind is not null loop
+        print(l_schema_suites(l_ind), 0);
+        l_ind := l_schema_suites.next(l_ind);
+      end loop;
+    end if;
+  
+  end config_schema;
+
+  procedure run_schema_suites(a_owner_name varchar2, a_reporter in out nocopy ut_suite_reporter) is
+    l_ind   varchar2(4000 char);
+    l_suite ut_test_suite;
+  begin
+    if not g_schema_suites.exists(a_owner_name) or g_schema_suites(a_owner_name).count = 0 then
+      config_schema(a_owner_name);
+    end if;
+  
+    if g_schema_suites.exists(a_owner_name) then
+      l_ind := g_schema_suites(a_owner_name).first;
+      while l_ind is not null loop
+        l_suite := g_schema_suites(a_owner_name) (l_ind);
+        l_suite.execute(a_reporter => a_reporter);
+        g_schema_suites(a_owner_name)(l_ind) := l_suite;
+        l_ind := g_schema_suites(a_owner_name).next(l_ind);
+      end loop;
+    else
+      -- we have to figure out what to do here
+      null;
+    end if;
+  
+  end run_schema_suites;
+
+  procedure run_schema_suites_static(a_owner_name varchar2, a_reporter in ut_suite_reporter) is
+    l_temp_reported ut_suite_reporter;
+  begin
+    l_temp_reported := a_reporter;
+    run_schema_suites(a_owner_name, l_temp_reported);
+  end run_schema_suites_static;
+
+  procedure run_cur_schema_suites(a_reporter in out nocopy ut_suite_reporter) is
+  begin
+    run_schema_suites(sys_context('userenv', 'current_schema'), a_reporter);
+  end run_cur_schema_suites;
+
+  procedure run_cur_schema_suites_static(a_reporter in ut_suite_reporter) is
+    l_temp_reported ut_suite_reporter;
+  begin
+    l_temp_reported := a_reporter;
+    run_schema_suites(sys_context('userenv', 'current_schema'), l_temp_reported);
+  end run_cur_schema_suites_static;
+
+end ut_suite_manager;
+/

--- a/source/ut_suite_manager.pkb
+++ b/source/ut_suite_manager.pkb
@@ -40,9 +40,9 @@ create or replace package body ut_suite_manager is
     
       if l_annotation_data.annotations.exists('suitepackage') then
         a_suite_package := ut_metadata.get_annotation_param(l_annotation_data.annotations('suitepackage'), 1) || '.' ||
-                           lower(a_object_name);
+                           lower(l_object_name);
       else
-        a_suite_package := lower(a_object_name);
+        a_suite_package := lower(l_object_name);
       end if;
     
       a_object_suite := ut_test_suite(l_suite_name, a_suite_package);
@@ -66,15 +66,15 @@ create or replace package body ut_suite_manager is
       end loop;
     
       if l_suite_setup_proc is not null then
-        a_object_suite.set_suite_setup(a_object_name => a_object_name
+        a_object_suite.set_suite_setup(a_object_name => l_object_name
                                       ,a_proc_name   => l_suite_setup_proc
-                                      ,a_owner_name  => a_owner_name);
+                                      ,a_owner_name  => l_owner_name);
       end if;
     
       if l_suite_teardown_proc is not null then
-        a_object_suite.set_suite_teardown(a_object_name => a_object_name
+        a_object_suite.set_suite_teardown(a_object_name => l_object_name
                                          ,a_proc_name   => l_suite_teardown_proc
-                                         ,a_owner_name  => a_owner_name);
+                                         ,a_owner_name  => l_owner_name);
       end if;
     
       l_proc_index := l_annotation_data.procedures.first;
@@ -94,10 +94,10 @@ create or replace package body ut_suite_manager is
               l_teardown_procedure := ut_metadata.get_annotation_param(l_proc_annotations('testteardown'), 1);
             end if;
           
-            l_test := ut_test(a_object_name        => a_object_name
+            l_test := ut_test(a_object_name        => l_object_name
                              ,a_test_procedure     => l_proc_index
                              ,a_test_name          => ut_metadata.get_annotation_param(l_proc_annotations('test'), 1)
-                             ,a_owner_name         => a_owner_name
+                             ,a_owner_name         => l_owner_name
                              ,a_setup_procedure    => nvl(l_setup_procedure, l_default_setup_proc)
                              ,a_teardown_procedure => nvl(l_teardown_procedure, l_default_teardown_proc));
           

--- a/source/ut_suite_manager.pks
+++ b/source/ut_suite_manager.pks
@@ -1,0 +1,16 @@
+create or replace package ut_suite_manager is
+
+  procedure config_package(a_owner_name varchar2, a_object_name varchar2, a_object_suite out ut_test_suite, a_suite_package out varchar2);
+
+  procedure config_schema(a_owner_name varchar2);
+
+  procedure run_schema_suites(a_owner_name varchar2, a_reporter in out nocopy ut_suite_reporter);
+
+  procedure run_schema_suites_static(a_owner_name varchar2, a_reporter in ut_suite_reporter);
+
+  procedure run_cur_schema_suites(a_reporter in out nocopy ut_suite_reporter);
+
+  procedure run_cur_schema_suites_static(a_reporter in ut_suite_reporter);
+
+end ut_suite_manager;
+/


### PR DESCRIPTION
Configuration of the schema test suites based on the annotations in the schema's packages.

ut_metadata contains procedures to scan a package for pkg annotations and annotated procedures and defines necessary types.
ut_suite_manager contains procedures to process ut_metadata annotations data and configure suites hierarchies based on them.

For each package a suite is created. Also by setting %suitepackage annotation of the package like %suitepackage(parent.semiparent) one can define suites hierarchies. Suite configured for the package will be nested in the virtual suite "semiparent" which will also be nested in "parent" virtual suite.

ut_suite_manager.config_schema procedure scans for annotations all the packages in the specified schema and configure whole schema suites (several root suites with nested suites if present).
ut_suite_manager.run_schema_suites runs all suites for the schema reconfiguring it if needed
ut_suite_manager.run_current_schema_suites does the same for the current schema

ut_suite_manager is set to scan package and for annotations and generate schema suite hierarchy

create suite and tests by parsing package spec
Added suitesetup and suite teardown to the ut_test_suite object type

Created example to demonstrate how such configuration operates.