### PR TITLE
Now, number failures is explicitly displayed, even if it's ZERO.

### DIFF
--- a/source/reporters/ut_documentation_reporter.tpb
+++ b/source/reporters/ut_documentation_reporter.tpb
@@ -140,8 +140,8 @@ create or replace type body ut_documentation_reporter is
     self.print_text(
       test_count || ' tests' ||
       case
-        when failed_test_count > 1 then ', '||failed_test_count||' failures'
-        when failed_test_count > 0 then ', '||failed_test_count||' failure'
+        when failed_test_count = 1 then ', '||failed_test_count||' failure'
+        else ', '||failed_test_count||' failures'
       end ||
       case
         when igonred_test_count > 0 then ', '||igonred_test_count||' ignored'


### PR DESCRIPTION
So reporter will show summary:
123 tests, 0 failures