### PR TITLE
Now reporters can decide what and how to display from the assert

### DIFF
--- a/source/install.sql
+++ b/source/install.sql
@@ -7,6 +7,7 @@ prompt Installing utplsql framework
 @@types/ut_composite_object.tps
 @@types/ut_executable.tps
 @@types/ut_assert_result.tps
+@@types/ut_assert_list.tps
 @@ut_assert.pks
 @@types/ut_reporter.tps
 @@types/ut_reporters_list.tps

--- a/source/types/ut_assert_result.tpb
+++ b/source/types/ut_assert_result.tpb
@@ -1,12 +1,27 @@
 create or replace type body ut_assert_result is
 
-  constructor function ut_assert_result(a_result varchar2, a_message varchar2, a_name varchar2 default null)
+  constructor function ut_assert_result(a_result integer, a_message varchar2, a_name varchar2 default null)
     return self as result is
   begin
     self.name        := a_name;
     self.object_type := 0;
     self.result      := a_result;
     self.message     := a_message;
+    return;
+  end ut_assert_result;
+
+  constructor function ut_assert_result(a_name varchar2, a_result integer, a_expected_type varchar2, a_actual_type varchar2,
+    a_expected_value_string varchar2, a_actual_value_string varchar2, a_message varchar2 default null)
+    return self as result is
+  begin
+    self.name                  := a_name;
+    self.object_type           := 0;
+    self.result                := a_result;
+    self.message               := a_message;
+    self.expected_type         := a_expected_type;
+    self.actual_type           := a_actual_type;
+    self.expected_value_string := a_expected_value_string;
+    self.actual_value_string   := a_actual_value_string;
     return;
   end ut_assert_result;
 

--- a/source/types/ut_assert_result.tps
+++ b/source/types/ut_assert_result.tps
@@ -1,8 +1,14 @@
 create or replace type ut_assert_result force under ut_object
 (
-  message varchar2(4000 char),
-
-  constructor function ut_assert_result(a_result varchar2, a_message varchar2, a_name varchar2 default null)
+  message               varchar2(4000 char),
+  expected_type         varchar2(250 char),
+  actual_type           varchar2(250 char),
+  expected_value_string varchar2(4000 char),
+  actual_value_string   varchar2(4000 char),
+  constructor function ut_assert_result(a_result integer, a_message varchar2, a_name varchar2 default null)
+    return self as result,
+  constructor function ut_assert_result(a_name varchar2, a_result integer, a_expected_type varchar2, a_actual_type varchar2,
+    a_expected_value_string varchar2, a_actual_value_string varchar2, a_message varchar2 default null)
     return self as result
 )
 not final

--- a/source/types/ut_object.tps
+++ b/source/types/ut_object.tps
@@ -2,9 +2,9 @@ create or replace type ut_object as object
 (
   name varchar2(250 char),
   --execution_result ut_execution_result,
-	result integer(1),
+  result integer(1),
   object_type integer(1), --0 - assert, 1 -- test, 2 -- suite
-	
-	member function result_to_char return varchar2
+
+  member function result_to_char return varchar2
 ) not final not instantiable
 /

--- a/source/uninstall.sql
+++ b/source/uninstall.sql
@@ -22,6 +22,8 @@ drop type ut_reporters_list;
 
 drop type ut_reporter force;
 
+drop type ut_assert_list;
+
 drop type ut_assert_result;
 
 drop type ut_executable;

--- a/source/ut_assert.pkb
+++ b/source/ut_assert.pkb
@@ -1,6 +1,6 @@
 create or replace package body ut_assert is
 
-  g_asserts_called ut_objects_list := ut_objects_list();
+  g_asserts_called ut_assert_list := ut_assert_list();
 
   function get_aggregate_asserts_result return integer is
     l_result integer := ut_utils.tr_success;
@@ -8,7 +8,7 @@ create or replace package body ut_assert is
     ut_utils.debug_log('ut_assert.get_aggregate_asserts_result');
   
     for i in 1 .. g_asserts_called.count loop
-      l_result := greatest(l_result, treat(g_asserts_called(i) as ut_assert_result).result);
+      l_result := greatest(l_result, g_asserts_called(i).result);
       exit when l_result = ut_utils.tr_error;
     end loop;
     return l_result;
@@ -22,11 +22,16 @@ create or replace package body ut_assert is
   end;
 
   function get_asserts_results return ut_objects_list is
