### PR TITLE
Simple auto/manual transaction control implementation

### DIFF
--- a/source/types/ut_test.tpb
+++ b/source/types/ut_test.tpb
@@ -23,11 +23,8 @@ create or replace type body ut_test is
     end if;
     
     if a_rollback_type is not null then
-      if a_rollback_type in (ut_utils.gc_rollback_auto, ut_utils.gc_rollback_on_error, ut_utils.gc_rollback_manual) then
-        self.rollback_type := a_rollback_type;
-      else
-        raise_application_error(-20200,'Rollback type is not supported');
-      end if;
+      ut_utils.validate_rollback_type(a_rollback_type);
+      self.rollback_type := a_rollback_type;
     else
       self.rollback_type := ut_utils.gc_rollback_auto;
     end if;
@@ -53,7 +50,7 @@ create or replace type body ut_test is
     
     if self.rollback_type = ut_utils.gc_rollback_auto then
       l_savepoint := ut_utils.gen_savepoint_name;
-      execute immediate 'savepoint '||l_savepoint;
+      execute immediate 'savepoint ' || l_savepoint;
     end if;
   
     begin
@@ -88,7 +85,6 @@ create or replace type body ut_test is
           self.teardown.execute;
           l_reporter.after_test_teardown(self);
         end if;
-        
 
       end if;
     
@@ -105,7 +101,7 @@ create or replace type body ut_test is
     end;
     
     if self.rollback_type = ut_utils.gc_rollback_auto then
-      execute immediate 'rollback to '||l_savepoint;
+      execute immediate 'rollback to ' || l_savepoint;
     end if;
   
     self.end_time := current_timestamp;

--- a/source/types/ut_test.tps
+++ b/source/types/ut_test.tps
@@ -4,7 +4,7 @@ create or replace type ut_test force under ut_test_object
   test     ut_executable,
   teardown ut_executable,
 
-  constructor function ut_test(a_object_name varchar2, a_test_procedure varchar2, a_test_name in varchar2 default null, a_owner_name varchar2 default null, a_setup_procedure varchar2 default null, a_teardown_procedure varchar2 default null)
+  constructor function ut_test(a_object_name varchar2, a_test_procedure varchar2, a_test_name in varchar2 default null, a_owner_name varchar2 default null, a_setup_procedure varchar2 default null, a_teardown_procedure varchar2 default null, a_rollback_type integer default null)
     return self as result,
 
   member function is_valid return boolean,

--- a/source/types/ut_test_object.tps
+++ b/source/types/ut_test_object.tps
@@ -3,6 +3,7 @@ create or replace type ut_test_object force under ut_composite_object
   start_time  timestamp with time zone,
   end_time    timestamp with time zone,
   object_name varchar2(4000),
+  rollback_type integer(1), -- ut_tils:gc_rollback_% constants
   not instantiable member procedure execute(self in out nocopy ut_test_object, a_reporter ut_reporter),
   not instantiable member function execute(self in out nocopy ut_test_object, a_reporter ut_reporter)
     return ut_reporter,

--- a/source/types/ut_test_suite.tpb
+++ b/source/types/ut_test_suite.tpb
@@ -9,11 +9,8 @@ create or replace type body ut_test_suite is
     self.object_name := lower(trim(a_object_name));
     
     if a_rollback_type is not null then
-      if a_rollback_type in (ut_utils.gc_rollback_auto, ut_utils.gc_rollback_on_error, ut_utils.gc_rollback_manual) then
-        self.rollback_type := a_rollback_type;
-      else
-        raise_application_error(-20200,'Rollback type is not supported');
-      end if;
+      ut_utils.validate_rollback_type(a_rollback_type);
+      self.rollback_type := a_rollback_type;
     else
       self.rollback_type := ut_utils.gc_rollback_auto;
     end if;  
@@ -66,7 +63,7 @@ create or replace type body ut_test_suite is
       
       if self.rollback_type = ut_utils.gc_rollback_auto then
         l_savepoint := ut_utils.gen_savepoint_name;
-        execute immediate 'savepoint '||l_savepoint;
+        execute immediate 'savepoint ' || l_savepoint;
       end if;
     
       if self.setup is not null then
@@ -94,7 +91,7 @@ create or replace type body ut_test_suite is
       self.calc_execution_result;
       
       if self.rollback_type = ut_utils.gc_rollback_auto then
-        execute immediate 'rollback to '||l_savepoint;
+        execute immediate 'rollback to ' || l_savepoint;
       end if;
     else
       self.result := ut_utils.tr_error;

