### PR TITLE
"This" assert and minor fixes

### DIFF
--- a/source/types/ut_dbms_output_suite_reporter.tpb
+++ b/source/types/ut_dbms_output_suite_reporter.tpb
@@ -53,10 +53,12 @@ create or replace type body ut_dbms_output_suite_reporter is
   begin
     print('result: ' || test.result_to_char);
     print('asserts');
-    for i in test.items.first .. test.items.last loop
-      assert := treat(test.items(i) as ut_assert_result);
-      print('assert ' || i || ' ' || assert.result_to_char || ' message: ' || assert.message);
-    end loop;
+    if test.items is not null and test.items.count >0 then
+      for i in test.items.first .. test.items.last loop
+        assert := treat(test.items(i) as ut_assert_result);
+        print('assert ' || i || ' ' || assert.result_to_char || ' message: ' || assert.message);
+      end loop;
+    end if;
   end;
 
 end;

--- a/source/types/ut_test_object.tps
+++ b/source/types/ut_test_object.tps
@@ -2,7 +2,7 @@ create or replace type ut_test_object force under ut_composite_object
 (
   start_time  timestamp with time zone,
   end_time    timestamp with time zone,
-  object_name varchar2(32),
+  object_name varchar2(4000),
   not instantiable member procedure execute(self in out nocopy ut_test_object, a_reporter ut_reporter),
   not instantiable member function execute(self in out nocopy ut_test_object, a_reporter ut_reporter)
     return ut_reporter,

--- a/source/ut_assert.pkb
+++ b/source/ut_assert.pkb
@@ -6,13 +6,13 @@ create or replace package body ut_assert is
     l_result integer := ut_utils.tr_success;
   begin
     ut_utils.debug_log('ut_assert.get_aggregate_asserts_result');
-
+  
     for i in 1 .. g_asserts_called.count loop
       l_result := greatest(l_result, treat(g_asserts_called(i) as ut_assert_result).result);
       exit when l_result = ut_utils.tr_error;
     end loop;
     return l_result;
-
+  
   end get_aggregate_asserts_result;
 
   procedure clear_asserts is
@@ -39,30 +39,23 @@ create or replace package body ut_assert is
   function build_message(a_message varchar2, a_expected in varchar2, a_actual in varchar2) return varchar2 is
     c_max_value_len constant integer := 1800;
   begin
-    return
-      a_message
-      || ', expected: '
-      || case when length(a_expected)>c_max_value_len then substr(a_expected,1,c_max_value_len-3)||'...' else a_expected end
-      || ', actual: ' ||
-      case when length(a_actual)>c_max_value_len then substr(a_actual,1,c_max_value_len-3)||'...' else a_actual end;
+    return a_message || ', expected: ' || case when length(a_expected) > c_max_value_len then substr(a_expected
+                                                                                                    ,1
+                                                                                                    ,c_max_value_len - 3) || '...' else a_expected end || ', actual: ' || case when length(a_actual) > c_max_value_len then substr(a_actual
+                                                                                                                                                                                                                                  ,1
+                                                                                                                                                                                                                                  ,c_max_value_len - 3) || '...' else a_actual end;
   end;
 
   procedure build_assert_result(a_test boolean, a_expected in varchar2, a_actual in varchar2, a_message varchar2) is
   begin
     ut_utils.debug_log('ut_assert.build_assert_result :' || ut_utils.to_test_result(a_test) || ':' || a_message);
-    add_assert_result(
-      ut_assert_result(
-        ut_utils.to_test_result(a_test),
-        build_message(a_message, a_expected, a_actual)
-      )
-    );
+    add_assert_result(ut_assert_result(ut_utils.to_test_result(a_test), build_message(a_message, a_expected, a_actual)));
   end;
 
   procedure report_error(a_message in varchar2) is
   begin
     add_assert_result(ut_assert_result(ut_utils.tr_error, a_message));
   end;
-
 
   --assertions
   procedure are_equal(a_expected in number, a_actual in number) is
@@ -82,11 +75,11 @@ create or replace package body ut_assert is
 
   procedure are_equal(a_msg in varchar2, a_expected in anydata, a_actual in anydata) is
     l_expected any_data;
-    l_actual any_data;
+    l_actual   any_data;
   begin
-     l_expected := any_data_builder.build(a_expected);
-     l_actual := any_data_builder.build(a_actual);
-     build_assert_result((l_expected.eq(l_actual)), l_expected.to_string(), l_actual.to_string(), a_msg);
+    l_expected := any_data_builder.build(a_expected);
+    l_actual   := any_data_builder.build(a_actual);
+    build_assert_result((l_expected.eq(l_actual)), l_expected.to_string(), l_actual.to_string(), a_msg);
   end;
 
   procedure are_equal(a_expected in sys_refcursor, a_actual in sys_refcursor) is
@@ -96,11 +89,23 @@ create or replace package body ut_assert is
 
   procedure are_equal(a_msg in varchar2, a_expected in sys_refcursor, a_actual in sys_refcursor) is
     l_expected any_data;
-    l_actual any_data;
+    l_actual   any_data;
   begin
-     l_expected := any_data_builder.build(a_expected);
-     l_actual := any_data_builder.build(a_actual);
-     build_assert_result((l_expected.eq(l_actual)), l_expected.to_string(), l_actual.to_string(), a_msg);
+    l_expected := any_data_builder.build(a_expected);
+    l_actual   := any_data_builder.build(a_actual);
+    build_assert_result((l_expected.eq(l_actual)), l_expected.to_string(), l_actual.to_string(), a_msg);
+  end;
+
+  procedure this(a_condition in boolean) is
+  begin
+    this('Simple assert', a_condition);
+  end;
+  procedure this(a_msg in varchar2, a_condition in boolean) is
+  begin
+    build_assert_result(a_condition
+                       ,'TRUE'
+                       ,case a_condition when true then 'TRUE' when false then 'FALSE' else 'NULL' end
+                       ,a_msg);
   end;
 
 end ut_assert;

--- a/source/ut_assert.pks
+++ b/source/ut_assert.pks
@@ -14,6 +14,9 @@ create or replace package ut_assert authid current_user as
 
   procedure are_equal(a_expected in sys_refcursor, a_actual in sys_refcursor);
   procedure are_equal(a_msg in varchar2, a_expected in sys_refcursor, a_actual in sys_refcursor);
+  
+  procedure this(a_condition in boolean);
+  procedure this(a_msg in varchar2, a_condition in boolean);
 
 end ut_assert;
 /


### PR DESCRIPTION
Fixed ut_dbms_output_suite_reporter.tpb for not evaluating null assert_list object

Fixed size of object_name property as it might contain the full path with packages names
Added simple ut_assert.this as for now we have only "eq" procedure which is not enough for even simpliest appliactions