### PR TITLE
Annotations redesign

### DIFF
--- a/client_source/sqlplus/ut_run.sql
+++ b/client_source/sqlplus/ut_run.sql
@@ -14,7 +14,7 @@ Parameters:
   -p=ut_path(s)- A path or a comma separated list of paths to unit test to be executed.
                  The path can be in one of the following formats:
                    schema[.package[.procedure]]
-                   schema:suitepacakge[.suitepackage[.suitepackage][...]][.procedure]
+                   schema:suite[.suite[.suite][...]][.procedure]
                  Both formats can be mixed in the comma separated list.
                  If only schema is provided, then all suites owner by that schema (user) are executed.
                  If -p is omitted, the current schema is used.

--- a/docs/userguide/annotations.md
+++ b/docs/userguide/annotations.md
@@ -56,8 +56,8 @@ end test_pkg;
 | `%suitepath(<path>)` | Package | Similar to java package. The annotation allows logical grouping of suites into hierarcies. |
 | `%displayname(<description>)` | Package/procedure | Human-familiar describtion of the suite/test. `%displayname(Name of the suite/test)` |
 | `%test` | Procedure | Denotes that a method is a test method. |
-| `%beforeall` | Procedure | Denotes that the annotated procedure should be executed before all `%test` methods in the current suite. |
-| `%afterall` | Procedure | Denotes that the annotated procedure should be executed after all `%test` methods in the current suite. |
+| `%beforeall` | Procedure | Denotes that the annotated procedure should be executed once before all elements of the current suite. |
+| `%afterall` | Procedure | Denotes that the annotated procedure should be executed once after all elements of the current suite. |
 | `%beforeeach` | Procedure | Denotes that the annotated procedure should be executed before each `%test` method in the current suite. |
 | `%aftereach` | Procedure | Denotes that the annotated procedure should be executed after each `%test` method in the current suite. |
 | `%beforetest(<procedure_name>)` | Procedure | Denotes that mentioned procedure should be executed before the annotated `%test` procedure. |

--- a/docs/userguide/annotations.md
+++ b/docs/userguide/annotations.md
@@ -1,34 +1,37 @@
 # Annotations
 
 Annotations provide a way to configure tests and suites in a declarative way similar to modern OOP languages.