--- a/source/types/ut_test_suite.tps
+++ b/source/types/ut_test_suite.tps
@@ -4,7 +4,7 @@ create or replace type ut_test_suite force under ut_test_object
   setup    ut_executable,
   teardown ut_executable,
 
-  constructor function ut_test_suite(a_suite_name varchar2, a_object_name varchar2 default null, a_items ut_objects_list default ut_objects_list())
+  constructor function ut_test_suite(a_suite_name varchar2, a_object_name varchar2 default null, a_items ut_objects_list default ut_objects_list(), a_rollback_type number default null)
     return self as result,
 
   member procedure set_suite_setup(self in out nocopy ut_test_suite, a_object_name in varchar2, a_proc_name in varchar2, a_owner_name varchar2 default null),

--- a/source/ut_suite_manager.pkb
+++ b/source/ut_suite_manager.pkb
@@ -23,6 +23,9 @@ create or replace package body ut_suite_manager is
     l_owner_name  varchar2(32 char);
     l_object_name varchar2(32 char);
     l_suite       ut_test_suite;
+    
+    l_suite_rollback integer;
+    l_suite_rollback_annotation varchar2(4000);
   
   begin
     l_owner_name  := a_owner_name;
@@ -41,8 +44,24 @@ create or replace package body ut_suite_manager is
       else
         l_suite_package := lower(l_object_name);
       end if;
+      
+      if l_annotation_data.package_annotations.exists('rollback') then
+        l_suite_rollback_annotation := ut_annotations.get_annotation_param(l_annotation_data.package_annotations('rollback'), 1);
+        l_suite_rollback := case lower(l_suite_rollback_annotation) 
+                              when 'manual' then
+                                ut_utils.gc_rollback_manual
+                              when 'auto' then
+                                ut_utils.gc_rollback_auto
+                              --when 'on-error' then
+                              --  ut_utils.gc_rollback_on_error
+                              else
+                                ut_utils.gc_rollback_auto
+                            end;
+      else
+        l_suite_rollback := ut_utils.gc_rollback_auto;
+      end if;
     
-      l_suite := ut_test_suite(l_suite_name, l_suite_package);
+      l_suite := ut_test_suite(l_suite_name, l_suite_package, a_rollback_type => l_suite_rollback);
     
       l_proc_name := l_annotation_data.procedure_annotations.first;
       while (l_default_setup_proc is null or l_default_teardown_proc is null or l_suite_setup_proc is null or
@@ -76,13 +95,15 @@ create or replace package body ut_suite_manager is
     
       l_proc_name := l_annotation_data.procedure_annotations.first;
       while l_proc_name is not null loop
-        declare
-          l_setup_procedure    varchar2(30 char);
-          l_teardown_procedure varchar2(30 char);
-        begin
-          l_proc_annotations := l_annotation_data.procedure_annotations(l_proc_name);
-        
-          if l_proc_annotations.exists('test') then
+
+        l_proc_annotations := l_annotation_data.procedure_annotations(l_proc_name);
+        if l_proc_annotations.exists('test') then
+          declare
+            l_setup_procedure     varchar2(30 char);
+            l_teardown_procedure  varchar2(30 char);
+            l_rollback_annotation varchar2(4000);
+            l_rollback_type       integer := ut_utils.gc_rollback_auto;
+          begin
             if l_proc_annotations.exists('testsetup') then
               l_setup_procedure := ut_annotations.get_annotation_param(l_proc_annotations('testsetup'), 1);
             end if;
@@ -90,18 +111,33 @@ create or replace package body ut_suite_manager is
             if l_proc_annotations.exists('testteardown') then
               l_teardown_procedure := ut_annotations.get_annotation_param(l_proc_annotations('testteardown'), 1);
             end if;
+            
+            if l_proc_annotations.exists('rollback') then
+              l_rollback_annotation := ut_annotations.get_annotation_param(l_proc_annotations('rollback'), 1);
+              l_rollback_type := case lower(l_rollback_annotation) 
+                                   when 'manual' then
+                                     ut_utils.gc_rollback_manual
+                                   when 'auto' then
+                                     ut_utils.gc_rollback_auto
+                                   --when 'on-error' then
+                                   --  ut_utils.gc_rollback_on_error
+                                   else
+                                     l_suite_rollback
+                                   end;
+            end if;
           
             l_test := ut_test(a_object_name        => l_object_name
                              ,a_test_procedure     => l_proc_name
                              ,a_test_name          => ut_annotations.get_annotation_param(l_proc_annotations('test'), 1)
                              ,a_owner_name         => l_owner_name
                              ,a_setup_procedure    => nvl(l_setup_procedure, l_default_setup_proc)
-                             ,a_teardown_procedure => nvl(l_teardown_procedure, l_default_teardown_proc));
+                             ,a_teardown_procedure => nvl(l_teardown_procedure, l_default_teardown_proc)
+                             ,a_rollback_type      => l_rollback_type);
           
             l_suite.add_item(l_test);