-    l_asserts_results ut_objects_list;
+    l_asserts_results ut_objects_list := ut_objects_list();
   begin
     ut_utils.debug_log('ut_assert.get_asserts_results');
-    l_asserts_results := g_asserts_called;
-    clear_asserts();
+    if g_asserts_called is not null and g_asserts_called.count > 0 then
+      l_asserts_results.extend(g_asserts_called.count);
+      for i in 1 .. g_asserts_called.count loop
+        l_asserts_results(i) := g_asserts_called(i);
+      end loop;
+      clear_asserts();
+    end if;
     return l_asserts_results;
   end get_asserts_results;
 
@@ -39,17 +44,21 @@ create or replace package body ut_assert is
   function build_message(a_message varchar2, a_expected in varchar2, a_actual in varchar2) return varchar2 is
     c_max_value_len constant integer := 1800;
   begin
-    return a_message || ', expected: ' || case when length(a_expected) > c_max_value_len then substr(a_expected
-                                                                                                    ,1
-                                                                                                    ,c_max_value_len - 3) || '...' else a_expected end || ', actual: ' || case when length(a_actual) > c_max_value_len then substr(a_actual
-                                                                                                                                                                                                                                  ,1
-                                                                                                                                                                                                                                  ,c_max_value_len - 3) || '...' else a_actual end;
+    return a_message || ', expected: ' || ut_utils.to_string(a_expected)|| ', actual: ' || ut_utils.to_string(a_actual);
   end;
 
-  procedure build_assert_result(a_test boolean, a_expected in varchar2, a_actual in varchar2, a_message varchar2) is
+  procedure build_assert_result(
+    a_assert_result boolean, a_assert_name varchar2, a_expected_type in varchar2, a_actual_type in varchar2,
+    a_expected_value_string in varchar2, a_actual_value_string in varchar2, a_message varchar2
+  ) is
   begin
-    ut_utils.debug_log('ut_assert.build_assert_result :' || ut_utils.to_test_result(a_test) || ':' || a_message);
-    add_assert_result(ut_assert_result(ut_utils.to_test_result(a_test), build_message(a_message, a_expected, a_actual)));
+    ut_utils.debug_log('ut_assert.build_assert_result :' || ut_utils.to_test_result(a_assert_result) || ':' || a_message);
+    add_assert_result(
+      ut_assert_result(
+        a_assert_name, ut_utils.to_test_result(a_assert_result),
+        a_expected_type, a_actual_type, a_expected_value_string, a_actual_value_string, a_message
+      )
+    );
   end;
 
   procedure report_error(a_message in varchar2) is
@@ -61,47 +70,47 @@ create or replace package body ut_assert is
   --assertions
   procedure are_equal(a_expected in number, a_actual in number) is
   begin
-    are_equal('Equality test', a_expected, a_actual);
+    are_equal(null, a_expected, a_actual);
   end;
 
   procedure are_equal(a_msg in varchar2, a_expected in number, a_actual in number) is
   begin
-    build_assert_result((a_expected = a_actual), a_expected, a_actual, a_msg);
+    build_assert_result((a_expected = a_actual), 'are_equal', 'number', 'number', ut_utils.to_string(a_expected), ut_utils.to_string(a_actual), ut_utils.to_string(a_msg));
   end;
 
   procedure are_equal(a_expected in varchar2, a_actual in varchar2) is
   begin
-    are_equal('Equality test', a_expected, a_actual);
+    are_equal(null, a_expected, a_actual);
   end;
 
   procedure are_equal(a_msg in varchar2, a_expected in varchar2, a_actual in varchar2) is
   begin
-    build_assert_result((a_expected = a_actual), a_expected, a_actual, a_msg);
+    build_assert_result((a_expected = a_actual), 'are_equal', 'varchar2', 'varchar2', ut_utils.to_string(a_expected), ut_utils.to_string(a_actual), ut_utils.to_string(a_msg));
   end;
 
   procedure are_equal(a_expected in date, a_actual in date) is
   begin
-    are_equal('Equality test', a_expected, a_actual);
+    are_equal(null, a_expected, a_actual);
   end;
 
   procedure are_equal(a_msg in varchar2, a_expected in date, a_actual in date) is
   begin
-    build_assert_result((a_expected = a_actual), a_expected, a_actual, a_msg);
+    build_assert_result((a_expected = a_actual), 'are_equal', 'date', 'date', ut_utils.to_string(a_expected), ut_utils.to_string(a_actual), ut_utils.to_string(a_msg));
   end;
 
   procedure are_equal(a_expected in timestamp_unconstrained, a_actual in timestamp_unconstrained) is
   begin