+The annotation list is based on jUnit 5 implementation.
 
 # Example
 Let's say we have the test package like this:
 ```
 create or replace package test_pkg is
 
-  -- %suite(Name of suite)
-  -- %suitepackage(all.globaltests)
-  -- %suitetype(critical)
+  -- %suite
+  -- %displayname(Name of suite)
+  -- %suitepath(all.globaltests)
 
-  -- %suitesetup
+  -- %beforeall
   procedure globalsetup;
 
-  -- %suiteteardown
+  -- %afterall
   procedure global_teardown;
 
   /* Such comments are allowed */
 
-  -- %test(Name of test1)
-  -- %testtype(smoke)
+  -- %test
+  -- %displayname(Name of test1)
   procedure test1;
 
-  -- %test(Name of test2)
-  -- %testsetup(setup_test1)
-  -- %testteardown(teardown_test1)
+  -- %test
+  -- %displayname(Name of test2)
+  -- %beforetest(setup_test1)
+  -- %aftertest(teardown_test1)
   procedure test2;
 
-  -- %test(Name of test3)
+  -- %test
+  -- %displayname(Name of test3)
   -- %testtype(smoke)
   procedure test3;
 
@@ -36,10 +39,10 @@ create or replace package test_pkg is
 
   procedure teardown_test1;
 
-  -- %setup
+  -- %beforeeach
   procedure setup;
 
-  -- %teardown
+  -- %aftereach
   procedure teardown;
 
 end test_pkg;
@@ -47,19 +50,19 @@ end test_pkg;
 
 #Annotations meaning
 
-Annotation | Meaning
------------- | -------------
-%suite | Marks package to be a suite with it procedures as tests. This way all testing packages might be found in the schema. Parameter of the annotation is the Suite name
-%suitepackage | Similar to java package. The example suite should be put as an element of the "globaltests" suite which is an element of the "all" suite. This allows one to execute "glovaltests" suite which would recursively run all the child suites including this one.
-%suitetype | The way for suite to have something like a type. One might collect suites based on the subject of tests (a system module for example). There might be critical tests to run every time and more covering but slow tests. This technique allows to configure something like "fast" testing.
-%setup | Marks procedure as a default setup procedure for the suite.
-%teardown | Marks procedure as a default teardown procedure for the suite.
-%test | Marks procedure as a test. Parameter is a name of the test
-%testtype | Another way to tag tests to filter afterwards
-%testsetup | Marks that special setup procedure has to be run before the test instead of the default one
-%testteardown | Marks that special teardown procedure has to be run before the test instead of the default one
-%suitesetup | Procedure with executes once at the beginning of the suite and doesn't executes before each test
-%suiteteardown | Procedure with executes once after the execution of the last test in the suite.
+| Annotation |Level| Describtion |
+| --- | --- | --- |
+| `%suite` | Package | Marks package to be a suite of tests This way all testing packages might be found in a schema. |
+| `%suitepath(<path>)` | Package | Similar to java package. The annotation allows logical grouping of suites into hierarcies. |
+| `%displayname(<description>)` | Package/procedure | Human-familiar describtion of the suite/test. `%displayname(Name of the suite/test)` |
+| `%test` | Procedure | Denotes that a method is a test method. |
+| `%beforeall` | Procedure | Denotes that the annotated procedure should be executed before all `%test` methods in the current suite. |
+| `%afterall` | Procedure | Denotes that the annotated procedure should be executed after all `%test` methods in the current suite. |
+| `%beforeeach` | Procedure | Denotes that the annotated procedure should be executed before each `%test` method in the current suite. |
+| `%aftereach` | Procedure | Denotes that the annotated procedure should be executed after each `%test` method in the current suite. |
+| `%beforetest(<procedure_name>)` | Procedure | Denotes that mentioned procedure should be executed before the annotated `%test` procedure. |
+| `%aftertest(<procedure_name>)` | Procedure | Denotes that mentioned procedure should be executed after the annotated `%test` procedure. |
+| `%rollback(<type>)` | Package/procedure | Configure transaction control behaviour (type). Supported values: `auto`(default) - rollback to savepoint (before the test/suite setup) is issued after each test/suite teardown; `manual` - rollback is never issued automatically. Property can be overridden for child element (test in suite) |
+| `%disable` | Package/procedure | Used to disable a suite or a test |
 
 Annotations allow us to configure test infrastructure in a declarative way without anything stored in tables or config files. Suite manager would scan the schema for all the suitable packages, automatically configure suites and execute them. This can be simplified to the situation when you just ran suite manager over a schema for the defined types of tests and reporters and everything goes automatically. This is going to be convenient to be executed from CI tools using standard reporting formats.
-

--- a/examples/RunWithDocumentationReporter.sql
+++ b/examples/RunWithDocumentationReporter.sql
@@ -3,16 +3,21 @@ set linesize 10000
 set echo off
 
 create or replace package demo_doc_reporter1 is
-  -- %suite(Demo of documentation reporter)
-  -- %test(A passing test sample)
+  -- %suite
+  -- %displayname(Demo of documentation reporter)
+  
+  -- %test
+  -- %displayname(A passing test sample)
   procedure passing_test;
   -- %test
   procedure test_without_name;
-  -- %test(A failing test exsample)
+  -- %test
+  -- %displayname(A failing test exsample)
   procedure failing_test;
   -- %test
   procedure failing_no_name;
-  -- %test(repoting exception)
+  -- %test
+  -- %displayname(repoting exception)
   procedure failing_exception_raised;
 end;
 /
@@ -43,8 +48,11 @@ end;
 /
 
 create or replace package demo_doc_reporter2 is
-  -- %suite(A suite package without body)
-  -- %test(A test)
+  -- %suite
+  -- %displayname(A suite package without body)
+  
+  -- %test
+  -- %displayname(A test)
   procedure test1;
   -- %test
   procedure test2;
@@ -53,9 +61,12 @@ end;
 
 create or replace package suite_package_without_name is
   -- %suite
-  -- %test(A passing test sample)
+  
+  -- %test
+  -- %displayname(A passing test sample)
   procedure passing_test1;
-  -- %test(A passing test sample)
+  -- %test
+  -- %displayname(A passing test sample)
   procedure passing_test2;
 end;
 /

--- a/examples/award_bonus/test_award_bonus.pkg
+++ b/examples/award_bonus/test_award_bonus.pkg
@@ -1,13 +1,16 @@
 create or replace package test_award_bonus as
 
-  -- %suite(Award bonus)
+  -- %suite
+  -- %displayname(Award bonus)
 
-  -- %test(Sets new salary as pct commision * sales amount)
-  -- %testsetup(add_test_employee)
+  -- %test
+  -- %displayname(Sets new salary as pct commision * sales amount)
+  -- %beforetest(add_test_employee)
   procedure update_employee_salary;
 
-  -- %test(Raises exception if null bonus is passed)
-  -- %testsetup(add_employee_with_null_comm)
+  -- %test
+  -- %displayname(Raises exception if null bonus is passed)
+  -- %beforetest(add_employee_with_null_comm)
   procedure fail_on_null_bonus;
 
   procedure add_test_employee;
@@ -16,7 +19,6 @@ create or replace package test_award_bonus as
 
 end;
 /
-
 create or replace package body test_award_bonus as
 
   gc_test_employee constant integer := -1;

--- a/examples/between_string/test_betwnstr.pkg
+++ b/examples/between_string/test_betwnstr.pkg
@@ -1,21 +1,25 @@
 create or replace package test_betwnstr as
 
-  -- %suite(Between string function)
+  -- %suite
+  -- %displayname(Between string function)
 
-  -- %test(Returns substring from start position to end position)
+  -- %test
+  -- %displayname(Returns substring from start position to end position)
   procedure normal_case;
 
-  -- %test(Returns substring when start position is zero)
+  -- %test
+  -- %displayname(Returns substring when start position is zero)
   procedure zero_start_position;
 
-  -- %test(Returns string until end if end position is greated than string length)
+  -- %test
+  -- %displayname(Returns string until end if end position is greated than string length)
   procedure big_end_position;
 
-  -- %test(Returns null for null inlut srting value)
+  -- %test
+  -- %displayname(Returns null for null inlut srting value)
   procedure null_string;
 end;
 /
-
 create or replace package body test_betwnstr as
 
   procedure normal_case is

--- a/examples/demo_expectations.pck
+++ b/examples/demo_expectations.pck
@@ -1,53 +1,70 @@
 create or replace package demo_expectations is
 
-  -- %suite(Demoing asserts)
+  -- %suite
+  -- %displayname(Demoing asserts)
 
-  -- %test(demo of expectations with nulls)
+  -- %test
+  -- %displayname(demo of expectations with nulls)
   procedure demo_nulls_on_expectations;
 
-  -- %test(demo of failure for to_equal expectation on value mismatch)
+  -- %test
+  -- %displayname(demo of failure for to_equal expectation on value mismatch)
   procedure demo_to_equal_failure;
 
-  -- %test(demo of failure for to_equal expectation on data type mismatch)
+  -- %test
+  -- %displayname(demo of failure for to_equal expectation on data type mismatch)
   procedure demo_to_equal_failure_types;
 
-  -- %test(demo of success for to_equal expectation)
+  -- %test
+  -- %displayname(demo of success for to_equal expectation)
   procedure demo_to_equal_success;
 
-  -- %test(demo of failure for to_be_true and to_be_false expectation)
+  -- %test
+  -- %displayname(demo of failure for to_be_true and to_be_false expectation)
   procedure demo_to_be_true_false_failure;
 
-  -- %test(demo of success for to_be_true and to_be_false expectation)
+  -- %test
+  -- %displayname(demo of success for to_be_true and to_be_false expectation)
   procedure demo_to_be_true_false_success;
 
-  -- %test(demo of failure for to_be_null expectation )
+  -- %test
+  -- %displayname(demo of failure for to_be_null expectation )
   procedure demo_to_be_null_failure;
 
-  -- %test(demo of failure for to_be_null expectation )
+  -- %test
+  -- %displayname(demo of failure for to_be_null expectation )
   procedure demo_to_be_null_success;
 
-  -- %test(demo of success for to_be_not_null expectation )
+  -- %test
+  -- %displayname(demo of success for to_be_not_null expectation )
   procedure demo_to_be_not_null_failure;
 
-  -- %test(demo of success for to_be_not_null expectation)
+  -- %test
+  -- %displayname(demo of success for to_be_not_null expectation)
   procedure demo_to_be_not_null_success;
 
-  -- %test(demo of failure for to_match expectation)
+  -- %test
+  -- %displayname(demo of failure for to_match expectation)
   procedure demo_to_match_failure;
 
-  -- %test(demo of success for to_match expectation)
+  -- %test
+  -- %displayname(demo of success for to_match expectation)
   procedure demo_to_match_success;
 
-  -- %test(demo of failure for to_be_like expectation)
+  -- %test
+  -- %displayname(demo of failure for to_be_like expectation)
   procedure demo_to_be_like_failure;
 
-  -- %test(demo of success for to_be_like expectation)
+  -- %test
+  -- %displayname(demo of success for to_be_like expectation)
   procedure demo_to_be_like_success;
 
-  -- %test(demo of failure for not_to expectations)
+  -- %test
+  -- %displayname(demo of failure for not_to expectations)
   procedure demo_not_to_failure;
 
-  -- %test(demo of success for not_to expectations)
+  -- %test
+  -- %displayname(demo of success for not_to expectations)
   procedure demo_not_to_success;
 
 end;

--- a/examples/demo_of_expectations/demo_equal_matcher.sql
+++ b/examples/demo_of_expectations/demo_equal_matcher.sql
@@ -13,31 +13,39 @@ create or replace type demo_departments as table of demo_department
 
 create or replace package demo_equal_matcher as
 
-  -- %suite(Equal matcher)
-  -- %suitepackage(org.utplsql.v3.demo.matchers)
+  -- %suite
+  -- %displayname(Equal matcher)
+  -- %suitepath(org.utplsql.v3.demo.matchers)
 
   -- TODO this should go into context(compare_objects, Comparing objects)
   -- %context(compare_objects, Comparing objects)
 
-    -- %test(Gives success when comparing identical objects containing identical data)
+    -- %test
+    -- %displayname(Gives success when comparing identical objects containing identical data)
     procedure object_compare_success;
 
-    -- %test(Gives failure when comparing to a null actual)
+    -- %test
+    -- %displayname(Gives failure when comparing to a null actual)
     procedure object_compare_null_actual;
 
-    -- %test(Gives failure when comparing to a null expected)
+    -- %test
+    -- %displayname(Gives failure when comparing to a null expected)
     procedure object_compare_null_expected;
 
-    -- %test(Gives success when comparing null actual to a null expected)
+    -- %test
+    -- %displayname(Gives success when comparing null actual to a null expected)
     procedure object_compare_null_both_ok;
 
-    -- %test(Gives failure when comparing null actual to a null expected, setting null equal to false)
+    -- %test
+    -- %displayname(Gives failure when comparing null actual to a null expected, setting null equal to false)
     procedure object_compare_null_both_fail;
 
-    -- %test(Gives failure when comparing identical objects containing different data)
+    -- %test
+    -- %displayname(Gives failure when comparing identical objects containing different data)
     procedure object_compare_different_data;
 
-    -- %test(Gives failure when comparing different objects containing identical data)
+    -- %test
+    -- %displayname(Gives failure when comparing different objects containing identical data)
     procedure object_compare_different_type;
 
   -- %end_context

--- a/examples/developer_examples/tst_pkg_huge.pks
+++ b/examples/developer_examples/tst_pkg_huge.pks
@@ -1,1971 +1,2522 @@
 create or replace package tst_pkg_huge is
   
-  -- %suite(huge package suite name)
-  -- %suitepackage(all.tests)
+  -- %suite
+  -- %displayname(huge package suite name)
+  -- %suitepath(all.tests)
   
   
     
-    -- %test(Test number 1)
-    procedure test1;
-    
-    -- %test(Test number 2)
-    procedure test2;
-    
-    -- %test(Test number 3)
-    procedure test3;
-    
-    -- %test(Test number 4)
-    procedure test4;
-    
-    -- %test(Test number 5)
-    procedure test5;
-    
-    -- %test(Test number 6)
-    procedure test6;
-    
-    -- %test(Test number 7)
-    procedure test7;
-    
-    -- %test(Test number 8)
-    procedure test8;
-    
-    -- %test(Test number 9)
-    procedure test9;
-    
-    -- %test(Test number 10)
-    procedure test10;
-    
-    -- %test(Test number 11)
-    procedure test11;
-    
-    -- %test(Test number 12)
-    procedure test12;
-    
-    -- %test(Test number 13)
-    procedure test13;
-    
-    -- %test(Test number 14)
-    procedure test14;
-    
-    -- %test(Test number 15)
-    procedure test15;
-    
-    -- %test(Test number 16)
-    procedure test16;
-    
-    -- %test(Test number 17)
-    procedure test17;
-    
-    -- %test(Test number 18)
-    procedure test18;
-    
-    -- %test(Test number 19)
-    procedure test19;
-    
-    -- %test(Test number 20)
-    procedure test20;
-    
-    -- %test(Test number 21)
-    procedure test21;
-    
-    -- %test(Test number 22)
-    procedure test22;
-    
-    -- %test(Test number 23)
-    procedure test23;
-    
-    -- %test(Test number 24)
-    procedure test24;
-    
-    -- %test(Test number 25)
-    procedure test25;
-    
-    -- %test(Test number 26)
-    procedure test26;
-    
-    -- %test(Test number 27)
-    procedure test27;
-    
-    -- %test(Test number 28)
-    procedure test28;
-    
-    -- %test(Test number 29)
-    procedure test29;
-    
-    -- %test(Test number 30)
-    procedure test30;
-    
-    -- %test(Test number 31)
-    procedure test31;
-    
-    -- %test(Test number 32)
-    procedure test32;
-    
-    -- %test(Test number 33)
-    procedure test33;
-    
-    -- %test(Test number 34)
-    procedure test34;
-    
-    -- %test(Test number 35)
-    procedure test35;
-    
-    -- %test(Test number 36)
-    procedure test36;
-    
-    -- %test(Test number 37)
-    procedure test37;
-    
-    -- %test(Test number 38)
-    procedure test38;
-    
-    -- %test(Test number 39)
-    procedure test39;
-    
-    -- %test(Test number 40)
-    procedure test40;
-    
-    -- %test(Test number 41)
-    procedure test41;
-    
-    -- %test(Test number 42)
-    procedure test42;
-    
-    -- %test(Test number 43)
-    procedure test43;
-    
-    -- %test(Test number 44)
-    procedure test44;
-    
-    -- %test(Test number 45)
-    procedure test45;
-    
-    -- %test(Test number 46)
-    procedure test46;
-    
-    -- %test(Test number 47)
-    procedure test47;
-    
-    -- %test(Test number 48)
-    procedure test48;
-    
-    -- %test(Test number 49)
-    procedure test49;
-    
-    -- %test(Test number 50)
-    procedure test50;
-    
-    -- %test(Test number 51)
-    procedure test51;
-    
-    -- %test(Test number 52)
-    procedure test52;
-    
-    -- %test(Test number 53)
-    procedure test53;
-    
-    -- %test(Test number 54)
-    procedure test54;
-    
-    -- %test(Test number 55)
-    procedure test55;
-    
-    -- %test(Test number 56)
-    procedure test56;
-    
-    -- %test(Test number 57)
-    procedure test57;
-    
-    -- %test(Test number 58)
-    procedure test58;
-    
-    -- %test(Test number 59)
-    procedure test59;
-    
-    -- %test(Test number 60)
-    procedure test60;
-    
-    -- %test(Test number 61)
-    procedure test61;
-    
-    -- %test(Test number 62)
-    procedure test62;
-    
-    -- %test(Test number 63)
-    procedure test63;
-    
-    -- %test(Test number 64)
-    procedure test64;
-    
-    -- %test(Test number 65)
-    procedure test65;
-    
-    -- %test(Test number 66)
-    procedure test66;
-    
-    -- %test(Test number 67)
-    procedure test67;
-    
-    -- %test(Test number 68)
-    procedure test68;
-    
-    -- %test(Test number 69)
-    procedure test69;
-    
-    -- %test(Test number 70)
-    procedure test70;
-    
-    -- %test(Test number 71)
-    procedure test71;
-    
-    -- %test(Test number 72)
-    procedure test72;
-    
-    -- %test(Test number 73)
-    procedure test73;
-    
-    -- %test(Test number 74)
-    procedure test74;
-    
-    -- %test(Test number 75)
-    procedure test75;
-    
-    -- %test(Test number 76)
-    procedure test76;
-    
-    -- %test(Test number 77)
-    procedure test77;
-    
-    -- %test(Test number 78)
-    procedure test78;
-    
-    -- %test(Test number 79)
-    procedure test79;
-    
-    -- %test(Test number 80)
-    procedure test80;
-    
-    -- %test(Test number 81)
-    procedure test81;
-    
-    -- %test(Test number 82)
-    procedure test82;
-    
-    -- %test(Test number 83)
-    procedure test83;
-    
-    -- %test(Test number 84)
-    procedure test84;
-    
-    -- %test(Test number 85)
-    procedure test85;
-    
-    -- %test(Test number 86)
-    procedure test86;
-    
-    -- %test(Test number 87)
-    procedure test87;
-    
-    -- %test(Test number 88)
-    procedure test88;
-    
-    -- %test(Test number 89)
-    procedure test89;
-    
-    -- %test(Test number 90)
-    procedure test90;
-    
-    -- %test(Test number 91)
-    procedure test91;
-    
-    -- %test(Test number 92)
-    procedure test92;
-    
-    -- %test(Test number 93)
-    procedure test93;
-    
-    -- %test(Test number 94)
-    procedure test94;
-    
-    -- %test(Test number 95)
-    procedure test95;
-    
-    -- %test(Test number 96)
-    procedure test96;
-    
-    -- %test(Test number 97)
-    procedure test97;
-    
-    -- %test(Test number 98)
-    procedure test98;
-    
-    -- %test(Test number 99)
-    procedure test99;
-    
-    -- %test(Test number 100)
-    procedure test100;
-    
-    -- %test(Test number 101)
-    procedure test101;
-    
-    -- %test(Test number 102)
-    procedure test102;
-    
-    -- %test(Test number 103)
-    procedure test103;
-    
-    -- %test(Test number 104)
-    procedure test104;
-    
-    -- %test(Test number 105)
-    procedure test105;
-    
-    -- %test(Test number 106)
-    procedure test106;
-    
-    -- %test(Test number 107)
-    procedure test107;
-    
-    -- %test(Test number 108)
-    procedure test108;
-    
-    -- %test(Test number 109)
-    procedure test109;
-    
-    -- %test(Test number 110)
-    procedure test110;
-    
-    -- %test(Test number 111)
-    procedure test111;
-    
-    -- %test(Test number 112)
-    procedure test112;
-    
-    -- %test(Test number 113)
-    procedure test113;
-    
-    -- %test(Test number 114)
-    procedure test114;
-    
-    -- %test(Test number 115)
-    procedure test115;
-    
-    -- %test(Test number 116)
-    procedure test116;
-    
-    -- %test(Test number 117)
-    procedure test117;
-    
-    -- %test(Test number 118)
-    procedure test118;
-    
-    -- %test(Test number 119)
-    procedure test119;
-    
-    -- %test(Test number 120)
-    procedure test120;
-    
-    -- %test(Test number 121)
-    procedure test121;
-    
-    -- %test(Test number 122)
-    procedure test122;
-    
-    -- %test(Test number 123)
-    procedure test123;
-    
-    -- %test(Test number 124)
-    procedure test124;
-    
-    -- %test(Test number 125)
-    procedure test125;
-    
-    -- %test(Test number 126)
-    procedure test126;
-    
-    -- %test(Test number 127)
-    procedure test127;
-    
-    -- %test(Test number 128)
-    procedure test128;
-    
-    -- %test(Test number 129)
-    procedure test129;
-    
-    -- %test(Test number 130)
-    procedure test130;
-    
-    -- %test(Test number 131)
-    procedure test131;
-    
-    -- %test(Test number 132)
-    procedure test132;
-    
-    -- %test(Test number 133)
-    procedure test133;
-    
-    -- %test(Test number 134)
-    procedure test134;
-    
-    -- %test(Test number 135)
-    procedure test135;
-    
-    -- %test(Test number 136)
-    procedure test136;
-    
-    -- %test(Test number 137)
-    procedure test137;
-    
-    -- %test(Test number 138)
-    procedure test138;
-    
-    -- %test(Test number 139)
-    procedure test139;
-    
-    -- %test(Test number 140)
-    procedure test140;
-    
-    -- %test(Test number 141)
-    procedure test141;
-    
-    -- %test(Test number 142)
-    procedure test142;
-    
-    -- %test(Test number 143)
-    procedure test143;
-    
-    -- %test(Test number 144)
-    procedure test144;
-    
-    -- %test(Test number 145)
-    procedure test145;
-    
-    -- %test(Test number 146)
-    procedure test146;
-    
-    -- %test(Test number 147)
-    procedure test147;
-    
-    -- %test(Test number 148)
-    procedure test148;
-    
-    -- %test(Test number 149)
-    procedure test149;
-    
-    -- %test(Test number 150)
-    procedure test150;
-    
-    -- %test(Test number 151)
-    procedure test151;
-    
-    -- %test(Test number 152)
-    procedure test152;
-    
-    -- %test(Test number 153)
-    procedure test153;
-    
-    -- %test(Test number 154)
-    procedure test154;
-    
-    -- %test(Test number 155)
-    procedure test155;
-    
-    -- %test(Test number 156)
-    procedure test156;
-    
-    -- %test(Test number 157)
-    procedure test157;
-    
-    -- %test(Test number 158)
-    procedure test158;
-    
-    -- %test(Test number 159)
-    procedure test159;
-    
-    -- %test(Test number 160)
-    procedure test160;
-    
-    -- %test(Test number 161)
-    procedure test161;
-    
-    -- %test(Test number 162)
-    procedure test162;
-    
-    -- %test(Test number 163)
-    procedure test163;
-    
-    -- %test(Test number 164)
-    procedure test164;
-    
-    -- %test(Test number 165)
-    procedure test165;
-    
-    -- %test(Test number 166)
-    procedure test166;
-    
-    -- %test(Test number 167)
-    procedure test167;
-    
-    -- %test(Test number 168)
-    procedure test168;
-    
-    -- %test(Test number 169)
-    procedure test169;
-    
-    -- %test(Test number 170)
-    procedure test170;
-    
-    -- %test(Test number 171)
-    procedure test171;
-    
-    -- %test(Test number 172)
-    procedure test172;
-    
-    -- %test(Test number 173)
-    procedure test173;
-    
-    -- %test(Test number 174)
-    procedure test174;
-    
-    -- %test(Test number 175)
-    procedure test175;
-    
-    -- %test(Test number 176)
-    procedure test176;
-    
-    -- %test(Test number 177)
-    procedure test177;
-    
-    -- %test(Test number 178)
-    procedure test178;
-    
-    -- %test(Test number 179)
-    procedure test179;
-    
-    -- %test(Test number 180)
-    procedure test180;
-    
-    -- %test(Test number 181)
-    procedure test181;
-    
-    -- %test(Test number 182)
-    procedure test182;
-    
-    -- %test(Test number 183)
-    procedure test183;
-    
-    -- %test(Test number 184)
-    procedure test184;
-    
-    -- %test(Test number 185)
-    procedure test185;
-    
-    -- %test(Test number 186)
-    procedure test186;
-    
-    -- %test(Test number 187)
-    procedure test187;
-    
-    -- %test(Test number 188)
-    procedure test188;
-    
-    -- %test(Test number 189)
-    procedure test189;
-    
-    -- %test(Test number 190)
-    procedure test190;
-    
-    -- %test(Test number 191)
-    procedure test191;
-    
-    -- %test(Test number 192)
-    procedure test192;
-    
-    -- %test(Test number 193)
-    procedure test193;
-    
-    -- %test(Test number 194)
-    procedure test194;
-    
-    -- %test(Test number 195)
-    procedure test195;
-    
-    -- %test(Test number 196)
-    procedure test196;
-    
-    -- %test(Test number 197)
-    procedure test197;
-    
-    -- %test(Test number 198)
-    procedure test198;
-    
-    -- %test(Test number 199)
-    procedure test199;
-    
-    -- %test(Test number 200)
-    procedure test200;
-    
-    -- %test(Test number 201)
-    procedure test201;
-    
-    -- %test(Test number 202)
-    procedure test202;
-    
-    -- %test(Test number 203)
-    procedure test203;
-    
-    -- %test(Test number 204)
-    procedure test204;
-    
-    -- %test(Test number 205)
-    procedure test205;
-    
-    -- %test(Test number 206)
-    procedure test206;
-    
-    -- %test(Test number 207)
-    procedure test207;
-    
-    -- %test(Test number 208)
-    procedure test208;
-    
-    -- %test(Test number 209)
-    procedure test209;
-    
-    -- %test(Test number 210)
-    procedure test210;
-    
-    -- %test(Test number 211)
-    procedure test211;
-    
-    -- %test(Test number 212)
-    procedure test212;
-    
-    -- %test(Test number 213)
-    procedure test213;
-    
-    -- %test(Test number 214)
-    procedure test214;
-    
-    -- %test(Test number 215)
-    procedure test215;
-    
-    -- %test(Test number 216)
-    procedure test216;
-    
-    -- %test(Test number 217)
-    procedure test217;
-    
-    -- %test(Test number 218)
-    procedure test218;
-    
-    -- %test(Test number 219)
-    procedure test219;
-    
-    -- %test(Test number 220)
-    procedure test220;
-    
-    -- %test(Test number 221)
-    procedure test221;
-    
-    -- %test(Test number 222)
-    procedure test222;
-    
-    -- %test(Test number 223)
-    procedure test223;
-    
-    -- %test(Test number 224)
-    procedure test224;
-    
-    -- %test(Test number 225)
-    procedure test225;
-    
-    -- %test(Test number 226)
-    procedure test226;
-    
-    -- %test(Test number 227)
-    procedure test227;
-    
-    -- %test(Test number 228)
-    procedure test228;
-    
-    -- %test(Test number 229)
-    procedure test229;
-    
-    -- %test(Test number 230)
-    procedure test230;
-    
-    -- %test(Test number 231)
-    procedure test231;
-    
-    -- %test(Test number 232)
-    procedure test232;
-    
-    -- %test(Test number 233)
-    procedure test233;
-    
-    -- %test(Test number 234)
-    procedure test234;
-    
-    -- %test(Test number 235)
-    procedure test235;
-    
-    -- %test(Test number 236)
-    procedure test236;
-    
-    -- %test(Test number 237)
-    procedure test237;
-    
-    -- %test(Test number 238)
-    procedure test238;
-    
-    -- %test(Test number 239)
-    procedure test239;
-    
-    -- %test(Test number 240)
-    procedure test240;
-    
-    -- %test(Test number 241)
-    procedure test241;
-    
-    -- %test(Test number 242)
-    procedure test242;
-    
-    -- %test(Test number 243)
-    procedure test243;
-    
-    -- %test(Test number 244)
-    procedure test244;
-    
-    -- %test(Test number 245)
-    procedure test245;
-    
-    -- %test(Test number 246)
-    procedure test246;
-    
-    -- %test(Test number 247)
-    procedure test247;
-    
-    -- %test(Test number 248)
-    procedure test248;
-    
-    -- %test(Test number 249)
-    procedure test249;
-    
-    -- %test(Test number 250)
-    procedure test250;
-    
-    -- %test(Test number 251)
-    procedure test251;
-    
-    -- %test(Test number 252)
-    procedure test252;
-    
-    -- %test(Test number 253)
-    procedure test253;
-    
-    -- %test(Test number 254)
-    procedure test254;
-    
-    -- %test(Test number 255)
-    procedure test255;
-    
-    -- %test(Test number 256)
-    procedure test256;
-    
-    -- %test(Test number 257)
-    procedure test257;
-    
-    -- %test(Test number 258)
-    procedure test258;
-    
-    -- %test(Test number 259)
-    procedure test259;
-    
-    -- %test(Test number 260)
-    procedure test260;
-    
-    -- %test(Test number 261)
-    procedure test261;
-    
-    -- %test(Test number 262)
-    procedure test262;
-    
-    -- %test(Test number 263)
-    procedure test263;
-    
-    -- %test(Test number 264)
-    procedure test264;
-    
-    -- %test(Test number 265)
-    procedure test265;
-    
-    -- %test(Test number 266)
-    procedure test266;
-    
-    -- %test(Test number 267)
-    procedure test267;
-    
-    -- %test(Test number 268)
-    procedure test268;
-    
-    -- %test(Test number 269)
-    procedure test269;
-    
-    -- %test(Test number 270)
-    procedure test270;
-    
-    -- %test(Test number 271)
-    procedure test271;
-    
-    -- %test(Test number 272)
-    procedure test272;
-    
-    -- %test(Test number 273)
-    procedure test273;
-    
-    -- %test(Test number 274)
-    procedure test274;
-    
-    -- %test(Test number 275)
-    procedure test275;
-    
-    -- %test(Test number 276)
-    procedure test276;
-    
-    -- %test(Test number 277)
-    procedure test277;
-    
-    -- %test(Test number 278)
-    procedure test278;
-    
-    -- %test(Test number 279)
-    procedure test279;
-    
-    -- %test(Test number 280)
-    procedure test280;
-    
-    -- %test(Test number 281)
-    procedure test281;
-    
-    -- %test(Test number 282)
-    procedure test282;
-    
-    -- %test(Test number 283)
-    procedure test283;
-    
-    -- %test(Test number 284)
-    procedure test284;
-    
-    -- %test(Test number 285)
-    procedure test285;
-    
-    -- %test(Test number 286)
-    procedure test286;
-    
-    -- %test(Test number 287)
-    procedure test287;
-    
-    -- %test(Test number 288)
-    procedure test288;
-    
-    -- %test(Test number 289)
-    procedure test289;
-    
-    -- %test(Test number 290)
-    procedure test290;
-    
-    -- %test(Test number 291)
-    procedure test291;
-    
-    -- %test(Test number 292)
-    procedure test292;
-    
-    -- %test(Test number 293)
-    procedure test293;
-    
-    -- %test(Test number 294)
-    procedure test294;
-    
-    -- %test(Test number 295)
-    procedure test295;
-    
-    -- %test(Test number 296)
-    procedure test296;
-    
-    -- %test(Test number 297)
-    procedure test297;
-    
-    -- %test(Test number 298)
-    procedure test298;
-    
-    -- %test(Test number 299)
-    procedure test299;
-    
-    -- %test(Test number 300)
-    procedure test300;
-    
-    -- %test(Test number 301)
-    procedure test301;
-    
-    -- %test(Test number 302)
-    procedure test302;
-    
-    -- %test(Test number 303)
-    procedure test303;
-    
-    -- %test(Test number 304)
-    procedure test304;
-    
-    -- %test(Test number 305)
-    procedure test305;
-    
-    -- %test(Test number 306)
-    procedure test306;
-    
-    -- %test(Test number 307)
-    procedure test307;
-    
-    -- %test(Test number 308)
-    procedure test308;
-    
-    -- %test(Test number 309)
-    procedure test309;
-    
-    -- %test(Test number 310)
-    procedure test310;
-    
-    -- %test(Test number 311)
-    procedure test311;
-    
-    -- %test(Test number 312)
-    procedure test312;
-    
-    -- %test(Test number 313)
-    procedure test313;
-    
-    -- %test(Test number 314)
-    procedure test314;
-    
-    -- %test(Test number 315)
-    procedure test315;
-    
-    -- %test(Test number 316)
-    procedure test316;
-    
-    -- %test(Test number 317)
-    procedure test317;
-    
-    -- %test(Test number 318)
-    procedure test318;
-    
-    -- %test(Test number 319)
-    procedure test319;
-    
-    -- %test(Test number 320)
-    procedure test320;
-    
-    -- %test(Test number 321)
-    procedure test321;
-    
-    -- %test(Test number 322)
-    procedure test322;
-    
-    -- %test(Test number 323)
-    procedure test323;
-    
-    -- %test(Test number 324)
-    procedure test324;
-    
-    -- %test(Test number 325)
-    procedure test325;
-    
-    -- %test(Test number 326)
-    procedure test326;
-    
-    -- %test(Test number 327)
-    procedure test327;
-    
-    -- %test(Test number 328)
-    procedure test328;
-    
-    -- %test(Test number 329)
-    procedure test329;
-    
-    -- %test(Test number 330)
-    procedure test330;
-    
-    -- %test(Test number 331)
-    procedure test331;
-    
-    -- %test(Test number 332)
-    procedure test332;
-    
-    -- %test(Test number 333)
-    procedure test333;
-    
-    -- %test(Test number 334)
-    procedure test334;
-    
-    -- %test(Test number 335)
-    procedure test335;
-    
-    -- %test(Test number 336)
-    procedure test336;
-    
-    -- %test(Test number 337)
-    procedure test337;
-    
-    -- %test(Test number 338)
-    procedure test338;
-    
-    -- %test(Test number 339)
-    procedure test339;
-    
-    -- %test(Test number 340)
-    procedure test340;
-    
-    -- %test(Test number 341)
-    procedure test341;
-    
-    -- %test(Test number 342)
-    procedure test342;
-    
-    -- %test(Test number 343)
-    procedure test343;
-    
-    -- %test(Test number 344)
-    procedure test344;
-    
-    -- %test(Test number 345)
-    procedure test345;
-    
-    -- %test(Test number 346)
-    procedure test346;
-    
-    -- %test(Test number 347)
-    procedure test347;
-    
-    -- %test(Test number 348)
-    procedure test348;
-    
-    -- %test(Test number 349)
-    procedure test349;
-    
-    -- %test(Test number 350)
-    procedure test350;
-    
-    -- %test(Test number 351)
-    procedure test351;
-    
-    -- %test(Test number 352)
-    procedure test352;
-    
-    -- %test(Test number 353)
-    procedure test353;
-    
-    -- %test(Test number 354)
-    procedure test354;
-    
-    -- %test(Test number 355)
-    procedure test355;
-    
-    -- %test(Test number 356)
-    procedure test356;
-    
-    -- %test(Test number 357)
-    procedure test357;
-    
-    -- %test(Test number 358)
-    procedure test358;
-    
-    -- %test(Test number 359)
-    procedure test359;
-    
-    -- %test(Test number 360)
-    procedure test360;
-    
-    -- %test(Test number 361)
-    procedure test361;
-    
-    -- %test(Test number 362)
-    procedure test362;
-    
-    -- %test(Test number 363)
-    procedure test363;
-    
-    -- %test(Test number 364)
-    procedure test364;
-    
-    -- %test(Test number 365)
-    procedure test365;
-    
-    -- %test(Test number 366)
-    procedure test366;
-    
-    -- %test(Test number 367)
-    procedure test367;
-    
-    -- %test(Test number 368)
-    procedure test368;
-    
-    -- %test(Test number 369)
-    procedure test369;
-    
-    -- %test(Test number 370)
-    procedure test370;
-    
-    -- %test(Test number 371)
-    procedure test371;
-    
-    -- %test(Test number 372)
-    procedure test372;
-    
-    -- %test(Test number 373)
-    procedure test373;
-    
-    -- %test(Test number 374)
-    procedure test374;
-    
-    -- %test(Test number 375)
-    procedure test375;
-    
-    -- %test(Test number 376)
-    procedure test376;
-    
-    -- %test(Test number 377)
-    procedure test377;
-    
-    -- %test(Test number 378)
-    procedure test378;
-    
-    -- %test(Test number 379)
-    procedure test379;
-    
-    -- %test(Test number 380)
-    procedure test380;
-    
-    -- %test(Test number 381)
-    procedure test381;
-    
-    -- %test(Test number 382)
-    procedure test382;
-    
-    -- %test(Test number 383)
-    procedure test383;
-    
-    -- %test(Test number 384)
-    procedure test384;
-    
-    -- %test(Test number 385)
-    procedure test385;
-    
-    -- %test(Test number 386)
-    procedure test386;
-    
-    -- %test(Test number 387)
-    procedure test387;
-    
-    -- %test(Test number 388)
-    procedure test388;
-    
-    -- %test(Test number 389)
-    procedure test389;
-    
-    -- %test(Test number 390)
-    procedure test390;
-    
-    -- %test(Test number 391)
-    procedure test391;
-    
-    -- %test(Test number 392)
-    procedure test392;
-    
-    -- %test(Test number 393)
-    procedure test393;
-    
-    -- %test(Test number 394)
-    procedure test394;
-    
-    -- %test(Test number 395)
-    procedure test395;
-    
-    -- %test(Test number 396)
-    procedure test396;
-    
-    -- %test(Test number 397)
-    procedure test397;
-    
-    -- %test(Test number 398)
-    procedure test398;
-    
-    -- %test(Test number 399)
-    procedure test399;
-    
-    -- %test(Test number 400)
-    procedure test400;
-    
-    -- %test(Test number 401)
-    procedure test401;
-    
-    -- %test(Test number 402)
-    procedure test402;
-    
-    -- %test(Test number 403)
-    procedure test403;
-    
-    -- %test(Test number 404)
-    procedure test404;
-    
-    -- %test(Test number 405)
-    procedure test405;
-    
-    -- %test(Test number 406)
-    procedure test406;
-    
-    -- %test(Test number 407)
-    procedure test407;
-    
-    -- %test(Test number 408)
-    procedure test408;
-    
-    -- %test(Test number 409)
-    procedure test409;
-    
-    -- %test(Test number 410)
-    procedure test410;
-    
-    -- %test(Test number 411)
-    procedure test411;
-    
-    -- %test(Test number 412)
-    procedure test412;
-    
-    -- %test(Test number 413)
-    procedure test413;
-    
-    -- %test(Test number 414)
-    procedure test414;
-    
-    -- %test(Test number 415)
-    procedure test415;
-    
-    -- %test(Test number 416)
-    procedure test416;
-    
-    -- %test(Test number 417)
-    procedure test417;
-    
-    -- %test(Test number 418)
-    procedure test418;
-    
-    -- %test(Test number 419)
-    procedure test419;
-    
-    -- %test(Test number 420)
-    procedure test420;
-    
-    -- %test(Test number 421)
-    procedure test421;
-    
-    -- %test(Test number 422)
-    procedure test422;
-    
-    -- %test(Test number 423)
-    procedure test423;
-    
-    -- %test(Test number 424)
-    procedure test424;
-    
-    -- %test(Test number 425)
-    procedure test425;
-    
-    -- %test(Test number 426)
-    procedure test426;
-    
-    -- %test(Test number 427)
-    procedure test427;
-    
-    -- %test(Test number 428)
-    procedure test428;
-    
-    -- %test(Test number 429)
-    procedure test429;
-    
-    -- %test(Test number 430)
-    procedure test430;
-    
-    -- %test(Test number 431)
-    procedure test431;
-    
-    -- %test(Test number 432)
-    procedure test432;
-    
-    -- %test(Test number 433)
-    procedure test433;
-    
-    -- %test(Test number 434)
-    procedure test434;
-    
-    -- %test(Test number 435)
-    procedure test435;
-    
-    -- %test(Test number 436)
-    procedure test436;
-    
-    -- %test(Test number 437)
-    procedure test437;
-    
-    -- %test(Test number 438)
-    procedure test438;
-    
-    -- %test(Test number 439)
-    procedure test439;
-    
-    -- %test(Test number 440)
-    procedure test440;
-    
-    -- %test(Test number 441)
-    procedure test441;
-    
-    -- %test(Test number 442)
-    procedure test442;
-    
-    -- %test(Test number 443)
-    procedure test443;
-    
-    -- %test(Test number 444)
-    procedure test444;
-    
-    -- %test(Test number 445)
-    procedure test445;
-    
-    -- %test(Test number 446)
-    procedure test446;
-    
-    -- %test(Test number 447)
-    procedure test447;
-    
-    -- %test(Test number 448)
-    procedure test448;
-    
-    -- %test(Test number 449)
-    procedure test449;
-    
-    -- %test(Test number 450)
-    procedure test450;
-    
-    -- %test(Test number 451)
-    procedure test451;
-    
-    -- %test(Test number 452)
-    procedure test452;
-    
-    -- %test(Test number 453)
-    procedure test453;
-    
-    -- %test(Test number 454)
-    procedure test454;
-    
-    -- %test(Test number 455)
-    procedure test455;
-    
-    -- %test(Test number 456)
-    procedure test456;
-    
-    -- %test(Test number 457)
-    procedure test457;
-    
-    -- %test(Test number 458)
-    procedure test458;
-    
-    -- %test(Test number 459)
-    procedure test459;
-    
-    -- %test(Test number 460)
-    procedure test460;
-    
-    -- %test(Test number 461)
-    procedure test461;
-    
-    -- %test(Test number 462)
-    procedure test462;
-    
-    -- %test(Test number 463)
-    procedure test463;
-    
-    -- %test(Test number 464)
-    procedure test464;
-    
-    -- %test(Test number 465)
-    procedure test465;
-    
-    -- %test(Test number 466)
-    procedure test466;
-    
-    -- %test(Test number 467)
-    procedure test467;
-    
-    -- %test(Test number 468)
-    procedure test468;
-    
-    -- %test(Test number 469)
-    procedure test469;
-    
-    -- %test(Test number 470)
-    procedure test470;
-    
-    -- %test(Test number 471)
-    procedure test471;
-    
-    -- %test(Test number 472)
-    procedure test472;
-    
-    -- %test(Test number 473)
-    procedure test473;
-    
-    -- %test(Test number 474)
-    procedure test474;
-    
-    -- %test(Test number 475)
-    procedure test475;
-    
-    -- %test(Test number 476)
-    procedure test476;
-    
-    -- %test(Test number 477)
-    procedure test477;
-    
-    -- %test(Test number 478)
-    procedure test478;
-    
-    -- %test(Test number 479)
-    procedure test479;
-    
-    -- %test(Test number 480)
-    procedure test480;
-    
-    -- %test(Test number 481)
-    procedure test481;
-    
-    -- %test(Test number 482)
-    procedure test482;
-    
-    -- %test(Test number 483)
-    procedure test483;
-    
-    -- %test(Test number 484)
-    procedure test484;
-    
-    -- %test(Test number 485)
-    procedure test485;
-    
-    -- %test(Test number 486)
-    procedure test486;
-    
-    -- %test(Test number 487)
-    procedure test487;
-    
-    -- %test(Test number 488)
-    procedure test488;
-    
-    -- %test(Test number 489)
-    procedure test489;
-    
-    -- %test(Test number 490)
-    procedure test490;
-    
-    -- %test(Test number 491)
-    procedure test491;
-    
-    -- %test(Test number 492)
-    procedure test492;
-    
-    -- %test(Test number 493)
-    procedure test493;
-    
-    -- %test(Test number 494)
-    procedure test494;
-    
-    -- %test(Test number 495)
-    procedure test495;
-    
-    -- %test(Test number 496)
-    procedure test496;
-    
-    -- %test(Test number 497)
-    procedure test497;
-    
-    -- %test(Test number 498)
-    procedure test498;
-    
-    -- %test(Test number 499)
-    procedure test499;
-    
-    -- %test(Test number 500)
-    procedure test500;
-    
-    -- %test(Test with setup number 1)
-    -- %testsetup(test_setup1)
-    -- %testteardown(test_teardown1)
-    procedure test_with_procs1;
-    
-    procedure test_setup1;
+  -- %test
+  -- %displayname(Test number 1)
+  procedure test1;
+    
+  -- %test
+  -- %displayname(Test number 2)
+  procedure test2;
+    
+  -- %test
+  -- %displayname(Test number 3)
+  procedure test3;
+    
+  -- %test
+  -- %displayname(Test number 4)
+  procedure test4;
+    
+  -- %test
+  -- %displayname(Test number 5)
+  procedure test5;
+    
+  -- %test
+  -- %displayname(Test number 6)
+  procedure test6;
+    
+  -- %test
+  -- %displayname(Test number 7)
+  procedure test7;
+    
+  -- %test
+  -- %displayname(Test number 8)
+  procedure test8;
+    
+  -- %test
+  -- %displayname(Test number 9)
+  procedure test9;
+    
+  -- %test
+  -- %displayname(Test number 10)
+  procedure test10;
+    
+  -- %test
+  -- %displayname(Test number 11)
+  procedure test11;
+    
+  -- %test
+  -- %displayname(Test number 12)
+  procedure test12;
+    
+  -- %test
+  -- %displayname(Test number 13)
+  procedure test13;
+    
+  -- %test
+  -- %displayname(Test number 14)
+  procedure test14;
+    
+  -- %test
+  -- %displayname(Test number 15)
+  procedure test15;
+    
+  -- %test
+  -- %displayname(Test number 16)
+  procedure test16;
+    
+  -- %test
+  -- %displayname(Test number 17)
+  procedure test17;
+    
+  -- %test
+  -- %displayname(Test number 18)
+  procedure test18;
+    
+  -- %test
+  -- %displayname(Test number 19)
+  procedure test19;
+    
+  -- %test
+  -- %displayname(Test number 20)
+  procedure test20;
+    
+  -- %test
+  -- %displayname(Test number 21)
+  procedure test21;
+    
+  -- %test
+  -- %displayname(Test number 22)
+  procedure test22;
+    
+  -- %test
+  -- %displayname(Test number 23)
+  procedure test23;
+    
+  -- %test
+  -- %displayname(Test number 24)
+  procedure test24;
+    
+  -- %test
+  -- %displayname(Test number 25)
+  procedure test25;
+    
+  -- %test
+  -- %displayname(Test number 26)
+  procedure test26;
+    
+  -- %test
+  -- %displayname(Test number 27)
+  procedure test27;
+    
+  -- %test
+  -- %displayname(Test number 28)
+  procedure test28;
+    
+  -- %test
+  -- %displayname(Test number 29)
+  procedure test29;
+    
+  -- %test
+  -- %displayname(Test number 30)
+  procedure test30;
+    
+  -- %test
+  -- %displayname(Test number 31)
+  procedure test31;
+    
+  -- %test
+  -- %displayname(Test number 32)
+  procedure test32;
+    
+  -- %test
+  -- %displayname(Test number 33)
+  procedure test33;
+    
+  -- %test
+  -- %displayname(Test number 34)
+  procedure test34;
+    
+  -- %test
+  -- %displayname(Test number 35)
+  procedure test35;
+    
+  -- %test
+  -- %displayname(Test number 36)
+  procedure test36;
+    
+  -- %test
+  -- %displayname(Test number 37)
+  procedure test37;
+    
+  -- %test
+  -- %displayname(Test number 38)
+  procedure test38;
+    
+  -- %test
+  -- %displayname(Test number 39)
+  procedure test39;
+    
+  -- %test
+  -- %displayname(Test number 40)
+  procedure test40;
+    
+  -- %test
+  -- %displayname(Test number 41)
+  procedure test41;
+    
+  -- %test
+  -- %displayname(Test number 42)
+  procedure test42;
+    
+  -- %test
+  -- %displayname(Test number 43)
+  procedure test43;
+    
+  -- %test
+  -- %displayname(Test number 44)
+  procedure test44;
+    
+  -- %test
+  -- %displayname(Test number 45)
+  procedure test45;
+    
+  -- %test
+  -- %displayname(Test number 46)
+  procedure test46;
+    
+  -- %test
+  -- %displayname(Test number 47)
+  procedure test47;
+    
+  -- %test
+  -- %displayname(Test number 48)
+  procedure test48;
+    
+  -- %test
+  -- %displayname(Test number 49)
+  procedure test49;
+    
+  -- %test
+  -- %displayname(Test number 50)
+  procedure test50;
+    
+  -- %test
+  -- %displayname(Test number 51)
+  procedure test51;
+    
+  -- %test
+  -- %displayname(Test number 52)
+  procedure test52;
+    
+  -- %test
+  -- %displayname(Test number 53)
+  procedure test53;
+    
+  -- %test
+  -- %displayname(Test number 54)
+  procedure test54;
+    
+  -- %test
+  -- %displayname(Test number 55)
+  procedure test55;
+    
+  -- %test
+  -- %displayname(Test number 56)
+  procedure test56;
+    
+  -- %test
+  -- %displayname(Test number 57)
+  procedure test57;
+    
+  -- %test
+  -- %displayname(Test number 58)
+  procedure test58;
+    
+  -- %test
+  -- %displayname(Test number 59)
+  procedure test59;
+    
+  -- %test
+  -- %displayname(Test number 60)
+  procedure test60;
+    
+  -- %test
+  -- %displayname(Test number 61)
+  procedure test61;
+    
+  -- %test
+  -- %displayname(Test number 62)
+  procedure test62;
+    
+  -- %test
+  -- %displayname(Test number 63)
+  procedure test63;
+    
+  -- %test
+  -- %displayname(Test number 64)
+  procedure test64;
+    
+  -- %test
+  -- %displayname(Test number 65)
+  procedure test65;
+    
+  -- %test
+  -- %displayname(Test number 66)
+  procedure test66;
+    
+  -- %test
+  -- %displayname(Test number 67)
+  procedure test67;
+    
+  -- %test
+  -- %displayname(Test number 68)
+  procedure test68;
+    
+  -- %test
+  -- %displayname(Test number 69)
+  procedure test69;
+    
+  -- %test
+  -- %displayname(Test number 70)
+  procedure test70;
+    
+  -- %test
+  -- %displayname(Test number 71)
+  procedure test71;
+    
+  -- %test
+  -- %displayname(Test number 72)
+  procedure test72;
+    
+  -- %test
+  -- %displayname(Test number 73)
+  procedure test73;
+    
+  -- %test
+  -- %displayname(Test number 74)
+  procedure test74;
+    
+  -- %test
+  -- %displayname(Test number 75)
+  procedure test75;
+    
+  -- %test
+  -- %displayname(Test number 76)
+  procedure test76;
+    
+  -- %test
+  -- %displayname(Test number 77)
+  procedure test77;
+    
+  -- %test
+  -- %displayname(Test number 78)
+  procedure test78;
+    
+  -- %test
+  -- %displayname(Test number 79)
+  procedure test79;
+    
+  -- %test
+  -- %displayname(Test number 80)
+  procedure test80;
+    
+  -- %test
+  -- %displayname(Test number 81)
+  procedure test81;
+    
+  -- %test
+  -- %displayname(Test number 82)
+  procedure test82;
+    
+  -- %test
+  -- %displayname(Test number 83)
+  procedure test83;
+    
+  -- %test
+  -- %displayname(Test number 84)
+  procedure test84;
+    
+  -- %test
+  -- %displayname(Test number 85)
+  procedure test85;
+    
+  -- %test
+  -- %displayname(Test number 86)
+  procedure test86;
+    
+  -- %test
+  -- %displayname(Test number 87)
+  procedure test87;
+    
+  -- %test
+  -- %displayname(Test number 88)
+  procedure test88;
+    
+  -- %test
+  -- %displayname(Test number 89)
+  procedure test89;
+    
+  -- %test
+  -- %displayname(Test number 90)
+  procedure test90;
+    
+  -- %test
+  -- %displayname(Test number 91)
+  procedure test91;
+    
+  -- %test
+  -- %displayname(Test number 92)
+  procedure test92;
+    
+  -- %test
+  -- %displayname(Test number 93)
+  procedure test93;
+    
+  -- %test
+  -- %displayname(Test number 94)
+  procedure test94;
+    
+  -- %test
+  -- %displayname(Test number 95)
+  procedure test95;
+    
+  -- %test
+  -- %displayname(Test number 96)
+  procedure test96;
+    
+  -- %test
+  -- %displayname(Test number 97)
+  procedure test97;
+    
+  -- %test
+  -- %displayname(Test number 98)
+  procedure test98;
+    
+  -- %test
+  -- %displayname(Test number 99)
+  procedure test99;
+    
+  -- %test
+  -- %displayname(Test number 100)
+  procedure test100;
+    
+  -- %test
+  -- %displayname(Test number 101)
+  procedure test101;
+    
+  -- %test
+  -- %displayname(Test number 102)
+  procedure test102;
+    
+  -- %test
+  -- %displayname(Test number 103)
+  procedure test103;
+    
+  -- %test
+  -- %displayname(Test number 104)
+  procedure test104;
+    
+  -- %test
+  -- %displayname(Test number 105)
+  procedure test105;
+    
+  -- %test
+  -- %displayname(Test number 106)
+  procedure test106;
+    
+  -- %test
+  -- %displayname(Test number 107)
+  procedure test107;
+    
+  -- %test
+  -- %displayname(Test number 108)
+  procedure test108;
+    
+  -- %test
+  -- %displayname(Test number 109)
+  procedure test109;
+    
+  -- %test
+  -- %displayname(Test number 110)
+  procedure test110;
+    
+  -- %test
+  -- %displayname(Test number 111)
+  procedure test111;
+    
+  -- %test
+  -- %displayname(Test number 112)
+  procedure test112;
+    
+  -- %test
+  -- %displayname(Test number 113)
+  procedure test113;
+    
+  -- %test
+  -- %displayname(Test number 114)
+  procedure test114;
+    
+  -- %test
+  -- %displayname(Test number 115)
+  procedure test115;
+    
+  -- %test
+  -- %displayname(Test number 116)
+  procedure test116;
+    
+  -- %test
+  -- %displayname(Test number 117)
+  procedure test117;
+    
+  -- %test
+  -- %displayname(Test number 118)
+  procedure test118;
+    
+  -- %test
+  -- %displayname(Test number 119)
+  procedure test119;
+    
+  -- %test
+  -- %displayname(Test number 120)
+  procedure test120;
+    
+  -- %test
+  -- %displayname(Test number 121)
+  procedure test121;
+    
+  -- %test
+  -- %displayname(Test number 122)
+  procedure test122;
+    
+  -- %test
+  -- %displayname(Test number 123)
+  procedure test123;
+    
+  -- %test
+  -- %displayname(Test number 124)
+  procedure test124;
+    
+  -- %test
+  -- %displayname(Test number 125)
+  procedure test125;
+    
+  -- %test
+  -- %displayname(Test number 126)
+  procedure test126;
+    
+  -- %test
+  -- %displayname(Test number 127)
+  procedure test127;
+    
+  -- %test
+  -- %displayname(Test number 128)
+  procedure test128;
+    
+  -- %test
+  -- %displayname(Test number 129)
+  procedure test129;
+    
+  -- %test
+  -- %displayname(Test number 130)
+  procedure test130;
+    
+  -- %test
+  -- %displayname(Test number 131)
+  procedure test131;
+    
+  -- %test
+  -- %displayname(Test number 132)
+  procedure test132;
+    
+  -- %test
+  -- %displayname(Test number 133)
+  procedure test133;
+    
+  -- %test
+  -- %displayname(Test number 134)
+  procedure test134;
+    
+  -- %test
+  -- %displayname(Test number 135)
+  procedure test135;
+    
+  -- %test
+  -- %displayname(Test number 136)
+  procedure test136;
+    
+  -- %test
+  -- %displayname(Test number 137)
+  procedure test137;
+    
+  -- %test
+  -- %displayname(Test number 138)
+  procedure test138;
+    
+  -- %test
+  -- %displayname(Test number 139)
+  procedure test139;
+    
+  -- %test
+  -- %displayname(Test number 140)
+  procedure test140;
+    
+  -- %test
+  -- %displayname(Test number 141)
+  procedure test141;
+    
+  -- %test
+  -- %displayname(Test number 142)
+  procedure test142;
+    
+  -- %test
+  -- %displayname(Test number 143)
+  procedure test143;
+    
+  -- %test
+  -- %displayname(Test number 144)
+  procedure test144;
+    
+  -- %test
+  -- %displayname(Test number 145)
+  procedure test145;
+    
+  -- %test
+  -- %displayname(Test number 146)
+  procedure test146;
+    
+  -- %test
+  -- %displayname(Test number 147)
+  procedure test147;
+    
+  -- %test
+  -- %displayname(Test number 148)
+  procedure test148;
+    
+  -- %test
+  -- %displayname(Test number 149)
+  procedure test149;
+    
+  -- %test
+  -- %displayname(Test number 150)
+  procedure test150;
+    
+  -- %test
+  -- %displayname(Test number 151)
+  procedure test151;
+    
+  -- %test
+  -- %displayname(Test number 152)
+  procedure test152;
+    
+  -- %test
+  -- %displayname(Test number 153)
+  procedure test153;
+    
+  -- %test
+  -- %displayname(Test number 154)
+  procedure test154;
+    
+  -- %test
+  -- %displayname(Test number 155)
+  procedure test155;
+    
+  -- %test
+  -- %displayname(Test number 156)
+  procedure test156;
+    
+  -- %test
+  -- %displayname(Test number 157)
+  procedure test157;
+    
+  -- %test
+  -- %displayname(Test number 158)
+  procedure test158;
+    
+  -- %test
+  -- %displayname(Test number 159)
+  procedure test159;
+    
+  -- %test
+  -- %displayname(Test number 160)
+  procedure test160;
+    
+  -- %test
+  -- %displayname(Test number 161)
+  procedure test161;
+    
+  -- %test
+  -- %displayname(Test number 162)
+  procedure test162;
+    
+  -- %test
+  -- %displayname(Test number 163)
+  procedure test163;
+    
+  -- %test
+  -- %displayname(Test number 164)
+  procedure test164;
+    
+  -- %test
+  -- %displayname(Test number 165)
+  procedure test165;
+    
+  -- %test
+  -- %displayname(Test number 166)
+  procedure test166;
+    
+  -- %test
+  -- %displayname(Test number 167)
+  procedure test167;
+    
+  -- %test
+  -- %displayname(Test number 168)
+  procedure test168;
+    
+  -- %test
+  -- %displayname(Test number 169)
+  procedure test169;
+    
+  -- %test
+  -- %displayname(Test number 170)
+  procedure test170;
+    
+  -- %test
+  -- %displayname(Test number 171)
+  procedure test171;
+    
+  -- %test
+  -- %displayname(Test number 172)
+  procedure test172;
+    
+  -- %test
+  -- %displayname(Test number 173)
+  procedure test173;
+    
+  -- %test
+  -- %displayname(Test number 174)
+  procedure test174;
+    
+  -- %test
+  -- %displayname(Test number 175)
+  procedure test175;
+    
+  -- %test
+  -- %displayname(Test number 176)
+  procedure test176;
+    
+  -- %test
+  -- %displayname(Test number 177)
+  procedure test177;
+    
+  -- %test
+  -- %displayname(Test number 178)
+  procedure test178;
+    
+  -- %test
+  -- %displayname(Test number 179)
+  procedure test179;
+    
+  -- %test
+  -- %displayname(Test number 180)
+  procedure test180;
+    
+  -- %test
+  -- %displayname(Test number 181)
+  procedure test181;
+    
+  -- %test
+  -- %displayname(Test number 182)
+  procedure test182;
+    
+  -- %test
+  -- %displayname(Test number 183)
+  procedure test183;
+    
+  -- %test
+  -- %displayname(Test number 184)
+  procedure test184;
+    
+  -- %test
+  -- %displayname(Test number 185)
+  procedure test185;
+    
+  -- %test
+  -- %displayname(Test number 186)
+  procedure test186;
+    
+  -- %test
+  -- %displayname(Test number 187)
+  procedure test187;
+    
+  -- %test
+  -- %displayname(Test number 188)
+  procedure test188;
+    
+  -- %test
+  -- %displayname(Test number 189)
+  procedure test189;
+    
+  -- %test
+  -- %displayname(Test number 190)
+  procedure test190;
+    
+  -- %test
+  -- %displayname(Test number 191)
+  procedure test191;
+    
+  -- %test
+  -- %displayname(Test number 192)
+  procedure test192;
+    
+  -- %test
+  -- %displayname(Test number 193)
+  procedure test193;
+    
+  -- %test
+  -- %displayname(Test number 194)
+  procedure test194;
+    
+  -- %test
+  -- %displayname(Test number 195)
+  procedure test195;
+    
+  -- %test
+  -- %displayname(Test number 196)
+  procedure test196;
+    
+  -- %test
+  -- %displayname(Test number 197)
+  procedure test197;
+    
+  -- %test
+  -- %displayname(Test number 198)
+  procedure test198;
+    
+  -- %test
+  -- %displayname(Test number 199)
+  procedure test199;
+    
+  -- %test
+  -- %displayname(Test number 200)
+  procedure test200;
+    
+  -- %test
+  -- %displayname(Test number 201)
+  procedure test201;
+    
+  -- %test
+  -- %displayname(Test number 202)
+  procedure test202;
+    
+  -- %test
+  -- %displayname(Test number 203)
+  procedure test203;
+    
+  -- %test
+  -- %displayname(Test number 204)
+  procedure test204;
+    
+  -- %test
+  -- %displayname(Test number 205)
+  procedure test205;
+    
+  -- %test
+  -- %displayname(Test number 206)
+  procedure test206;
+    
+  -- %test
+  -- %displayname(Test number 207)
+  procedure test207;
+    
+  -- %test
+  -- %displayname(Test number 208)
+  procedure test208;
+    
+  -- %test
+  -- %displayname(Test number 209)
+  procedure test209;
+    
+  -- %test
+  -- %displayname(Test number 210)
+  procedure test210;
+    
+  -- %test
+  -- %displayname(Test number 211)
+  procedure test211;
+    
+  -- %test
+  -- %displayname(Test number 212)
+  procedure test212;
+    
+  -- %test
+  -- %displayname(Test number 213)
+  procedure test213;
+    
+  -- %test
+  -- %displayname(Test number 214)
+  procedure test214;
+    
+  -- %test
+  -- %displayname(Test number 215)
+  procedure test215;
+    
+  -- %test
+  -- %displayname(Test number 216)
+  procedure test216;
+    
+  -- %test
+  -- %displayname(Test number 217)
+  procedure test217;
+    
+  -- %test
+  -- %displayname(Test number 218)
+  procedure test218;
+    
+  -- %test
+  -- %displayname(Test number 219)
+  procedure test219;
+    
+  -- %test
+  -- %displayname(Test number 220)
+  procedure test220;
+    
+  -- %test
+  -- %displayname(Test number 221)
+  procedure test221;
+    
+  -- %test
+  -- %displayname(Test number 222)
+  procedure test222;
+    
+  -- %test
+  -- %displayname(Test number 223)
+  procedure test223;
+    
+  -- %test
+  -- %displayname(Test number 224)
+  procedure test224;
+    
+  -- %test
+  -- %displayname(Test number 225)
+  procedure test225;
+    
+  -- %test
+  -- %displayname(Test number 226)
+  procedure test226;
+    
+  -- %test
+  -- %displayname(Test number 227)
+  procedure test227;
+    
+  -- %test
+  -- %displayname(Test number 228)
+  procedure test228;
+    
+  -- %test
+  -- %displayname(Test number 229)
+  procedure test229;
+    
+  -- %test
+  -- %displayname(Test number 230)
+  procedure test230;
+    
+  -- %test
+  -- %displayname(Test number 231)
+  procedure test231;
+    
+  -- %test
+  -- %displayname(Test number 232)
+  procedure test232;
+    
+  -- %test
+  -- %displayname(Test number 233)
+  procedure test233;
+    
+  -- %test
+  -- %displayname(Test number 234)
+  procedure test234;
+    
+  -- %test
+  -- %displayname(Test number 235)
+  procedure test235;
+    
+  -- %test
+  -- %displayname(Test number 236)
+  procedure test236;
+    
+  -- %test
+  -- %displayname(Test number 237)
+  procedure test237;
+    
+  -- %test
+  -- %displayname(Test number 238)
+  procedure test238;
+    
+  -- %test
+  -- %displayname(Test number 239)
+  procedure test239;
+    
+  -- %test
+  -- %displayname(Test number 240)
+  procedure test240;
+    
+  -- %test
+  -- %displayname(Test number 241)
+  procedure test241;
+    
+  -- %test
+  -- %displayname(Test number 242)
+  procedure test242;
+    
+  -- %test
+  -- %displayname(Test number 243)
+  procedure test243;
+    
+  -- %test
+  -- %displayname(Test number 244)
+  procedure test244;
+    
+  -- %test
+  -- %displayname(Test number 245)
+  procedure test245;
+    
+  -- %test
+  -- %displayname(Test number 246)
+  procedure test246;
+    
+  -- %test
+  -- %displayname(Test number 247)
+  procedure test247;
+    
+  -- %test
+  -- %displayname(Test number 248)
+  procedure test248;
+    
+  -- %test
+  -- %displayname(Test number 249)
+  procedure test249;
+    
+  -- %test
+  -- %displayname(Test number 250)
+  procedure test250;
+    
+  -- %test
+  -- %displayname(Test number 251)
+  procedure test251;
+    
+  -- %test
+  -- %displayname(Test number 252)
+  procedure test252;
+    
+  -- %test
+  -- %displayname(Test number 253)
+  procedure test253;
+    
+  -- %test
+  -- %displayname(Test number 254)
+  procedure test254;
+    
+  -- %test
+  -- %displayname(Test number 255)
+  procedure test255;
+    
+  -- %test
+  -- %displayname(Test number 256)
+  procedure test256;
+    
+  -- %test
+  -- %displayname(Test number 257)
+  procedure test257;
+    
+  -- %test
+  -- %displayname(Test number 258)
+  procedure test258;
+    
+  -- %test
+  -- %displayname(Test number 259)
+  procedure test259;
+    
+  -- %test
+  -- %displayname(Test number 260)
+  procedure test260;
+    
+  -- %test
+  -- %displayname(Test number 261)
+  procedure test261;
+    
+  -- %test
+  -- %displayname(Test number 262)
+  procedure test262;
+    
+  -- %test
+  -- %displayname(Test number 263)
+  procedure test263;
+    
+  -- %test
+  -- %displayname(Test number 264)
+  procedure test264;
+    
+  -- %test
+  -- %displayname(Test number 265)
+  procedure test265;
+    
+  -- %test
+  -- %displayname(Test number 266)
+  procedure test266;
+    
+  -- %test
+  -- %displayname(Test number 267)
+  procedure test267;
+    
+  -- %test
+  -- %displayname(Test number 268)
+  procedure test268;
+    
+  -- %test
+  -- %displayname(Test number 269)
+  procedure test269;
+    
+  -- %test
+  -- %displayname(Test number 270)
+  procedure test270;
+    
+  -- %test
+  -- %displayname(Test number 271)
+  procedure test271;
+    
+  -- %test
+  -- %displayname(Test number 272)
+  procedure test272;
+    
+  -- %test
+  -- %displayname(Test number 273)
+  procedure test273;
+    
+  -- %test
+  -- %displayname(Test number 274)
+  procedure test274;
+    
+  -- %test
+  -- %displayname(Test number 275)
+  procedure test275;
+    
+  -- %test
+  -- %displayname(Test number 276)
+  procedure test276;
+    
+  -- %test
+  -- %displayname(Test number 277)
+  procedure test277;
+    
+  -- %test
+  -- %displayname(Test number 278)
+  procedure test278;
+    
+  -- %test
+  -- %displayname(Test number 279)
+  procedure test279;
+    
+  -- %test
+  -- %displayname(Test number 280)
+  procedure test280;
+    
+  -- %test
+  -- %displayname(Test number 281)
+  procedure test281;
+    
+  -- %test
+  -- %displayname(Test number 282)
+  procedure test282;
+    
+  -- %test
+  -- %displayname(Test number 283)
+  procedure test283;
+    
+  -- %test
+  -- %displayname(Test number 284)
+  procedure test284;
+    
+  -- %test
+  -- %displayname(Test number 285)
+  procedure test285;
+    
+  -- %test
+  -- %displayname(Test number 286)
+  procedure test286;
+    
+  -- %test
+  -- %displayname(Test number 287)
+  procedure test287;
+    
+  -- %test
+  -- %displayname(Test number 288)
+  procedure test288;
+    
+  -- %test
+  -- %displayname(Test number 289)
+  procedure test289;
+    
+  -- %test
+  -- %displayname(Test number 290)
+  procedure test290;
+    
+  -- %test
+  -- %displayname(Test number 291)
+  procedure test291;
+    
+  -- %test
+  -- %displayname(Test number 292)
+  procedure test292;
+    
+  -- %test
+  -- %displayname(Test number 293)
+  procedure test293;
+    
+  -- %test
+  -- %displayname(Test number 294)
+  procedure test294;
+    
+  -- %test
+  -- %displayname(Test number 295)
+  procedure test295;
+    
+  -- %test
+  -- %displayname(Test number 296)
+  procedure test296;
+    
+  -- %test
+  -- %displayname(Test number 297)
+  procedure test297;
+    
+  -- %test
+  -- %displayname(Test number 298)
+  procedure test298;
+    
+  -- %test
+  -- %displayname(Test number 299)
+  procedure test299;
+    
+  -- %test
+  -- %displayname(Test number 300)
+  procedure test300;
+    
+  -- %test
+  -- %displayname(Test number 301)
+  procedure test301;
+    
+  -- %test
+  -- %displayname(Test number 302)
+  procedure test302;
+    
+  -- %test
+  -- %displayname(Test number 303)
+  procedure test303;
+    
+  -- %test
+  -- %displayname(Test number 304)
+  procedure test304;
+    
+  -- %test
+  -- %displayname(Test number 305)
+  procedure test305;
+    
+  -- %test
+  -- %displayname(Test number 306)
+  procedure test306;
+    
+  -- %test
+  -- %displayname(Test number 307)
+  procedure test307;
+    
+  -- %test
+  -- %displayname(Test number 308)
+  procedure test308;
+    
+  -- %test
+  -- %displayname(Test number 309)
+  procedure test309;
+    
+  -- %test
+  -- %displayname(Test number 310)
+  procedure test310;
+    
+  -- %test
+  -- %displayname(Test number 311)
+  procedure test311;
+    
+  -- %test
+  -- %displayname(Test number 312)
+  procedure test312;
+    
+  -- %test
+  -- %displayname(Test number 313)
+  procedure test313;
+    
+  -- %test
+  -- %displayname(Test number 314)
+  procedure test314;
+    
+  -- %test
+  -- %displayname(Test number 315)
+  procedure test315;
+    
+  -- %test
+  -- %displayname(Test number 316)
+  procedure test316;
+    
+  -- %test
+  -- %displayname(Test number 317)
+  procedure test317;
+    
+  -- %test
+  -- %displayname(Test number 318)
+  procedure test318;
+    
+  -- %test
+  -- %displayname(Test number 319)
+  procedure test319;
+    
+  -- %test
+  -- %displayname(Test number 320)
+  procedure test320;
+    
+  -- %test
+  -- %displayname(Test number 321)
+  procedure test321;
+    
+  -- %test
+  -- %displayname(Test number 322)
+  procedure test322;
+    
+  -- %test
+  -- %displayname(Test number 323)
+  procedure test323;
+    
+  -- %test
+  -- %displayname(Test number 324)
+  procedure test324;
+    
+  -- %test
+  -- %displayname(Test number 325)
+  procedure test325;
+    
+  -- %test
+  -- %displayname(Test number 326)
+  procedure test326;
+    
+  -- %test
+  -- %displayname(Test number 327)
+  procedure test327;
+    
+  -- %test
+  -- %displayname(Test number 328)
+  procedure test328;
+    
+  -- %test
+  -- %displayname(Test number 329)
+  procedure test329;
+    
+  -- %test
+  -- %displayname(Test number 330)
+  procedure test330;
+    
+  -- %test
+  -- %displayname(Test number 331)
+  procedure test331;
+    
+  -- %test
+  -- %displayname(Test number 332)
+  procedure test332;
+    
+  -- %test
+  -- %displayname(Test number 333)
+  procedure test333;
+    
+  -- %test
+  -- %displayname(Test number 334)
+  procedure test334;
+    
+  -- %test
+  -- %displayname(Test number 335)
+  procedure test335;
+    
+  -- %test
+  -- %displayname(Test number 336)
+  procedure test336;
+    
+  -- %test
+  -- %displayname(Test number 337)
+  procedure test337;
+    
+  -- %test
+  -- %displayname(Test number 338)
+  procedure test338;
+    
+  -- %test
+  -- %displayname(Test number 339)
+  procedure test339;
+    
+  -- %test
+  -- %displayname(Test number 340)
+  procedure test340;
+    
+  -- %test
+  -- %displayname(Test number 341)
+  procedure test341;
+    
+  -- %test
+  -- %displayname(Test number 342)
+  procedure test342;
+    
+  -- %test
+  -- %displayname(Test number 343)
+  procedure test343;
+    
+  -- %test
+  -- %displayname(Test number 344)
+  procedure test344;
+    
+  -- %test
+  -- %displayname(Test number 345)
+  procedure test345;
+    
+  -- %test
+  -- %displayname(Test number 346)
+  procedure test346;
+    
+  -- %test
+  -- %displayname(Test number 347)
+  procedure test347;
+    
+  -- %test
+  -- %displayname(Test number 348)
+  procedure test348;
+    
+  -- %test
+  -- %displayname(Test number 349)
+  procedure test349;
+    
+  -- %test
+  -- %displayname(Test number 350)
+  procedure test350;
+    
+  -- %test
+  -- %displayname(Test number 351)
+  procedure test351;
+    
+  -- %test
+  -- %displayname(Test number 352)
+  procedure test352;
+    
+  -- %test
+  -- %displayname(Test number 353)
+  procedure test353;
+    
+  -- %test
+  -- %displayname(Test number 354)
+  procedure test354;
+    
+  -- %test
+  -- %displayname(Test number 355)
+  procedure test355;
+    
+  -- %test
+  -- %displayname(Test number 356)
+  procedure test356;
+    
+  -- %test
+  -- %displayname(Test number 357)
+  procedure test357;
+    
+  -- %test
+  -- %displayname(Test number 358)
+  procedure test358;
+    
+  -- %test
+  -- %displayname(Test number 359)
+  procedure test359;
+    
+  -- %test
+  -- %displayname(Test number 360)
+  procedure test360;
+    
+  -- %test
+  -- %displayname(Test number 361)
+  procedure test361;
+    
+  -- %test
+  -- %displayname(Test number 362)
+  procedure test362;
+    
+  -- %test
+  -- %displayname(Test number 363)
+  procedure test363;
+    
+  -- %test
+  -- %displayname(Test number 364)
+  procedure test364;
+    
+  -- %test
+  -- %displayname(Test number 365)
+  procedure test365;
+    
+  -- %test
+  -- %displayname(Test number 366)
+  procedure test366;
+    
+  -- %test
+  -- %displayname(Test number 367)
+  procedure test367;
+    
+  -- %test
+  -- %displayname(Test number 368)
+  procedure test368;
+    
+  -- %test
+  -- %displayname(Test number 369)
+  procedure test369;
+    
+  -- %test
+  -- %displayname(Test number 370)
+  procedure test370;
+    
+  -- %test
+  -- %displayname(Test number 371)
+  procedure test371;
+    
+  -- %test
+  -- %displayname(Test number 372)
+  procedure test372;
+    
+  -- %test
+  -- %displayname(Test number 373)
+  procedure test373;
+    
+  -- %test
+  -- %displayname(Test number 374)
+  procedure test374;
+    
+  -- %test
+  -- %displayname(Test number 375)
+  procedure test375;
+    
+  -- %test
+  -- %displayname(Test number 376)
+  procedure test376;
+    
+  -- %test
+  -- %displayname(Test number 377)
+  procedure test377;
+    
+  -- %test
+  -- %displayname(Test number 378)
+  procedure test378;
+    
+  -- %test
+  -- %displayname(Test number 379)
+  procedure test379;
+    
+  -- %test
+  -- %displayname(Test number 380)
+  procedure test380;
+    
+  -- %test
+  -- %displayname(Test number 381)
+  procedure test381;
+    
+  -- %test
+  -- %displayname(Test number 382)
+  procedure test382;
+    
+  -- %test
+  -- %displayname(Test number 383)
+  procedure test383;
+    
+  -- %test
+  -- %displayname(Test number 384)
+  procedure test384;
+    
+  -- %test
+  -- %displayname(Test number 385)
+  procedure test385;
+    
+  -- %test
+  -- %displayname(Test number 386)
+  procedure test386;
+    
+  -- %test
+  -- %displayname(Test number 387)
+  procedure test387;
+    
+  -- %test
+  -- %displayname(Test number 388)
+  procedure test388;
+    
+  -- %test
+  -- %displayname(Test number 389)
+  procedure test389;
+    
+  -- %test
+  -- %displayname(Test number 390)
+  procedure test390;
+    
+  -- %test
+  -- %displayname(Test number 391)
+  procedure test391;
+    
+  -- %test
+  -- %displayname(Test number 392)
+  procedure test392;
+    
+  -- %test
+  -- %displayname(Test number 393)
+  procedure test393;
+    
+  -- %test
+  -- %displayname(Test number 394)
+  procedure test394;
+    
+  -- %test
+  -- %displayname(Test number 395)
+  procedure test395;
+    
+  -- %test
+  -- %displayname(Test number 396)
+  procedure test396;
+    
+  -- %test
+  -- %displayname(Test number 397)
+  procedure test397;
+    
+  -- %test
+  -- %displayname(Test number 398)
+  procedure test398;
+    
+  -- %test
+  -- %displayname(Test number 399)
+  procedure test399;
+    
+  -- %test
+  -- %displayname(Test number 400)
+  procedure test400;
+    
+  -- %test
+  -- %displayname(Test number 401)
+  procedure test401;
+    
+  -- %test
+  -- %displayname(Test number 402)
+  procedure test402;
+    
+  -- %test
+  -- %displayname(Test number 403)
+  procedure test403;
+    
+  -- %test
+  -- %displayname(Test number 404)
+  procedure test404;
+    
+  -- %test
+  -- %displayname(Test number 405)
+  procedure test405;
+    
+  -- %test
+  -- %displayname(Test number 406)
+  procedure test406;
+    
+  -- %test
+  -- %displayname(Test number 407)
+  procedure test407;
+    
+  -- %test
+  -- %displayname(Test number 408)
+  procedure test408;
+    
+  -- %test
+  -- %displayname(Test number 409)
+  procedure test409;
+    
+  -- %test
+  -- %displayname(Test number 410)
+  procedure test410;
+    
+  -- %test
+  -- %displayname(Test number 411)
+  procedure test411;
+    
+  -- %test
+  -- %displayname(Test number 412)
+  procedure test412;
+    
+  -- %test
+  -- %displayname(Test number 413)
+  procedure test413;
+    
+  -- %test
+  -- %displayname(Test number 414)
+  procedure test414;
+    
+  -- %test
+  -- %displayname(Test number 415)
+  procedure test415;
+    
+  -- %test
+  -- %displayname(Test number 416)
+  procedure test416;
+    
+  -- %test
+  -- %displayname(Test number 417)
+  procedure test417;
+    
+  -- %test
+  -- %displayname(Test number 418)
+  procedure test418;
+    
+  -- %test
+  -- %displayname(Test number 419)
+  procedure test419;
+    
+  -- %test
+  -- %displayname(Test number 420)
+  procedure test420;
+    
+  -- %test
+  -- %displayname(Test number 421)
+  procedure test421;
+    
+  -- %test
+  -- %displayname(Test number 422)
+  procedure test422;
+    
+  -- %test
+  -- %displayname(Test number 423)
+  procedure test423;
+    
+  -- %test
+  -- %displayname(Test number 424)
+  procedure test424;
+    
+  -- %test
+  -- %displayname(Test number 425)
+  procedure test425;
+    
+  -- %test
+  -- %displayname(Test number 426)
+  procedure test426;
+    
+  -- %test
+  -- %displayname(Test number 427)
+  procedure test427;
+    
+  -- %test
+  -- %displayname(Test number 428)
+  procedure test428;
+    
+  -- %test
+  -- %displayname(Test number 429)
+  procedure test429;
+    
+  -- %test
+  -- %displayname(Test number 430)
+  procedure test430;
+    
+  -- %test
+  -- %displayname(Test number 431)
+  procedure test431;
+    
+  -- %test
+  -- %displayname(Test number 432)
+  procedure test432;
+    
+  -- %test
+  -- %displayname(Test number 433)
+  procedure test433;
+    
+  -- %test
+  -- %displayname(Test number 434)
+  procedure test434;
+    
+  -- %test
+  -- %displayname(Test number 435)
+  procedure test435;
+    
+  -- %test
+  -- %displayname(Test number 436)
+  procedure test436;
+    
+  -- %test
+  -- %displayname(Test number 437)
+  procedure test437;
+    
+  -- %test
+  -- %displayname(Test number 438)
+  procedure test438;
+    
+  -- %test
+  -- %displayname(Test number 439)
+  procedure test439;
+    
+  -- %test
+  -- %displayname(Test number 440)
+  procedure test440;
+    
+  -- %test
+  -- %displayname(Test number 441)
+  procedure test441;
+    
+  -- %test
+  -- %displayname(Test number 442)
+  procedure test442;
+    
+  -- %test
+  -- %displayname(Test number 443)
+  procedure test443;
+    
+  -- %test
+  -- %displayname(Test number 444)
+  procedure test444;
+    
+  -- %test
+  -- %displayname(Test number 445)
+  procedure test445;
+    
+  -- %test
+  -- %displayname(Test number 446)
+  procedure test446;
+    
+  -- %test
+  -- %displayname(Test number 447)
+  procedure test447;
+    
+  -- %test
+  -- %displayname(Test number 448)
+  procedure test448;
+    
+  -- %test
+  -- %displayname(Test number 449)
+  procedure test449;
+    
+  -- %test
+  -- %displayname(Test number 450)
+  procedure test450;
+    
+  -- %test
+  -- %displayname(Test number 451)
+  procedure test451;
+    
+  -- %test
+  -- %displayname(Test number 452)
+  procedure test452;
+    
+  -- %test
+  -- %displayname(Test number 453)
+  procedure test453;
+    
+  -- %test
+  -- %displayname(Test number 454)
+  procedure test454;
+    
+  -- %test
+  -- %displayname(Test number 455)
+  procedure test455;
+    
+  -- %test
+  -- %displayname(Test number 456)
+  procedure test456;
+    
+  -- %test
+  -- %displayname(Test number 457)
+  procedure test457;
+    
+  -- %test
+  -- %displayname(Test number 458)
+  procedure test458;
+    
+  -- %test
+  -- %displayname(Test number 459)
+  procedure test459;
+    
+  -- %test
+  -- %displayname(Test number 460)
+  procedure test460;
+    
+  -- %test
+  -- %displayname(Test number 461)
+  procedure test461;
+    
+  -- %test
+  -- %displayname(Test number 462)
+  procedure test462;
+    
+  -- %test
+  -- %displayname(Test number 463)
+  procedure test463;
+    
+  -- %test
+  -- %displayname(Test number 464)
+  procedure test464;
+    
+  -- %test
+  -- %displayname(Test number 465)
+  procedure test465;
+    
+  -- %test
+  -- %displayname(Test number 466)
+  procedure test466;
+    
+  -- %test
+  -- %displayname(Test number 467)
+  procedure test467;
+    
+  -- %test
+  -- %displayname(Test number 468)
+  procedure test468;
+    
+  -- %test
+  -- %displayname(Test number 469)
+  procedure test469;
+    
+  -- %test
+  -- %displayname(Test number 470)
+  procedure test470;
+    
+  -- %test
+  -- %displayname(Test number 471)
+  procedure test471;
+    
+  -- %test
+  -- %displayname(Test number 472)
+  procedure test472;
+    
+  -- %test
+  -- %displayname(Test number 473)
+  procedure test473;
+    
+  -- %test
+  -- %displayname(Test number 474)
+  procedure test474;
+    
+  -- %test
+  -- %displayname(Test number 475)
+  procedure test475;
+    
+  -- %test
+  -- %displayname(Test number 476)
+  procedure test476;
+    
+  -- %test
+  -- %displayname(Test number 477)
+  procedure test477;
+    
+  -- %test
+  -- %displayname(Test number 478)
+  procedure test478;
+    
+  -- %test
+  -- %displayname(Test number 479)
+  procedure test479;
+    
+  -- %test
+  -- %displayname(Test number 480)
+  procedure test480;
+    
+  -- %test
+  -- %displayname(Test number 481)
+  procedure test481;
+    
+  -- %test
+  -- %displayname(Test number 482)
+  procedure test482;
+    
+  -- %test
+  -- %displayname(Test number 483)
+  procedure test483;
+    
+  -- %test
+  -- %displayname(Test number 484)
+  procedure test484;
+    
+  -- %test
+  -- %displayname(Test number 485)
+  procedure test485;
+    
+  -- %test
+  -- %displayname(Test number 486)
+  procedure test486;
+    
+  -- %test
+  -- %displayname(Test number 487)
+  procedure test487;
+    
+  -- %test
+  -- %displayname(Test number 488)
+  procedure test488;
+    
+  -- %test
+  -- %displayname(Test number 489)
+  procedure test489;
+    
+  -- %test
+  -- %displayname(Test number 490)
+  procedure test490;
+    
+  -- %test
+  -- %displayname(Test number 491)
+  procedure test491;
+    
+  -- %test
+  -- %displayname(Test number 492)
+  procedure test492;
+    
+  -- %test
+  -- %displayname(Test number 493)
+  procedure test493;
+    
+  -- %test
+  -- %displayname(Test number 494)
+  procedure test494;
+    
+  -- %test
+  -- %displayname(Test number 495)
+  procedure test495;
+    
+  -- %test
+  -- %displayname(Test number 496)
+  procedure test496;
+    
+  -- %test
+  -- %displayname(Test number 497)
+  procedure test497;
+    
+  -- %test
+  -- %displayname(Test number 498)
+  procedure test498;
+    
+  -- %test
+  -- %displayname(Test number 499)
+  procedure test499;
+    
+  -- %test
+  -- %displayname(Test number 500)
+  procedure test500;
+    
+  -- %test
+  -- %displayname(Test with setup number 1)
+  -- %beforetest(test_setup1)
+  -- %aftertest(test_teardown1)
+  procedure test_with_procs1;
+    
+  procedure test_setup1;
       
-    procedure test_teardown1;
+  procedure test_teardown1;
     
-    -- %test(Test with setup number 2)
-    -- %testsetup(test_setup2)
-    -- %testteardown(test_teardown2)
-    procedure test_with_procs2;
+  -- %test
+  -- %displayname(Test with setup number 2)
+  -- %beforetest(test_setup2)
+  -- %aftertest(test_teardown2)
+  procedure test_with_procs2;
     
-    procedure test_setup2;
+  procedure test_setup2;
       
-    procedure test_teardown2;
+  procedure test_teardown2;
     
-    -- %test(Test with setup number 3)
-    -- %testsetup(test_setup3)
-    -- %testteardown(test_teardown3)
-    procedure test_with_procs3;
+  -- %test
+  -- %displayname(Test with setup number 3)
+  -- %beforetest(test_setup3)
+  -- %aftertest(test_teardown3)
+  procedure test_with_procs3;
     
-    procedure test_setup3;
+  procedure test_setup3;
       
-    procedure test_teardown3;
+  procedure test_teardown3;
     
-    -- %test(Test with setup number 4)
-    -- %testsetup(test_setup4)
-    -- %testteardown(test_teardown4)
-    procedure test_with_procs4;
+  -- %test
+  -- %displayname(Test with setup number 4)
+  -- %beforetest(test_setup4)
+  -- %aftertest(test_teardown4)
+  procedure test_with_procs4;
     
-    procedure test_setup4;
+  procedure test_setup4;
       
-    procedure test_teardown4;
+  procedure test_teardown4;
     
-    -- %test(Test with setup number 5)
-    -- %testsetup(test_setup5)
-    -- %testteardown(test_teardown5)
-    procedure test_with_procs5;
+  -- %test
+  -- %displayname(Test with setup number 5)
+  -- %beforetest(test_setup5)
+  -- %aftertest(test_teardown5)
+  procedure test_with_procs5;
     
-    procedure test_setup5;
+  procedure test_setup5;
       
-    procedure test_teardown5;
+  procedure test_teardown5;
     
-    -- %test(Test with setup number 6)
-    -- %testsetup(test_setup6)
-    -- %testteardown(test_teardown6)
-    procedure test_with_procs6;
+  -- %test
+  -- %displayname(Test with setup number 6)
+  -- %beforetest(test_setup6)
+  -- %aftertest(test_teardown6)
+  procedure test_with_procs6;
     
-    procedure test_setup6;
+  procedure test_setup6;
       
-    procedure test_teardown6;
+  procedure test_teardown6;
     
-    -- %test(Test with setup number 7)
-    -- %testsetup(test_setup7)
-    -- %testteardown(test_teardown7)
-    procedure test_with_procs7;
+  -- %test
+  -- %displayname(Test with setup number 7)
+  -- %beforetest(test_setup7)
+  -- %aftertest(test_teardown7)
+  procedure test_with_procs7;
     
-    procedure test_setup7;
+  procedure test_setup7;
       
-    procedure test_teardown7;
+  procedure test_teardown7;
     
-    -- %test(Test with setup number 8)
-    -- %testsetup(test_setup8)
-    -- %testteardown(test_teardown8)
-    procedure test_with_procs8;
+  -- %test
+  -- %displayname(Test with setup number 8)
+  -- %beforetest(test_setup8)
+  -- %aftertest(test_teardown8)
+  procedure test_with_procs8;
     
-    procedure test_setup8;
+  procedure test_setup8;
       
-    procedure test_teardown8;
+  procedure test_teardown8;
     
-    -- %test(Test with setup number 9)
-    -- %testsetup(test_setup9)
-    -- %testteardown(test_teardown9)
-    procedure test_with_procs9;
+  -- %test
+  -- %displayname(Test with setup number 9)
+  -- %beforetest(test_setup9)
+  -- %aftertest(test_teardown9)
+  procedure test_with_procs9;
     
-    procedure test_setup9;
+  procedure test_setup9;
       
-    procedure test_teardown9;
+  procedure test_teardown9;
     
-    -- %test(Test with setup number 10)
-    -- %testsetup(test_setup10)
-    -- %testteardown(test_teardown10)
-    procedure test_with_procs10;
+  -- %test
+  -- %displayname(Test with setup number 10)
+  -- %beforetest(test_setup10)
+  -- %aftertest(test_teardown10)
+  procedure test_with_procs10;
     
-    procedure test_setup10;
+  procedure test_setup10;
       
-    procedure test_teardown10;
+  procedure test_teardown10;
     
-    -- %test(Test with setup number 11)
-    -- %testsetup(test_setup11)
-    -- %testteardown(test_teardown11)
-    procedure test_with_procs11;
+  -- %test
+  -- %displayname(Test with setup number 11)
+  -- %beforetest(test_setup11)
+  -- %aftertest(test_teardown11)
+  procedure test_with_procs11;
     
-    procedure test_setup11;
+  procedure test_setup11;
       
-    procedure test_teardown11;
+  procedure test_teardown11;
     
-    -- %test(Test with setup number 12)
-    -- %testsetup(test_setup12)
-    -- %testteardown(test_teardown12)
-    procedure test_with_procs12;
+  -- %test
+  -- %displayname(Test with setup number 12)
+  -- %beforetest(test_setup12)
+  -- %aftertest(test_teardown12)
+  procedure test_with_procs12;
     
-    procedure test_setup12;
+  procedure test_setup12;
       
-    procedure test_teardown12;
+  procedure test_teardown12;
     
-    -- %test(Test with setup number 13)
-    -- %testsetup(test_setup13)
-    -- %testteardown(test_teardown13)
-    procedure test_with_procs13;
+  -- %test
+  -- %displayname(Test with setup number 13)
+  -- %beforetest(test_setup13)
+  -- %aftertest(test_teardown13)
+  procedure test_with_procs13;
     
-    procedure test_setup13;
+  procedure test_setup13;
       
-    procedure test_teardown13;
+  procedure test_teardown13;
     
-    -- %test(Test with setup number 14)
-    -- %testsetup(test_setup14)
-    -- %testteardown(test_teardown14)
-    procedure test_with_procs14;
+  -- %test
+  -- %displayname(Test with setup number 14)
+  -- %beforetest(test_setup14)
+  -- %aftertest(test_teardown14)
+  procedure test_with_procs14;
     
-    procedure test_setup14;
+  procedure test_setup14;
       
-    procedure test_teardown14;
+  procedure test_teardown14;
     
-    -- %test(Test with setup number 15)
-    -- %testsetup(test_setup15)
-    -- %testteardown(test_teardown15)
-    procedure test_with_procs15;
+  -- %test
+  -- %displayname(Test with setup number 15)
+  -- %beforetest(test_setup15)
+  -- %aftertest(test_teardown15)
+  procedure test_with_procs15;
     
-    procedure test_setup15;
+  procedure test_setup15;
       
-    procedure test_teardown15;
+  procedure test_teardown15;
     
-    -- %test(Test with setup number 16)
-    -- %testsetup(test_setup16)
-    -- %testteardown(test_teardown16)
-    procedure test_with_procs16;
+  -- %test
+  -- %displayname(Test with setup number 16)
+  -- %beforetest(test_setup16)
+  -- %aftertest(test_teardown16)
+  procedure test_with_procs16;
     
-    procedure test_setup16;
+  procedure test_setup16;
       
-    procedure test_teardown16;
+  procedure test_teardown16;
     
-    -- %test(Test with setup number 17)
-    -- %testsetup(test_setup17)
-    -- %testteardown(test_teardown17)
-    procedure test_with_procs17;
+  -- %test
+  -- %displayname(Test with setup number 17)
+  -- %beforetest(test_setup17)
+  -- %aftertest(test_teardown17)
+  procedure test_with_procs17;
     
-    procedure test_setup17;
+  procedure test_setup17;
       
-    procedure test_teardown17;
+  procedure test_teardown17;
     
-    -- %test(Test with setup number 18)
-    -- %testsetup(test_setup18)
-    -- %testteardown(test_teardown18)
-    procedure test_with_procs18;
+  -- %test
+  -- %displayname(Test with setup number 18)
+  -- %beforetest(test_setup18)
+  -- %aftertest(test_teardown18)
+  procedure test_with_procs18;
     
-    procedure test_setup18;
+  procedure test_setup18;
       
-    procedure test_teardown18;
+  procedure test_teardown18;
     
-    -- %test(Test with setup number 19)
-    -- %testsetup(test_setup19)
-    -- %testteardown(test_teardown19)
-    procedure test_with_procs19;
+  -- %test
+  -- %displayname(Test with setup number 19)
+  -- %beforetest(test_setup19)
+  -- %aftertest(test_teardown19)
+  procedure test_with_procs19;
     
-    procedure test_setup19;
+  procedure test_setup19;
       
-    procedure test_teardown19;
+  procedure test_teardown19;
     
-    -- %test(Test with setup number 20)
-    -- %testsetup(test_setup20)
-    -- %testteardown(test_teardown20)
-    procedure test_with_procs20;
+  -- %test
+  -- %displayname(Test with setup number 20)
+  -- %beforetest(test_setup20)
+  -- %aftertest(test_teardown20)
+  procedure test_with_procs20;
     
-    procedure test_setup20;
+  procedure test_setup20;
       
-    procedure test_teardown20;
+  procedure test_teardown20;
     
-    -- %test(Test with setup number 21)
-    -- %testsetup(test_setup21)
-    -- %testteardown(test_teardown21)
-    procedure test_with_procs21;
+  -- %test
+  -- %displayname(Test with setup number 21)
+  -- %beforetest(test_setup21)
+  -- %aftertest(test_teardown21)
+  procedure test_with_procs21;
     
-    procedure test_setup21;
+  procedure test_setup21;
       
-    procedure test_teardown21;
+  procedure test_teardown21;
     
-    -- %test(Test with setup number 22)
-    -- %testsetup(test_setup22)
-    -- %testteardown(test_teardown22)
-    procedure test_with_procs22;
+  -- %test
+  -- %displayname(Test with setup number 22)
+  -- %beforetest(test_setup22)
+  -- %aftertest(test_teardown22)
+  procedure test_with_procs22;
     
-    procedure test_setup22;
+  procedure test_setup22;
       
-    procedure test_teardown22;
+  procedure test_teardown22;
     
-    -- %test(Test with setup number 23)
-    -- %testsetup(test_setup23)
-    -- %testteardown(test_teardown23)
-    procedure test_with_procs23;
+  -- %test
+  -- %displayname(Test with setup number 23)
+  -- %beforetest(test_setup23)
+  -- %aftertest(test_teardown23)
+  procedure test_with_procs23;
     
-    procedure test_setup23;
+  procedure test_setup23;
       
-    procedure test_teardown23;
+  procedure test_teardown23;
     
-    -- %test(Test with setup number 24)
-    -- %testsetup(test_setup24)
-    -- %testteardown(test_teardown24)
-    procedure test_with_procs24;
+  -- %test
+  -- %displayname(Test with setup number 24)
+  -- %beforetest(test_setup24)
+  -- %aftertest(test_teardown24)
+  procedure test_with_procs24;
     
-    procedure test_setup24;
+  procedure test_setup24;
       
-    procedure test_teardown24;
+  procedure test_teardown24;
     
-    -- %test(Test with setup number 25)
-    -- %testsetup(test_setup25)
-    -- %testteardown(test_teardown25)
-    procedure test_with_procs25;
+  -- %test
+  -- %displayname(Test with setup number 25)
+  -- %beforetest(test_setup25)
+  -- %aftertest(test_teardown25)
+  procedure test_with_procs25;
     
-    procedure test_setup25;
+  procedure test_setup25;
       
-    procedure test_teardown25;
+  procedure test_teardown25;
     
-    -- %test(Test with setup number 26)
-    -- %testsetup(test_setup26)
-    -- %testteardown(test_teardown26)
-    procedure test_with_procs26;
+  -- %test
+  -- %displayname(Test with setup number 26)
+  -- %beforetest(test_setup26)
+  -- %aftertest(test_teardown26)
+  procedure test_with_procs26;
     
-    procedure test_setup26;
+  procedure test_setup26;
       
-    procedure test_teardown26;
+  procedure test_teardown26;
     
-    -- %test(Test with setup number 27)
-    -- %testsetup(test_setup27)
-    -- %testteardown(test_teardown27)
-    procedure test_with_procs27;
+  -- %test
+  -- %displayname(Test with setup number 27)
+  -- %beforetest(test_setup27)
+  -- %aftertest(test_teardown27)
+  procedure test_with_procs27;
     
-    procedure test_setup27;
+  procedure test_setup27;
       
-    procedure test_teardown27;
+  procedure test_teardown27;
     
-    -- %test(Test with setup number 28)
-    -- %testsetup(test_setup28)
-    -- %testteardown(test_teardown28)
-    procedure test_with_procs28;
+  -- %test
+  -- %displayname(Test with setup number 28)
+  -- %beforetest(test_setup28)
+  -- %aftertest(test_teardown28)
+  procedure test_with_procs28;
     
-    procedure test_setup28;
+  procedure test_setup28;
       
-    procedure test_teardown28;
+  procedure test_teardown28;
     
-    -- %test(Test with setup number 29)
-    -- %testsetup(test_setup29)
-    -- %testteardown(test_teardown29)
-    procedure test_with_procs29;
+  -- %test
+  -- %displayname(Test with setup number 29)
+  -- %beforetest(test_setup29)
+  -- %aftertest(test_teardown29)
+  procedure test_with_procs29;
     
-    procedure test_setup29;
+  procedure test_setup29;
       
-    procedure test_teardown29;
+  procedure test_teardown29;
     
-    -- %test(Test with setup number 30)
-    -- %testsetup(test_setup30)
-    -- %testteardown(test_teardown30)
-    procedure test_with_procs30;
+  -- %test
+  -- %displayname(Test with setup number 30)
+  -- %beforetest(test_setup30)
+  -- %aftertest(test_teardown30)
+  procedure test_with_procs30;
     
-    procedure test_setup30;
+  procedure test_setup30;
       
-    procedure test_teardown30;
+  procedure test_teardown30;
     
-    -- %test(Test with setup number 31)
-    -- %testsetup(test_setup31)
-    -- %testteardown(test_teardown31)
-    procedure test_with_procs31;
+  -- %test
+  -- %displayname(Test with setup number 31)
+  -- %beforetest(test_setup31)
+  -- %aftertest(test_teardown31)
+  procedure test_with_procs31;
     
-    procedure test_setup31;
+  procedure test_setup31;
       
-    procedure test_teardown31;
+  procedure test_teardown31;
     
-    -- %test(Test with setup number 32)
-    -- %testsetup(test_setup32)
-    -- %testteardown(test_teardown32)
-    procedure test_with_procs32;
+  -- %test
+  -- %displayname(Test with setup number 32)
+  -- %beforetest(test_setup32)
+  -- %aftertest(test_teardown32)
+  procedure test_with_procs32;
     
-    procedure test_setup32;
+  procedure test_setup32;
       
-    procedure test_teardown32;
+  procedure test_teardown32;
     
-    -- %test(Test with setup number 33)
-    -- %testsetup(test_setup33)
-    -- %testteardown(test_teardown33)
-    procedure test_with_procs33;
+  -- %test
+  -- %displayname(Test with setup number 33)
+  -- %beforetest(test_setup33)
+  -- %aftertest(test_teardown33)
+  procedure test_with_procs33;
     
-    procedure test_setup33;
+  procedure test_setup33;
       
-    procedure test_teardown33;
+  procedure test_teardown33;
     
-    -- %test(Test with setup number 34)
-    -- %testsetup(test_setup34)
-    -- %testteardown(test_teardown34)
-    procedure test_with_procs34;
+  -- %test
+  -- %displayname(Test with setup number 34)
+  -- %beforetest(test_setup34)
+  -- %aftertest(test_teardown34)
+  procedure test_with_procs34;
     
-    procedure test_setup34;
+  procedure test_setup34;
       
-    procedure test_teardown34;
+  procedure test_teardown34;
     
-    -- %test(Test with setup number 35)
-    -- %testsetup(test_setup35)
-    -- %testteardown(test_teardown35)
-    procedure test_with_procs35;
+  -- %test
+  -- %displayname(Test with setup number 35)
+  -- %beforetest(test_setup35)
+  -- %aftertest(test_teardown35)
+  procedure test_with_procs35;
     
-    procedure test_setup35;
+  procedure test_setup35;
       
-    procedure test_teardown35;
+  procedure test_teardown35;
     
-    -- %test(Test with setup number 36)
-    -- %testsetup(test_setup36)
-    -- %testteardown(test_teardown36)
-    procedure test_with_procs36;
+  -- %test
+  -- %displayname(Test with setup number 36)
+  -- %beforetest(test_setup36)
+  -- %aftertest(test_teardown36)
+  procedure test_with_procs36;
     
-    procedure test_setup36;
+  procedure test_setup36;
       
-    procedure test_teardown36;
+  procedure test_teardown36;
     
-    -- %test(Test with setup number 37)
-    -- %testsetup(test_setup37)
-    -- %testteardown(test_teardown37)
-    procedure test_with_procs37;
+  -- %test
+  -- %displayname(Test with setup number 37)
+  -- %beforetest(test_setup37)
+  -- %aftertest(test_teardown37)
+  procedure test_with_procs37;
     
-    procedure test_setup37;
+  procedure test_setup37;
       
-    procedure test_teardown37;
+  procedure test_teardown37;
     
-    -- %test(Test with setup number 38)
-    -- %testsetup(test_setup38)
-    -- %testteardown(test_teardown38)
-    procedure test_with_procs38;
+  -- %test
+  -- %displayname(Test with setup number 38)
+  -- %beforetest(test_setup38)
+  -- %aftertest(test_teardown38)
+  procedure test_with_procs38;
     
-    procedure test_setup38;
+  procedure test_setup38;
       
-    procedure test_teardown38;
+  procedure test_teardown38;
     
-    -- %test(Test with setup number 39)
-    -- %testsetup(test_setup39)
-    -- %testteardown(test_teardown39)
-    procedure test_with_procs39;
+  -- %test
+  -- %displayname(Test with setup number 39)
+  -- %beforetest(test_setup39)
+  -- %aftertest(test_teardown39)
+  procedure test_with_procs39;
     
-    procedure test_setup39;
+  procedure test_setup39;
       
-    procedure test_teardown39;
+  procedure test_teardown39;
     
-    -- %test(Test with setup number 40)
-    -- %testsetup(test_setup40)
-    -- %testteardown(test_teardown40)
-    procedure test_with_procs40;
+  -- %test
+  -- %displayname(Test with setup number 40)
+  -- %beforetest(test_setup40)
+  -- %aftertest(test_teardown40)
+  procedure test_with_procs40;
     
-    procedure test_setup40;
+  procedure test_setup40;
       
-    procedure test_teardown40;
+  procedure test_teardown40;
     
-    -- %test(Test with setup number 41)
-    -- %testsetup(test_setup41)
-    -- %testteardown(test_teardown41)
-    procedure test_with_procs41;
+  -- %test
+  -- %displayname(Test with setup number 41)
+  -- %beforetest(test_setup41)
+  -- %aftertest(test_teardown41)
+  procedure test_with_procs41;
     
-    procedure test_setup41;
+  procedure test_setup41;
       
-    procedure test_teardown41;
+  procedure test_teardown41;
     
-    -- %test(Test with setup number 42)
-    -- %testsetup(test_setup42)
-    -- %testteardown(test_teardown42)
-    procedure test_with_procs42;
+  -- %test
+  -- %displayname(Test with setup number 42)
+  -- %beforetest(test_setup42)
+  -- %aftertest(test_teardown42)
+  procedure test_with_procs42;
     
-    procedure test_setup42;
+  procedure test_setup42;
       
-    procedure test_teardown42;
+  procedure test_teardown42;
     
-    -- %test(Test with setup number 43)
-    -- %testsetup(test_setup43)
-    -- %testteardown(test_teardown43)
-    procedure test_with_procs43;
+  -- %test
+  -- %displayname(Test with setup number 43)
+  -- %beforetest(test_setup43)
+  -- %aftertest(test_teardown43)
+  procedure test_with_procs43;
     
-    procedure test_setup43;
+  procedure test_setup43;
       
-    procedure test_teardown43;
+  procedure test_teardown43;
     
-    -- %test(Test with setup number 44)
-    -- %testsetup(test_setup44)
-    -- %testteardown(test_teardown44)
-    procedure test_with_procs44;
+  -- %test
+  -- %displayname(Test with setup number 44)
+  -- %beforetest(test_setup44)
+  -- %aftertest(test_teardown44)
+  procedure test_with_procs44;
     
-    procedure test_setup44;
+  procedure test_setup44;
       
-    procedure test_teardown44;
+  procedure test_teardown44;
     
-    -- %test(Test with setup number 45)
-    -- %testsetup(test_setup45)
-    -- %testteardown(test_teardown45)
-    procedure test_with_procs45;
+  -- %test
+  -- %displayname(Test with setup number 45)
+  -- %beforetest(test_setup45)
+  -- %aftertest(test_teardown45)
+  procedure test_with_procs45;
     
-    procedure test_setup45;
+  procedure test_setup45;
       
-    procedure test_teardown45;
+  procedure test_teardown45;
     
-    -- %test(Test with setup number 46)
-    -- %testsetup(test_setup46)
-    -- %testteardown(test_teardown46)
-    procedure test_with_procs46;
+  -- %test
+  -- %displayname(Test with setup number 46)
+  -- %beforetest(test_setup46)
+  -- %aftertest(test_teardown46)
+  procedure test_with_procs46;
     
-    procedure test_setup46;
+  procedure test_setup46;
       
-    procedure test_teardown46;
+  procedure test_teardown46;
     
-    -- %test(Test with setup number 47)
-    -- %testsetup(test_setup47)
-    -- %testteardown(test_teardown47)
-    procedure test_with_procs47;
+  -- %test
+  -- %displayname(Test with setup number 47)
+  -- %beforetest(test_setup47)
+  -- %aftertest(test_teardown47)
+  procedure test_with_procs47;
     
-    procedure test_setup47;
+  procedure test_setup47;
       
-    procedure test_teardown47;
+  procedure test_teardown47;
     
-    -- %test(Test with setup number 48)
-    -- %testsetup(test_setup48)
-    -- %testteardown(test_teardown48)
-    procedure test_with_procs48;
+  -- %test
+  -- %displayname(Test with setup number 48)
+  -- %beforetest(test_setup48)
+  -- %aftertest(test_teardown48)
+  procedure test_with_procs48;
     
-    procedure test_setup48;
+  procedure test_setup48;
       
-    procedure test_teardown48;
+  procedure test_teardown48;
     
-    -- %test(Test with setup number 49)
-    -- %testsetup(test_setup49)
-    -- %testteardown(test_teardown49)
-    procedure test_with_procs49;
+  -- %test
+  -- %displayname(Test with setup number 49)
+  -- %beforetest(test_setup49)
+  -- %aftertest(test_teardown49)
+  procedure test_with_procs49;
     
-    procedure test_setup49;
+  procedure test_setup49;
       
-    procedure test_teardown49;
+  procedure test_teardown49;
     
-    -- %test(Test with setup number 50)
-    -- %testsetup(test_setup50)
-    -- %testteardown(test_teardown50)
-    procedure test_with_procs50;
+  -- %test
+  -- %displayname(Test with setup number 50)
+  -- %beforetest(test_setup50)
+  -- %aftertest(test_teardown50)
+  procedure test_with_procs50;
     
-    procedure test_setup50;
+  procedure test_setup50;
       
-    procedure test_teardown50;
+  procedure test_teardown50;
     
-    -- %setup
-    procedure def_setup;
+  -- %beforeeach
+  procedure def_setup;
     
-    -- %teardown
-    procedure def_teardown;
+  -- %aftereach
+  procedure def_teardown;
     
-  -- %suitesetup
+  -- %beforeall
   procedure global_setup;
-  
-  --%suiteteardown
+    
+  --%afterall
   procedure global_teardown;
   
-  end;
+end;
 /

--- a/examples/remove_rooms_by_name/test_remove_rooms_by_name.pkg
+++ b/examples/remove_rooms_by_name/test_remove_rooms_by_name.pkg
@@ -1,22 +1,25 @@
 create or replace package test_remove_rooms_by_name as
 
-  -- %suite(Remove rooms by name)
+  -- %suite
+  -- %displayname(Remove rooms by name)
 
-  -- %suitesetup
+  -- %beforeall
   procedure setup_rooms;
 
-  -- %test(Removes a room without content in it)
+  -- %test
+  -- %displayname(Removes a room without content in it)
   procedure remove_empty_room;
 
-  -- %test(Does not remove room when it has content)
+  -- %test
+  -- %displayname(Does not remove room when it has content)
   procedure room_with_content;
 
-  -- %test(Raises exception when null room name given)
+  -- %test
+  -- %displayname(Raises exception when null room name given)
   procedure null_room_name;
 
 end;
 /
-
 create or replace package body test_remove_rooms_by_name as
 
   procedure setup_rooms is

--- a/examples/test_pkg1.pck
+++ b/examples/test_pkg1.pck
@@ -1,10 +1,11 @@
-create or replace package TEST_PKG1 is
+create or replace package test_pkg1 is
 
   /*
   This is the correct annotation
   */
-  -- %suite(Name of suite on test_pkg1)
-  -- %suitepackage(all.globaltests)
+  -- %suite
+  -- %displayname(Name of suite on test_pkg1)
+  -- %suitepath(all.globaltests)
 
   /*
   Such comments are skipped
@@ -21,34 +22,37 @@ create or replace package TEST_PKG1 is
   */
   --test name
   --%test1
-  --%test2(name=123)
+  --%test2
+  --%displayname(name=123)
   ----  %test3(name2=123,tete=123)
   ---- asd %test4(name2=123,tete)
   --  t3 t4
   procedure foo;
 
-  -- %test(Name of test1)
-  -- %testsetup(setup_test1)
-  -- %testteardown(teardown_test1)
+  -- %test
+  -- %displayname(Name of test1)
+  -- %beforetest(setup_test1)
+  -- %aftertest(teardown_test1)
   procedure test1;
 
-  -- %test(Name of test2)
+  -- %test
+  -- %displayname(Name of test2)
   procedure test2;
 
-  -- %suitesetup
+  -- %beforeall
   procedure global_setup;
 
   procedure setup_test1;
 
   procedure teardown_test1;
 
-  -- %setup
+  -- %beforeeach
   procedure def_setup;
 
-  -- %teardown
+  -- %aftereach
   procedure def_teardown;
 
-  --%suiteteardown
+  --%afterall
   procedure global_teardown;
 
 end;

--- a/examples/test_pkg2.pck
+++ b/examples/test_pkg2.pck
@@ -3,13 +3,16 @@ create or replace package test_pkg2 is
   /*
   This is the correct annotation
   */
-  -- %suite(Name of suite on test_pkg2)
-  -- %suitepackage(all)
+  -- %suite
+  -- %displayname(Name of suite on test_pkg2)
+  -- %suitepath(all)
 
-  -- %test(Name of test1)
+  -- %test
+  -- %displayname(Name of test1)
   procedure test1;
 
-  -- %test(Name of test2)
+  -- %test
+  -- %displayname(Name of test2)
   procedure test2;
 
 end;

--- a/tests/helpers/test_package_1.pck
+++ b/tests/helpers/test_package_1.pck
@@ -1,22 +1,22 @@
 create or replace package test_package_1 is
 
   --%suite
-  --%suitepackage(tests)
+  --%suitepath(tests)
 
   gv_glob_val number;
 
-  --%setup
+  --%beforeeach
   procedure global_setup;
 
-  --%teardown
+  --%aftereach
   procedure global_teardown;
 
   --%test
   procedure test1;
 
   --%test
-  --%testsetup(test2_setup)
-  --%testteardown(test2_teardown)
+  --%beforetest(test2_setup)
+  --%aftertest(test2_teardown)
   procedure test2;
 
   procedure test2_setup;

--- a/tests/helpers/test_package_2.pck
+++ b/tests/helpers/test_package_2.pck
@@ -1,22 +1,22 @@
 create or replace package test_package_2 is
 
   --%suite
-  --%suitepackage(tests.test_package_1)
+  --%suitepath(tests.test_package_1)
 
   gv_glob_val varchar2(1);
 
-  --%setup
+  --%beforeeach
   procedure global_setup;
 
-  --%teardown
+  --%aftereach
   procedure global_teardown;
 
   --%test
   procedure test1;
 
   --%test
-  --%testsetup(test2_setup)
-  --%testteardown(test2_teardown)
+  --%beforetest(test2_setup)
+  --%aftertest(test2_teardown)
   procedure test2;
 
   procedure test2_setup;

--- a/tests/helpers/test_package_3.pck
+++ b/tests/helpers/test_package_3.pck
@@ -1,22 +1,22 @@
 create or replace package test_package_3 is
 
   --%suite
-  --%suitepackage(tests2)
+  --%suitepath(tests2)
 
   gv_glob_val number;
 
-  --%setup
+  --%beforeeach
   procedure global_setup;
 
-  --%teardown
+  --%aftereach
   procedure global_teardown;
 
   --%test
   procedure test1;
 
   --%test
-  --%testsetup(test2_setup)
-  --%testteardown(test2_teardown)
+  --%beforetest(test2_setup)
+  --%aftertest(test2_teardown)
   procedure test2;
 
   procedure test2_setup;

--- a/tests/ut_annotations/ut_annotations.parse_package_annotations.ParseAnnotationMixedWithWrongBeforeProcedure.sql
+++ b/tests/ut_annotations/ut_annotations.parse_package_annotations.ParseAnnotationMixedWithWrongBeforeProcedure.sql
@@ -9,8 +9,9 @@ declare
 
 begin
   l_source := 'PACKAGE test_tt AS
-  -- %suite(Name of suite)
-  -- %suitepackage(all.globaltests)
+  -- %suite
+  -- %displayname(Name of suite)
+  -- %suitepath(all.globaltests)
   
   -- %ann1(Name of suite)
   -- wrong line
@@ -24,11 +25,12 @@ END;';
 --Assert
   l_ann_param := null;
   l_ann_param.val := 'Name of suite'; 
-  l_expected.package_annotations('suite')(1) := l_ann_param;
+  l_expected.package_annotations('suite') := cast( null as ut_annotations.tt_annotation_params);
+  l_expected.package_annotations('displayname')(1) := l_ann_param;
   
   l_ann_param := null;
   l_ann_param.val := 'all.globaltests';  
-  l_expected.package_annotations('suitepackage')(1) := l_ann_param;
+  l_expected.package_annotations('suitepath')(1) := l_ann_param;
   
   l_ann_param := null;
   l_ann_param.val := 'some_value';  

--- a/tests/ut_annotations/ut_annotations.parse_package_annotations.ParseAnnotationNotBeforeProcedure.sql
+++ b/tests/ut_annotations/ut_annotations.parse_package_annotations.ParseAnnotationNotBeforeProcedure.sql
@@ -9,8 +9,9 @@ declare
 
 begin
   l_source := 'PACKAGE test_tt AS
-  -- %suite(Name of suite)
-  -- %suitepackage(all.globaltests)
+  -- %suite
+  -- %displayname(Name of suite)
+  -- %suitepath(all.globaltests)
   
   -- %ann1(Name of suite)
   -- %ann2(all.globaltests)  
@@ -24,11 +25,12 @@ END;';
 --Assert
   l_ann_param := null;
   l_ann_param.val := 'Name of suite'; 
-  l_expected.package_annotations('suite')(1) := l_ann_param;
+  l_expected.package_annotations('suite') := cast( null as ut_annotations.tt_annotation_params);
+  l_expected.package_annotations('displayname')(1) := l_ann_param;
   
   l_ann_param := null;
   l_ann_param.val := 'all.globaltests';  
-  l_expected.package_annotations('suitepackage')(1) := l_ann_param;
+  l_expected.package_annotations('suitepath')(1) := l_ann_param;
   
   check_annotation_parsing(l_expected, l_parsing_result);
   

--- a/tests/ut_annotations/ut_annotations.parse_package_annotations.ParseComplexPackage.sql
+++ b/tests/ut_annotations/ut_annotations.parse_package_annotations.ParseComplexPackage.sql
@@ -9,14 +9,15 @@ declare
 
 begin
   l_source := 'PACKAGE test_tt AS
-  -- %suite(Name of suite)
-  -- %suitepackage(all.globaltests)
+  -- %suite
+  -- %displayname(Name of suite)
+  -- %suitepath(all.globaltests)
   
   --%test
   procedure foo;
   
   
-  --%setup
+  --%beforeeach
   procedure foo2;
   
   --test comment
@@ -26,7 +27,7 @@ begin
   /*
   describtion of the procedure
   */
-  --%setup(key=testval)
+  --%beforeeach(key=testval)
   PROCEDURE foo3(a_value number default null);
   
   function foo4(a_val number default null
@@ -39,24 +40,25 @@ END;';
 --Assert
   l_ann_param := null;
   l_ann_param.val := 'Name of suite'; 
-  l_expected.package_annotations('suite')(1) := l_ann_param;
+  l_expected.package_annotations('suite') := cast( null as ut_annotations.tt_annotation_params);
+  l_expected.package_annotations('displayname')(1) := l_ann_param;
   
   l_ann_param := null;
   l_ann_param.val := 'all.globaltests';  
-  l_expected.package_annotations('suitepackage')(1) := l_ann_param;
+  l_expected.package_annotations('suitepath')(1) := l_ann_param;
   
   l_expected.procedure_annotations(1).name := 'foo';
   l_expected.procedure_annotations(1).annotations('test') := cast( null as ut_annotations.tt_annotation_params);
   
   l_expected.procedure_annotations(2).name := 'foo2';
-  l_expected.procedure_annotations(2).annotations('setup') := cast( null as ut_annotations.tt_annotation_params);
+  l_expected.procedure_annotations(2).annotations('beforeeach') := cast( null as ut_annotations.tt_annotation_params);
   
   l_ann_param := null;
   l_ann_param.key := 'key'; 
   l_ann_param.val := 'testval';
   
   l_expected.procedure_annotations(3).name := 'foo3';
-  l_expected.procedure_annotations(3).annotations('setup')(1) := l_ann_param;
+  l_expected.procedure_annotations(3).annotations('beforeeach')(1) := l_ann_param;
   
   check_annotation_parsing(l_expected, l_parsing_result);
   

--- a/tests/ut_annotations/ut_annotations.parse_package_annotations.ParsePackageAndProcedureLevelAnnotations.sql
+++ b/tests/ut_annotations/ut_annotations.parse_package_annotations.ParsePackageAndProcedureLevelAnnotations.sql
@@ -9,8 +9,9 @@ declare
 
 begin
   l_source := 'PACKAGE test_tt AS
-  -- %suite(Name of suite)
-  -- %suitepackage(all.globaltests)
+  -- %suite
+  -- %displayname(Name of suite)
+  -- %suitepath(all.globaltests)
   
   --%test
   procedure foo;
@@ -22,11 +23,12 @@ END;';
 --Assert
   l_ann_param := null;
   l_ann_param.val := 'Name of suite'; 
-  l_expected.package_annotations('suite')(1) := l_ann_param;
+  l_expected.package_annotations('suite') := cast( null as ut_annotations.tt_annotation_params);
+  l_expected.package_annotations('displayname')(1) := l_ann_param;
   
   l_ann_param := null;
   l_ann_param.val := 'all.globaltests';  
-  l_expected.package_annotations('suitepackage')(1) := l_ann_param;
+  l_expected.package_annotations('suitepath')(1) := l_ann_param;
   
   l_expected.procedure_annotations(1).name := 'foo';
   l_expected.procedure_annotations(1).annotations('test') := cast( null as ut_annotations.tt_annotation_params);

--- a/tests/ut_annotations/ut_annotations.parse_package_annotations.ParsePackageLevelAnnotation.sql
+++ b/tests/ut_annotations/ut_annotations.parse_package_annotations.ParsePackageLevelAnnotation.sql
@@ -9,8 +9,9 @@ declare
 
 begin
   l_source := 'PACKAGE test_tt AS
-  -- %suite(Name of suite)
-  -- %suitepackage(all.globaltests)
+  -- %suite
+  -- %displayname(Name of suite)
+  -- %suitepath(all.globaltests)
   
   procedure foo;
 END;';
@@ -21,11 +22,12 @@ END;';
 --Assert
   l_ann_param := null;
   l_ann_param.val := 'Name of suite'; 
-  l_expected.package_annotations('suite')(1) := l_ann_param;
+  l_expected.package_annotations('suite') := cast( null as ut_annotations.tt_annotation_params);
+  l_expected.package_annotations('displayname')(1) := l_ann_param;
   
   l_ann_param := null;
   l_ann_param.val := 'all.globaltests';  
-  l_expected.package_annotations('suitepackage')(1) := l_ann_param;
+  l_expected.package_annotations('suitepath')(1) := l_ann_param;
   
   check_annotation_parsing(l_expected, l_parsing_result);
   

--- a/tests/ut_annotations/ut_annotations.parse_package_annotations.ParsePackageLevelAnnotationWithKeyValue.sql
+++ b/tests/ut_annotations/ut_annotations.parse_package_annotations.ParsePackageLevelAnnotationWithKeyValue.sql
@@ -9,8 +9,9 @@ declare
 
 begin
   l_source := 'PACKAGE test_tt AS
-  -- %suite(name = Name of suite)
-  -- %suitepackage(key=all.globaltests,key2=foo)
+  -- %suite
+  --%displayname(name = Name of suite)
+  -- %suitepath(key=all.globaltests,key2=foo)
   
   procedure foo;
 END;';
@@ -22,17 +23,18 @@ END;';
   l_ann_param := null;
   l_ann_param.key := 'name'; 
   l_ann_param.val := 'Name of suite'; 
-  l_expected.package_annotations('suite')(1) := l_ann_param;
+  l_expected.package_annotations('suite') := cast( null as ut_annotations.tt_annotation_params);
+  l_expected.package_annotations('displayname')(1) := l_ann_param;
   
   l_ann_param := null;
   l_ann_param.key := 'key'; 
   l_ann_param.val := 'all.globaltests';  
-  l_expected.package_annotations('suitepackage')(1) := l_ann_param;
+  l_expected.package_annotations('suitepath')(1) := l_ann_param;
   
   l_ann_param := null;
   l_ann_param.key := 'key2'; 
   l_ann_param.val := 'foo';  
-  l_expected.package_annotations('suitepackage')(2) := l_ann_param;
+  l_expected.package_annotations('suitepath')(2) := l_ann_param;
   
   check_annotation_parsing(l_expected, l_parsing_result);
   

--- a/tests/ut_annotations/ut_annotations.parse_package_annotations.ParsePackageLevelAnnotationWithMultilineComment.sql
+++ b/tests/ut_annotations/ut_annotations.parse_package_annotations.ParsePackageLevelAnnotationWithMultilineComment.sql
@@ -13,8 +13,9 @@ begin
   Some comment
   -- inlined
   */
-  -- %suite(Name of suite)
-  -- %suitepackage(all.globaltests)
+  -- %suite
+  --%displayname(Name of suite)
+  -- %suitepath(all.globaltests)
   
   procedure foo;
 END;';
@@ -25,11 +26,12 @@ END;';
 --Assert
   l_ann_param := null;
   l_ann_param.val := 'Name of suite'; 
-  l_expected.package_annotations('suite')(1) := l_ann_param;
+  l_expected.package_annotations('suite') := cast( null as ut_annotations.tt_annotation_params);
+  l_expected.package_annotations('displayname')(1) := l_ann_param;
   
   l_ann_param := null;
   l_ann_param.val := 'all.globaltests';  
-  l_expected.package_annotations('suitepackage')(1) := l_ann_param;
+  l_expected.package_annotations('suitepath')(1) := l_ann_param;
   
   check_annotation_parsing(l_expected, l_parsing_result);
   


### PR DESCRIPTION
Redesign according to #133 


Changin code to use new `%displayname` annotation a realized I like the old way `%suite(Name of the suite)`, `%test(Name of the test)` really much, so maybe we should get back to the old approach.
Additionaly as IDE doesn't help us with autocomplete on annotations, the less of them we need to specify, the more stable is test package configuration.
What do you think? Look at the comparison of old and new examples.

Or we can use both aproaches with `%displayname` prioritized.