-          end if;
-        
-        end;
+          end;
+        end if;
+
         l_proc_name := l_annotation_data.procedure_annotations.next(l_proc_name);
       end loop;
     end if;

--- a/source/ut_utils.pkb
+++ b/source/ut_utils.pkb
@@ -18,6 +18,11 @@ create or replace package body ut_utils is
              else tr_failure
            end;
   end;
+  
+  function gen_savepoint_name return varchar2 is
+  begin
+    return 'ut_'||to_char(systimestamp,'yymmddhh24mmssff');
+  end;
 
   procedure debug_log(a_message varchar2) is
   begin

--- a/source/ut_utils.pkb
+++ b/source/ut_utils.pkb
@@ -23,6 +23,18 @@ create or replace package body ut_utils is
   begin
     return 'ut_'||to_char(systimestamp,'yymmddhh24mmssff');
   end;
+  
+  /*
+   Procedure: validate_rollback_type
+   
+   Validates passed value against supported rollback types
+  */
+  procedure validate_rollback_type(a_rollback_type number) is
+  begin
+    if a_rollback_type not in (gc_rollback_auto, gc_rollback_manual) then
+      raise_application_error(-20200,'Rollback type is not supported');
+    end if;
+  end validate_rollback_type;
 
   procedure debug_log(a_message varchar2) is
   begin

--- a/source/ut_utils.pks
+++ b/source/ut_utils.pks
@@ -18,6 +18,14 @@ create or replace package ut_utils is
   tr_success_char            constant varchar2(7) := 'Success'; -- test passed
   tr_failure_char            constant varchar2(7) := 'Failure'; -- one or more asserts failed
   tr_error_char              constant varchar2(5) := 'Error'; -- exception was raised
+  
+  /*
+    Constants: Rollback type for ut_test_object
+  */
+  gc_rollback_auto           constant number(1) := 0; -- rollback after each test and suite
+  gc_rollback_manual         constant number(1) := 1; -- leave transaction control manual
+  --gc_rollback_on_error       constant number(1) := 2; -- rollback tests only on error
+
 
   gc_max_sring_length        constant integer := 4000;
   gc_more_data_string        constant varchar2(5) := '[...]';
@@ -39,6 +47,8 @@ create or replace package ut_utils is
   function test_result_to_char(a_test_result integer) return varchar2;
 
   function to_test_result(a_test boolean) return integer;
+  
+  function gen_savepoint_name return varchar2;
 
   procedure debug_log(a_message varchar2);
 

--- a/source/ut_utils.pks
+++ b/source/ut_utils.pks
@@ -25,6 +25,9 @@ create or replace package ut_utils is
   gc_rollback_auto           constant number(1) := 0; -- rollback after each test and suite
   gc_rollback_manual         constant number(1) := 1; -- leave transaction control manual
   --gc_rollback_on_error       constant number(1) := 2; -- rollback tests only on error
+  
+  ex_unsopported_rollback_type exception;
+  pragma exception_init(ex_unsopported_rollback_type, -20200);
 
 
   gc_max_sring_length        constant integer := 4000;
@@ -61,6 +64,13 @@ create or replace package ut_utils is
   function to_string(a_value date) return varchar2;
 
   function to_string(a_value timestamp_unconstrained) return varchar2;
+  
+  /*
+   Procedure: validate_rollback_type
+   
+   Validates passed value against supported rollback types
+  */
+  procedure validate_rollback_type(a_rollback_type number);
 
 end ut_utils;
 /

--- a/tests/RunAll.sql
+++ b/tests/RunAll.sql
@@ -11,7 +11,8 @@ set serveroutput on size unlimited format truncated
 @@helpers/ut_example_tests.pks
 @@helpers/ut_example_tests.pkb
 @@helpers/check_annotation_parsing.prc
-@@helpers/cre_tab_ut_test_table.sql
+--@@helpers/cre_tab_ut_test_table.sql
+create table ut$test_table (val varchar2(1));
 @@helpers/ut_transaction_control.pck
 
 --Tests to invoke