-    are_equal('Equality test', a_expected, a_actual);
+    are_equal(null, a_expected, a_actual);
   end;
 
   procedure are_equal(a_msg in varchar2, a_expected in timestamp_unconstrained, a_actual in timestamp_unconstrained) is
   begin
-    build_assert_result((a_expected = a_actual), a_expected, a_actual, a_msg);
+    build_assert_result((a_expected = a_actual), 'are_equal', 'timestamp', 'timestamp', ut_utils.to_string(a_expected), ut_utils.to_string(a_actual), ut_utils.to_string(a_msg));
   end;
 
   procedure are_equal(a_expected in anydata, a_actual in anydata) is
   begin
-    are_equal('Equality test', a_expected, a_actual);
+    are_equal(null, a_expected, a_actual);
   end;
 
   procedure are_equal(a_msg in varchar2, a_expected in anydata, a_actual in anydata) is
@@ -110,12 +119,12 @@ create or replace package body ut_assert is
   begin
     l_expected := any_data_builder.build(a_expected);
     l_actual   := any_data_builder.build(a_actual);
-    build_assert_result((l_expected.eq(l_actual)), l_expected.to_string(), l_actual.to_string(), a_msg);
+    build_assert_result( l_expected.eq(l_actual), 'are_equal', l_expected.type_name, l_actual.type_name, ut_utils.to_string(l_expected.to_string()), ut_utils.to_string(l_actual.to_string()), ut_utils.to_string(a_msg));
   end;
 
   procedure are_equal(a_expected in sys_refcursor, a_actual in sys_refcursor) is
   begin
-    are_equal('Equality test', a_expected, a_actual);
+    are_equal(null, a_expected, a_actual);
   end;
 
   procedure are_equal(a_msg in varchar2, a_expected in sys_refcursor, a_actual in sys_refcursor) is
@@ -124,19 +133,17 @@ create or replace package body ut_assert is
   begin
     l_expected := any_data_builder.build(a_expected);
     l_actual   := any_data_builder.build(a_actual);
-    build_assert_result((l_expected.eq(l_actual)), l_expected.to_string(), l_actual.to_string(), a_msg);
+    build_assert_result( l_expected.eq(l_actual), 'are_equal', l_expected.type_name, l_actual.type_name, ut_utils.to_string(l_expected.to_string()), ut_utils.to_string(l_actual.to_string()), ut_utils.to_string(a_msg));
   end;
 
   procedure this(a_condition in boolean) is
   begin
     this('Simple assert', a_condition);
   end;
+
   procedure this(a_msg in varchar2, a_condition in boolean) is
   begin
-    build_assert_result(a_condition
-                       ,'TRUE'
-                       ,case a_condition when true then 'TRUE' when false then 'FALSE' else 'NULL' end
-                       ,a_msg);
+    build_assert_result(a_condition, 'this', 'boolean', 'boolean', ut_utils.to_string(true), ut_utils.to_string(a_condition), ut_utils.to_string(a_msg));
   end;
 
 end ut_assert;

--- a/source/ut_utils.pkb
+++ b/source/ut_utils.pkb
@@ -28,5 +28,34 @@ create or replace package body ut_utils is
     $end
   end;
 
+
+  function to_string(a_value varchar2) return varchar2 is
+  begin
+    return case
+      when length(a_value) <= gc_max_sring_length then a_value
+      else substr(a_value,1,gc_overflow_substr_len) || gc_more_data_string
+    end;
+  end;
+
+  function to_string(a_value boolean) return varchar2 is
+  begin
+    return case a_value when true then 'TRUE' when false then 'FALSE' else 'NULL' end;
+  end;
+
+  function to_string(a_value number) return varchar2 is
+  begin
+    return to_char(a_value,gc_number_format);
+  end;
+
+  function to_string(a_value date) return varchar2 is
+  begin
+    return to_char(a_value,gc_date_format);
+  end;
+
+  function to_string(a_value timestamp_unconstrained) return varchar2 is
+  begin
+    return to_char(a_value,gc_timestamp_format);
+  end;
+
 end ut_utils;
 /

--- a/source/ut_utils.pks
+++ b/source/ut_utils.pks
@@ -11,13 +11,20 @@ create or replace package ut_utils is
     tr_failure - one or more asserts failed
     tr_error   - exception was raised
   */