--- a/tests/RunAll.sql
+++ b/tests/RunAll.sql
@@ -11,6 +11,8 @@ set serveroutput on size unlimited format truncated
 @@helpers/ut_example_tests.pks
 @@helpers/ut_example_tests.pkb
 @@helpers/check_annotation_parsing.prc
+@@helpers/cre_tab_ut$test_table.sql
+@@helpers/ut_transaction_control.pck
 
 --Tests to invoke
 
@@ -27,6 +29,17 @@ set serveroutput on size unlimited format truncated
 @@lib/RunTest.sql ut_test/ut_test.TeardownExecutedAfterTest.sql
 @@lib/RunTest.sql ut_test/ut_test.TeardownProcedureNameInvalid.sql
 @@lib/RunTest.sql ut_test/ut_test.TeardownProcedureNameNull.sql
+
+@@lib/RunTest.sql ut_test/ut_test.Rollback_type.Auto.sql
+@@lib/RunTest.sql ut_test/ut_test.Rollback_type.AutoOnFailure.sql
+@@lib/RunTest.sql ut_test/ut_test.Rollback_type.Manual.sql
+@@lib/RunTest.sql ut_test/ut_test.Rollback_type.ManualOnFailure.sql
+
+@@lib/RunTest.sql ut_test_suite/ut_test_suite.Rollback_type.Auto.sql
+@@lib/RunTest.sql ut_test_suite/ut_test_suite.Rollback_type.AutoOnFailure.sql
+@@lib/RunTest.sql ut_test_suite/ut_test_suite.Rollback_type.Manual.sql
+@@lib/RunTest.sql ut_test_suite/ut_test_suite.Rollback_type.ManualOnFailure.sql
+
 @@lib/RunTest.sql ut_utils/ut_utils.test_result_to_char.RunsWithInvalidValues.sql
 @@lib/RunTest.sql ut_utils/ut_utils.test_result_to_char.RunsWithNullValue.sql
 @@lib/RunTest.sql ut_utils/ut_utils.test_result_to_char.Success.sql
@@ -108,6 +121,8 @@ set serveroutput on size unlimited format truncated
 --Global cleanup
 drop package ut_example_tests;
 drop procedure check_annotation_parsing;
+drop package ut_transaction_control;
+drop table ut$test_table;
 
 --Finally
 @@lib/RunSummary

--- a/tests/RunAll.sql
+++ b/tests/RunAll.sql
@@ -11,7 +11,7 @@ set serveroutput on size unlimited format truncated
 @@helpers/ut_example_tests.pks
 @@helpers/ut_example_tests.pkb
 @@helpers/check_annotation_parsing.prc
-@@helpers/cre_tab_ut$test_table.sql
+@@helpers/cre_tab_ut_test_table.sql
 @@helpers/ut_transaction_control.pck
 
 --Tests to invoke

--- a/tests/helpers/cre_tab_ut$test_table.sql
+++ b/tests/helpers/cre_tab_ut$test_table.sql
@@ -1,0 +1,1 @@
+create table ut$test_table (val varchar2(1));

--- a/tests/helpers/cre_tab_ut$test_table.sql
+++ b/tests/helpers/cre_tab_ut$test_table.sql
@@ -1,1 +1,0 @@
-create table ut$test_table (val varchar2(1));

--- a/tests/helpers/ut_transaction_control.pck
+++ b/tests/helpers/ut_transaction_control.pck
@@ -1,0 +1,44 @@
+create or replace package ut_transaction_control as
+
+  function count_rows(a_val varchar2) return number;
+
+  procedure setup;
+
+  procedure test;
+  
+  procedure test_failure;
+
+end;
+/
+create or replace package body ut_transaction_control
+as 
+
+  function count_rows(a_val varchar2) return number is
+    l_cnt number;
+  begin
+    select count(*) 
+      into l_cnt 
+      from ut$test_table t
+     where t.val = a_val;
+     
+    return l_cnt;
+  end;
+
+  procedure setup is begin
+    insert into ut$test_table values ('s');
+  end;
+  
+  procedure test is
+  begin
+    insert into ut$test_table values ('t');
+  end;
+  
+  procedure test_failure is
+  begin
+    insert into ut$test_table values ('t');
+    --raise no_data_found;
+    raise_application_error(-20001,'Error');
+  end;
+    
+end;
+/

--- a/tests/ut_assert/ut_assert.are_equal.anydata.GivesFailureWhenComparingDifferentData.sql
+++ b/tests/ut_assert/ut_assert.are_equal.anydata.GivesFailureWhenComparingDifferentData.sql
@@ -1,13 +1,13 @@
 PROMPT Gives a success when comparing equal oracle objects
 --Arrange
-create or replace type department as object(
+create or replace type department$ as object(
    dept_name varchar2(30)
 );
 /
 
 declare
-  l_expected department := department('HR');
-  l_actual   department := department('IT');
+  l_expected department$ := department$('HR');
+  l_actual   department$ := department$('IT');
   l_result   integer;
 begin
 --Act
@@ -23,4 +23,4 @@ end;
 /
 
 --Cleanup
-drop type department;
+drop type department$;

--- a/tests/ut_assert/ut_assert.are_equal.anydata.GivesSuccessWhenComparingTheSameData.sql
+++ b/tests/ut_assert/ut_assert.are_equal.anydata.GivesSuccessWhenComparingTheSameData.sql
@@ -1,13 +1,13 @@
 PROMPT Gives a success when comparing equal oracle objects
 --Arrange
-create or replace type department as object(
+create or replace type department$ as object(
    dept_name varchar2(30)
 );
 /
 
 declare
-  l_expected department := department('hr');
-  l_actual   department := department('hr');
+  l_expected department$ := department$('hr');
+  l_actual   department$ := department$('hr');
   l_result   integer;
 begin
 --Act
@@ -23,4 +23,4 @@ end;
 /
 
 --Cleanup
-drop type department;
+drop type department$;

--- a/tests/ut_assert/ut_assert.are_equal.anydata.PutsObjectStrucureIntoAssert.sql
+++ b/tests/ut_assert/ut_assert.are_equal.anydata.PutsObjectStrucureIntoAssert.sql
@@ -1,13 +1,13 @@
 PROMPT Puts Object structure as string into the Assert
 --Arrange
-create or replace type department as object(
+create or replace type department$ as object(
    dept_name varchar2(30)
 );
 /
 
 declare
-  l_expected department := department('HR');
-  l_actual   department := department('IT');
+  l_expected department$ := department$('HR');
+  l_actual   department$ := department$('IT');
   l_result   integer;
   l_assert_result  ut_assert_result;
 begin
@@ -17,8 +17,8 @@ begin
   l_assert_result := treat(ut_assert.get_asserts_results()(1) as ut_assert_result);
 
 --Assert
-  if l_assert_result.expected_value_string like q'[%DEPARTMENT(%dept_name => 'HR'%)%]'
-    and l_assert_result.actual_value_string like q'[%DEPARTMENT(%dept_name => 'IT'%)%]'
+  if l_assert_result.expected_value_string like q'[%DEPARTMENT$(%dept_name => 'HR'%)%]'
+    and l_assert_result.actual_value_string like q'[%DEPARTMENT$(%dept_name => 'IT'%)%]'
    then
     :test_result := ut_utils.tr_success;
   else
@@ -29,4 +29,4 @@ end;
 /
 
 --Cleanup
-drop type department;
+drop type department$;

--- a/tests/ut_assert/ut_assert.is_matching.GivesFailureForMatchingString.sql
+++ b/tests/ut_assert/ut_assert.is_matching.GivesFailureForMatchingString.sql
@@ -1,5 +1,5 @@
-PL/SQL Developer Test script 3.0
-17
+Prompt Give failure for matching string using regexp
+
 --Arrange
 declare
   l_mask     varchar2(20) := '[a-z]+\d[a-z]+';
@@ -16,9 +16,4 @@ begin
     dbms_output.put_line('expected: string like'''||l_mask||''', got: '''||l_result||'''' );
   end if;
 end;
---/
-1
-test_result
-0
-5
-0
+/

--- a/tests/ut_assert/ut_assert.is_null.anydata.GivesFailureWhenDataIsNotNull.sql
+++ b/tests/ut_assert/ut_assert.is_null.anydata.GivesFailureWhenDataIsNotNull.sql
@@ -1,12 +1,12 @@
 PROMPT Gives a falure when oracle object is not null
 --Arrange
-create or replace type department as object(
+create or replace type department$ as object(
    dept_name varchar2(30)
 );
 /
 
 declare
-  l_actual   department := department('IT');
+  l_actual   department$ := department$('IT');
   l_result   integer;
 begin
 --Act
@@ -22,4 +22,4 @@ end;
 /
 
 --Cleanup
-drop type department;
+drop type department$;

--- a/tests/ut_assert/ut_assert.is_null.anydata.GivesSuccessWhenDataIsNull.sql
+++ b/tests/ut_assert/ut_assert.is_null.anydata.GivesSuccessWhenDataIsNull.sql
@@ -1,12 +1,12 @@
 PROMPT Gives a success when oracle object is null
 --Arrange
-create or replace type department as object(
+create or replace type department$ as object(
    dept_name varchar2(30)
 );
 /
 
 declare
-  l_actual   department;
+  l_actual   department$;
   l_result   integer;
 begin
 --Act
@@ -22,4 +22,4 @@ end;
 /
 
 --Cleanup
-drop type department;
+drop type department$;

--- a/tests/ut_test/ut_test.Rollback_type.Auto.sql
+++ b/tests/ut_test/ut_test.Rollback_type.Auto.sql
@@ -1,0 +1,32 @@
+PROMPT Test auto transaction control 
+
+--Arrange
+declare
+  l_suite ut_test_suite;
+  l_test ut_test;
+  l_parsing_result ut_annotations.typ_annotated_package;
+  l_expected ut_annotations.typ_annotated_package;
+  l_ann_param ut_annotations.typ_annotation_param;
+  l_cnt number;
+
+begin
+  
+  delete from ut$test_table;
+
+  l_test := ut_test(a_object_name => 'ut_transaction_control',a_test_procedure => 'test', a_rollback_type => ut_utils.gc_rollback_manual);
+  l_suite := ut_test_suite(a_suite_name => 'Suite name', a_object_name => 'UT_TRANSACTION_CONTROL', a_items => ut_objects_list(l_test), a_rollback_type => ut_utils.gc_rollback_auto);
+
+--Act  
+  l_suite.execute;
+  
+  ut_assert.clear_asserts;
+
+--Assert  
+  ut_assert.this(ut_transaction_control.count_rows('t')=0);
+
+  if ut_assert.get_aggregate_asserts_result = ut_utils.tr_success then
+    :test_result := ut_utils.tr_success;
+  end if;
+
+end;
+/

--- a/tests/ut_test/ut_test.Rollback_type.AutoOnFailure.sql
+++ b/tests/ut_test/ut_test.Rollback_type.AutoOnFailure.sql
@@ -1,0 +1,32 @@
+PROMPT Test auto transaction control 
+
+--Arrange
+declare
+  l_suite ut_test_suite;
+  l_test ut_test;
+  l_parsing_result ut_annotations.typ_annotated_package;
+  l_expected ut_annotations.typ_annotated_package;
+  l_ann_param ut_annotations.typ_annotation_param;
+  l_cnt number;
+
+begin
+  
+  delete from ut$test_table;
+
+  l_test := ut_test(a_object_name => 'ut_transaction_control',a_test_procedure => 'test_failure', a_rollback_type => ut_utils.gc_rollback_manual);
+  l_suite := ut_test_suite(a_suite_name => 'Suite name', a_object_name => 'UT_TRANSACTION_CONTROL', a_items => ut_objects_list(l_test), a_rollback_type => ut_utils.gc_rollback_auto);
+
+--Act  
+  l_suite.execute;
+  
+  ut_assert.clear_asserts;
+
+--Assert  
+  ut_assert.this(ut_transaction_control.count_rows('t')=0);
+
+  if ut_assert.get_aggregate_asserts_result = ut_utils.tr_success then
+    :test_result := ut_utils.tr_success;
+  end if;
+
+end;
+/

--- a/tests/ut_test/ut_test.Rollback_type.Manual.sql
+++ b/tests/ut_test/ut_test.Rollback_type.Manual.sql
@@ -1,0 +1,32 @@
+PROMPT Test manual transaction control 
+
+--Arrange
+declare
+  l_suite ut_test_suite;
+  l_test ut_test;
+  l_parsing_result ut_annotations.typ_annotated_package;
+  l_expected ut_annotations.typ_annotated_package;
+  l_ann_param ut_annotations.typ_annotation_param;
+  l_cnt number;
+
+begin
+
+  delete from ut$test_table;
+
+  l_test := ut_test(a_object_name => 'ut_transaction_control',a_test_procedure => 'test', a_rollback_type => ut_utils.gc_rollback_manual);
+  l_suite := ut_test_suite(a_suite_name => 'Suite name', a_object_name => 'UT_TRANSACTION_CONTROL', a_items => ut_objects_list(l_test), a_rollback_type => ut_utils.gc_rollback_manual);
+
+--Act  
+  l_suite.execute;
+  
+  ut_assert.clear_asserts;
+
+--Assert  
+  ut_assert.this(ut_transaction_control.count_rows('t')>0);
+
+  if ut_assert.get_aggregate_asserts_result = ut_utils.tr_success then
+    :test_result := ut_utils.tr_success;
+  end if;
+
+end;
+/

--- a/tests/ut_test/ut_test.Rollback_type.ManualOnFailure.sql
+++ b/tests/ut_test/ut_test.Rollback_type.ManualOnFailure.sql
@@ -1,0 +1,34 @@
+PROMPT Test manual transaction control 
+
+--Arrange
+declare
+  l_suite ut_test_suite;
+  l_test ut_test;
+  l_parsing_result ut_annotations.typ_annotated_package;
+  l_expected ut_annotations.typ_annotated_package;
+  l_ann_param ut_annotations.typ_annotation_param;
+  l_cnt number;
+
+begin
+  
+  delete from ut$test_table;
+
+  l_test := ut_test(a_object_name => 'ut_transaction_control',a_test_procedure => 'test_failure', a_rollback_type => ut_utils.gc_rollback_manual);
+  l_suite := ut_test_suite(a_suite_name => 'Suite name', a_object_name => 'UT_TRANSACTION_CONTROL', a_items => ut_objects_list(l_test), a_rollback_type => ut_utils.gc_rollback_manual);
+
+--Act  
+  l_suite.execute;
+  
+  ut_assert.clear_asserts;
+
+--Assert  
+  --even if the manual mode is used and the feilure occurred all the changes in the test procedure are rollbacked by DB
+  --http://asktom.oracle.com/pls/apex/f?p=100:12:0::NO::P12_ORIG,P12_PREV_PAGE,P12_QUESTION_ID:Y,1,9532007800346890501
+  ut_assert.this(ut_transaction_control.count_rows('t')=0);
+
+  if ut_assert.get_aggregate_asserts_result = ut_utils.tr_success then
+    :test_result := ut_utils.tr_success;
+  end if;
+
+end;
+/

--- a/tests/ut_test_suite/ut_test_suite.Rollback_type.Auto.sql
+++ b/tests/ut_test_suite/ut_test_suite.Rollback_type.Auto.sql
@@ -1,0 +1,34 @@
+PROMPT Test suite auto transaction control 
+
+--Arrange
+declare
+  l_suite ut_test_suite;
+  l_test ut_test;
+  l_parsing_result ut_annotations.typ_annotated_package;
+  l_expected ut_annotations.typ_annotated_package;
+  l_ann_param ut_annotations.typ_annotation_param;
+  l_cnt number;
+
+begin
+  
+  delete from ut$test_table;
+
+  l_test := ut_test(a_object_name => 'ut_transaction_control',a_test_procedure => 'test', a_rollback_type => ut_utils.gc_rollback_auto);
+  l_suite := ut_test_suite(a_suite_name => 'Suite name', a_object_name => 'UT_TRANSACTION_CONTROL', a_items => ut_objects_list(l_test), a_rollback_type => ut_utils.gc_rollback_auto);
+  l_suite.set_suite_setup('ut_transaction_control','setup');
+
+--Act  
+  l_suite.execute;
+  
+  ut_assert.clear_asserts;
+
+--Assert  
+  ut_assert.this(ut_transaction_control.count_rows('t')=0);
+  ut_assert.this(ut_transaction_control.count_rows('s')=0);
+
+  if ut_assert.get_aggregate_asserts_result = ut_utils.tr_success then
+    :test_result := ut_utils.tr_success;
+  end if;
+
+end;
+/

--- a/tests/ut_test_suite/ut_test_suite.Rollback_type.AutoOnFailure.sql
+++ b/tests/ut_test_suite/ut_test_suite.Rollback_type.AutoOnFailure.sql
@@ -1,0 +1,34 @@
+PROMPT Test suite auto transaction control on failure
+
+--Arrange
+declare
+  l_suite ut_test_suite;
+  l_test ut_test;
+  l_parsing_result ut_annotations.typ_annotated_package;
+  l_expected ut_annotations.typ_annotated_package;
+  l_ann_param ut_annotations.typ_annotation_param;
+  l_cnt number;
+
+begin
+  
+  delete from ut$test_table;
+
+  l_test := ut_test(a_object_name => 'ut_transaction_control',a_test_procedure => 'test_failure', a_rollback_type => ut_utils.gc_rollback_auto);
+  l_suite := ut_test_suite(a_suite_name => 'Suite name', a_object_name => 'UT_TRANSACTION_CONTROL', a_items => ut_objects_list(l_test), a_rollback_type => ut_utils.gc_rollback_auto);
+  l_suite.set_suite_setup('ut_transaction_control','setup');
+
+--Act  
+  l_suite.execute;
+  
+  ut_assert.clear_asserts;
+
+--Assert  
+  ut_assert.this(ut_transaction_control.count_rows('t')=0);
+  ut_assert.this(ut_transaction_control.count_rows('s')=0);
+
+  if ut_assert.get_aggregate_asserts_result = ut_utils.tr_success then
+    :test_result := ut_utils.tr_success;
+  end if;
+
+end;
+/

--- a/tests/ut_test_suite/ut_test_suite.Rollback_type.Manual.sql
+++ b/tests/ut_test_suite/ut_test_suite.Rollback_type.Manual.sql
@@ -1,0 +1,34 @@
+PROMPT Test suite manual transaction control 
+
+--Arrange
+declare
+  l_suite ut_test_suite;
+  l_test ut_test;
+  l_parsing_result ut_annotations.typ_annotated_package;
+  l_expected ut_annotations.typ_annotated_package;
+  l_ann_param ut_annotations.typ_annotation_param;
+  l_cnt number;
+
+begin
+  
+  delete from ut$test_table;
+
+  l_test := ut_test(a_object_name => 'ut_transaction_control',a_test_procedure => 'test', a_rollback_type => ut_utils.gc_rollback_manual);
+  l_suite := ut_test_suite(a_suite_name => 'Suite name', a_object_name => 'UT_TRANSACTION_CONTROL', a_items => ut_objects_list(l_test), a_rollback_type => ut_utils.gc_rollback_manual);
+  l_suite.set_suite_setup('ut_transaction_control','setup');
+
+--Act  
+  l_suite.execute;
+  
+  ut_assert.clear_asserts;
+
+--Assert  
+  ut_assert.this(ut_transaction_control.count_rows('t')>0);
+  ut_assert.this(ut_transaction_control.count_rows('s')>0);
+
+  if ut_assert.get_aggregate_asserts_result = ut_utils.tr_success then
+    :test_result := ut_utils.tr_success;
+  end if;
+
+end;
+/

--- a/tests/ut_test_suite/ut_test_suite.Rollback_type.ManualOnFailure.sql
+++ b/tests/ut_test_suite/ut_test_suite.Rollback_type.ManualOnFailure.sql
@@ -1,0 +1,36 @@
+PROMPT Test suite manual transaction control on failure
+
+--Arrange
+declare
+  l_suite ut_test_suite;
+  l_test ut_test;
+  l_parsing_result ut_annotations.typ_annotated_package;
+  l_expected ut_annotations.typ_annotated_package;
+  l_ann_param ut_annotations.typ_annotation_param;
+  l_cnt number;
+
+begin
+  
+  delete from ut$test_table;
+
+  l_test := ut_test(a_object_name => 'ut_transaction_control',a_test_procedure => 'test_failure', a_rollback_type => ut_utils.gc_rollback_manual);
+  l_suite := ut_test_suite(a_suite_name => 'Suite name', a_object_name => 'UT_TRANSACTION_CONTROL', a_items => ut_objects_list(l_test), a_rollback_type => ut_utils.gc_rollback_manual);
+  l_suite.set_suite_setup('ut_transaction_control','setup');
+
+--Act  
+  l_suite.execute;
+  
+  ut_assert.clear_asserts;
+
+--Assert  
+  --even if the manual mode is used and the feilure occurred all the changes in the test procedure are rollbacked by DB
+  --http://asktom.oracle.com/pls/apex/f?p=100:12:0::NO::P12_ORIG,P12_PREV_PAGE,P12_QUESTION_ID:Y,1,9532007800346890501
+  ut_assert.this(ut_transaction_control.count_rows('t')=0);
+  ut_assert.this(ut_transaction_control.count_rows('s')>0);
+
+  if ut_assert.get_aggregate_asserts_result = ut_utils.tr_success then
+    :test_result := ut_utils.tr_success;
+  end if;
+
+end;
+/


### PR DESCRIPTION
Implemented transaction control using %rollback annotation for tests and suites. Connects to #64 

Added tests for suites and tests transaction control
Renamed department object type in anydata tests to department$ for less probable conflict with existing objects of the database if the framework is installed in non-empty schema
Fixed the error with one of existing tests