-  tr_success          constant number(1) := 1; -- test passed
-  tr_failure          constant number(1) := 2; -- one or more asserts failed
-  tr_error            constant number(1) := 3; -- exception was raised
+  tr_success                 constant number(1) := 1; -- test passed
+  tr_failure                 constant number(1) := 2; -- one or more asserts failed
+  tr_error                   constant number(1) := 3; -- exception was raised
 
-  tr_success_char     constant varchar2(7) := 'Success'; -- test passed
-  tr_failure_char     constant varchar2(7) := 'Failure'; -- one or more asserts failed
-  tr_error_char       constant varchar2(5) := 'Error'; -- exception was raised
+  tr_success_char            constant varchar2(7) := 'Success'; -- test passed
+  tr_failure_char            constant varchar2(7) := 'Failure'; -- one or more asserts failed
+  tr_error_char              constant varchar2(5) := 'Error'; -- exception was raised
+
+  gc_max_sring_length        constant integer := 4000;
+  gc_more_data_string        constant varchar2(5) := '[...]';
+  gc_overflow_substr_len     constant integer := gc_max_sring_length - length(gc_more_data_string);
+  gc_number_format           constant varchar2(100) := 'TM9';
+  gc_date_format             constant varchar2(100) := 'yyyy-mm-dd hh24:mi:ss';
+  gc_timestamp_format        constant varchar2(100) := 'yyyy-mm-dd hh24:mi:ssxff';
   /*
      Function: test_result_to_char
         returns a string representation of a test_result.
@@ -34,6 +41,16 @@ create or replace package ut_utils is
   function to_test_result(a_test boolean) return integer;
 
   procedure debug_log(a_message varchar2);
+
+  function to_string(a_value varchar2) return varchar2;
+
+  function to_string(a_value boolean) return varchar2;
+
+  function to_string(a_value number) return varchar2;
+
+  function to_string(a_value date) return varchar2;
+
+  function to_string(a_value timestamp_unconstrained) return varchar2;
 
 end ut_utils;
 /

--- a/tests/RunAll.sql
+++ b/tests/RunAll.sql
@@ -40,7 +40,7 @@ set serveroutput on size unlimited format truncated
 
 @@lib/RunTest.sql ut_assert/ut_assert.are_equal.anydata.GivesSuccessWhenComparingTheSameData.sql
 @@lib/RunTest.sql ut_assert/ut_assert.are_equal.anydata.GivesFailureWhenComparingDifferentData.sql
-@@lib/RunTest.sql ut_assert/ut_assert.are_equal.anydata.PutsObjectStrucureIntoMessage.sql
+@@lib/RunTest.sql ut_assert/ut_assert.are_equal.anydata.PutsObjectStrucureIntoAssert.sql
 @@lib/RunTest.sql ut_assert/ut_assert.are_equal.cursor.GivesFailureWhenComparingDifferentResultSets.sql
 @@lib/RunTest.sql ut_assert/ut_assert.are_equal.cursor.GivesSuccessWhenComparingIdenticalResultSets.sql
 
@@ -71,6 +71,10 @@ set serveroutput on size unlimited format truncated
 
 @@lib/RunTest.sql ut_assert/ut_assert.are_equal.scalar.FailsToExecuteWhenNullsPassedAsParameters.sql
 
+@@lib/RunTest.sql ut_utils/ut_utils.to_string.verySmallNumber.sql
+@@lib/RunTest.sql ut_utils/ut_utils.to_string.veryBigNumber.sql
+@@lib/RunTest.sql ut_utils/ut_utils.to_string.Date.sql
+@@lib/RunTest.sql ut_utils/ut_utils.to_string.Timestamp.sql
 --Global cleanup
 drop package ut_example_tests;
 

--- a/tests/ut_assert/ut_assert.are_equal.anydata.PutsObjectStrucureIntoAssert.sql
+++ b/tests/ut_assert/ut_assert.are_equal.anydata.PutsObjectStrucureIntoAssert.sql
@@ -1,4 +1,4 @@
-PROMPT Gives a success when comparing equal oracle objects
+PROMPT Puts Object structure as string into the Assert
 --Arrange
 create or replace type department as object(
    dept_name varchar2(30)
@@ -9,16 +9,16 @@ declare
   l_expected department := department('HR');
   l_actual   department := department('IT');
   l_result   integer;
-  assert_result  ut_assert_result;
+  l_assert_result  ut_assert_result;
 begin
 --Act
   ut_assert.are_equal( anydata.convertObject(l_expected), anydata.convertObject(l_actual) );
 
-  assert_result := treat(ut_assert.get_asserts_results()(1) as ut_assert_result);
+  l_assert_result := treat(ut_assert.get_asserts_results()(1) as ut_assert_result);
 
 --Assert
-  if assert_result.message like q'[%department(%dept_name => 'HR'%)%]'
-    and assert_result.message like q'[%department(%dept_name => 'IT'%)%]'
+  if l_assert_result.expected_value_string like q'[%department(%dept_name => 'HR'%)%]'
+    and l_assert_result.actual_value_string like q'[%department(%dept_name => 'IT'%)%]'
    then
     :test_result := ut_utils.tr_success;
   else

--- a/tests/ut_utils/ut_utils.to_string.Date.sql
+++ b/tests/ut_utils/ut_utils.to_string.Date.sql
@@ -1,0 +1,18 @@
+PROMPT Returns a full string representation of a date
+
+--Arrange
+declare
+  l_value    date := to_date('2016-12-31 23:59:59', 'yyyy-mm-dd hh24:mi:ss');
+  l_expected varchar2(100) := '2016-12-31 23:59:59';
+  l_result   varchar2(100);
+begin
+--Act
+  l_result :=  ut_utils.to_String(l_value);
+--Assert
+  if l_result = l_expected then
+    :test_result := ut_utils.tr_success;
+  else
+    dbms_output.put_line('expected: '||l_expected||', got: '||l_result );
+  end if;
+end;
+/

--- a/tests/ut_utils/ut_utils.to_string.Timestamp.sql
+++ b/tests/ut_utils/ut_utils.to_string.Timestamp.sql
@@ -1,0 +1,18 @@
+PROMPT Returns a full string representation of a timestamp with maximum precission
+
+--Arrange
+declare
+  l_value    timestamp(9) := to_timestamp('2016-12-31 23:59:59.123456789', 'yyyy-mm-dd hh24:mi:ss.ff');
+  l_expected varchar2(100) := '2016-12-31 23:59:59.123456789';
+  l_result   varchar2(100);
+begin
+--Act
+  l_result :=  ut_utils.to_String(l_value);
+--Assert
+  if l_result = l_expected then
+    :test_result := ut_utils.tr_success;
+  else
+    dbms_output.put_line('expected: '||l_expected||', got: '||l_result );
+  end if;
+end;
+/

--- a/tests/ut_utils/ut_utils.to_string.veryBigNumber.sql
+++ b/tests/ut_utils/ut_utils.to_string.veryBigNumber.sql
@@ -1,0 +1,18 @@
+PROMPT Returns a full string representation of a very big number
+
+--Arrange
+declare
+  l_value    number := 1234567890123456789012345678901234567890;
+  l_expected varchar2(100) := '1234567890123456789012345678901234567890';
+  l_result   varchar2(100);
+begin
+--Act
+  l_result :=  ut_utils.to_String(l_value);
+--Assert
+  if l_result = l_expected then
+    :test_result := ut_utils.tr_success;
+  else
+    dbms_output.put_line('expected: '||l_expected||', got: '||l_result );
+  end if;
+end;
+/

--- a/tests/ut_utils/ut_utils.to_string.verySmallNumber.sql
+++ b/tests/ut_utils/ut_utils.to_string.verySmallNumber.sql
@@ -1,0 +1,18 @@
+PROMPT Returns a full string representation of a very small number
+
+--Arrange
+declare
+  l_value    number := 0.123456789012345678901234567890123456789;
+  l_expected varchar2(100) := '.123456789012345678901234567890123456789';
+  l_result   varchar2(100);
+begin
+--Act
+  l_result :=  ut_utils.to_String(l_value);
+--Assert
+  if l_result = l_expected then
+    :test_result := ut_utils.tr_success;
+  else
+    dbms_output.put_line('expected: '||l_expected||', got: '||l_result );
+  end if;
+end;
+/


### PR DESCRIPTION
Removed formatting of assert message from the assertions.
Added to_string conversion functions to convert asserted to it's string representation.
Added unit tests for new utility functions.
Enriched to ut_assert_result with fields:
-expected/actual type
-expected/actual value string
-added propagation of name to the ut_assert_result (to identify assertion type)