### PR TITLE
Restored old syntax

### DIFF
--- a/docs/userguide/annotations.md
+++ b/docs/userguide/annotations.md
@@ -1,15 +1,15 @@
 # Annotations
 
 Annotations provide a way to configure tests and suites in a declarative way similar to modern OOP languages.
-The annotation list is based on jUnit 5 implementation.
+The annotation list is based on moder testing framework such as jUnit 5, RSpec.
 
-# Example
-Let's say we have the test package like this:
+Annotations allow to configure test infrastructure in a declarative way without anything stored in tables or config files. The framework runner scans the schema for all the suitable annotated packages, automatically configures suites, forms hierarchy from then and executes them.
+
+# Example of annotated package
 ```
 create or replace package test_pkg is
 
-  -- %suite
-  -- %displayname(Name of suite)
+  -- %suite(Name of suite)
   -- %suitepath(all.globaltests)
 
   -- %beforeall
@@ -24,16 +24,19 @@ create or replace package test_pkg is
   -- %displayname(Name of test1)
   procedure test1;
 
-  -- %test
-  -- %displayname(Name of test2)
+  -- %test(Name of test2)
   -- %beforetest(setup_test1)
   -- %aftertest(teardown_test1)
   procedure test2;
 
   -- %test
   -- %displayname(Name of test3)
-  -- %testtype(smoke)
+  -- %disable
   procedure test3;
+  
+  -- %test(Name of test4)
+  -- %rollback(manual)
+  procedure test4;
 
   procedure setup_test1;
 
@@ -52,10 +55,10 @@ end test_pkg;
 
 | Annotation |Level| Describtion |
 | --- | --- | --- |
-| `%suite` | Package | Marks package to be a suite of tests This way all testing packages might be found in a schema. |
+| `%suite(<description>)` | Package | Marks package to be a suite of tests This way all testing packages might be found in a schema. Optional schema discription can by provided, similar to `%displayname` annotation. |
 | `%suitepath(<path>)` | Package | Similar to java package. The annotation allows logical grouping of suites into hierarcies. |
-| `%displayname(<description>)` | Package/procedure | Human-familiar describtion of the suite/test. `%displayname(Name of the suite/test)` |
-| `%test` | Procedure | Denotes that a method is a test method. |
+| `%displayname(<description>)` | Package/procedure | Human-familiar describtion of the suite/test. Syntax is based on jUnit annotation: `%displayname(Name of the suite/test)` |
+| `%test(<description>)` | Procedure | Denotes that a method is a test method.  Optional test discription can by provided, similar to `%displayname` annotation. |
 | `%beforeall` | Procedure | Denotes that the annotated procedure should be executed once before all elements of the current suite. |
 | `%afterall` | Procedure | Denotes that the annotated procedure should be executed once after all elements of the current suite. |
 | `%beforeeach` | Procedure | Denotes that the annotated procedure should be executed before each `%test` method in the current suite. |
@@ -64,5 +67,3 @@ end test_pkg;
 | `%aftertest(<procedure_name>)` | Procedure | Denotes that mentioned procedure should be executed after the annotated `%test` procedure. |
 | `%rollback(<type>)` | Package/procedure | Configure transaction control behaviour (type). Supported values: `auto`(default) - rollback to savepoint (before the test/suite setup) is issued after each test/suite teardown; `manual` - rollback is never issued automatically. Property can be overridden for child element (test in suite) |
 | `%disable` | Package/procedure | Used to disable a suite or a test |
-
-Annotations allow us to configure test infrastructure in a declarative way without anything stored in tables or config files. Suite manager would scan the schema for all the suitable packages, automatically configure suites and execute them. This can be simplified to the situation when you just ran suite manager over a schema for the defined types of tests and reporters and everything goes automatically. This is going to be convenient to be executed from CI tools using standard reporting formats.

--- a/readme.md
+++ b/readme.md
@@ -67,6 +67,76 @@ The following table is a work in progress right now, and **will** change.   If y
 
 <sup>3</sup> Test execution comparison is in a single call so the results are combined.   We know it was always possible group in any way with multiple calls.  But that may not be desired under CI system where you want a single JUnit XML Output.
 
+# Annotations
+
+Annotations provide a way to configure tests and suites in a declarative way similar to modern OOP languages.
+The annotation list is based on moder testing framework such as jUnit 5, RSpec.
+
+Annotations allow to configure test infrastructure in a declarative way without anything stored in tables or config files. The framework runner scans the schema for all the suitable annotated packages, automatically configures suites, forms hierarchy from then and executes them.
+
+# Example of annotated package
+```
+create or replace package test_pkg is
+
+  -- %suite(Name of suite)
+  -- %suitepath(all.globaltests)
+
+  -- %beforeall
+  procedure globalsetup;
+
+  -- %afterall
+  procedure global_teardown;
+
+  /* Such comments are allowed */
+
+  -- %test
+  -- %displayname(Name of test1)
+  procedure test1;
+
+  -- %test(Name of test2)
+  -- %beforetest(setup_test1)
+  -- %aftertest(teardown_test1)
+  procedure test2;
+
+  -- %test
+  -- %displayname(Name of test3)
+  -- %disable
+  procedure test3;
+  
+  -- %test(Name of test4)
+  -- %rollback(manual)
+  procedure test4;
+
+  procedure setup_test1;
+
+  procedure teardown_test1;
+
+  -- %beforeeach
+  procedure setup;
+
+  -- %aftereach
+  procedure teardown;
+
+end test_pkg;
+```
+
+#Annotations meaning
+
+| Annotation |Level| Describtion |
+| --- | --- | --- |
+| `%suite(<description>)` | Package | Marks package to be a suite of tests This way all testing packages might be found in a schema. Optional schema discription can by provided, similar to `%displayname` annotation. |
+| `%suitepath(<path>)` | Package | Similar to java package. The annotation allows logical grouping of suites into hierarcies. |
+| `%displayname(<description>)` | Package/procedure | Human-familiar describtion of the suite/test. Syntax is based on jUnit annotation: `%displayname(Name of the suite/test)` |
+| `%test(<description>)` | Procedure | Denotes that a method is a test method.  Optional test discription can by provided, similar to `%displayname` annotation. |
+| `%beforeall` | Procedure | Denotes that the annotated procedure should be executed once before all elements of the current suite. |
+| `%afterall` | Procedure | Denotes that the annotated procedure should be executed once after all elements of the current suite. |
+| `%beforeeach` | Procedure | Denotes that the annotated procedure should be executed before each `%test` method in the current suite. |
+| `%aftereach` | Procedure | Denotes that the annotated procedure should be executed after each `%test` method in the current suite. |
+| `%beforetest(<procedure_name>)` | Procedure | Denotes that mentioned procedure should be executed before the annotated `%test` procedure. |
+| `%aftertest(<procedure_name>)` | Procedure | Denotes that mentioned procedure should be executed after the annotated `%test` procedure. |
+| `%rollback(<type>)` | Package/procedure | Configure transaction control behaviour (type). Supported values: `auto`(default) - rollback to savepoint (before the test/suite setup) is issued after each test/suite teardown; `manual` - rollback is never issued automatically. Property can be overridden for child element (test in suite) |
+| `%disable` | Package/procedure | Used to disable a suite or a test |
+
 
 __Primary Directories__
 

--- a/source/core/ut_suite_manager.pkb
+++ b/source/core/ut_suite_manager.pkb
@@ -55,6 +55,8 @@ create or replace package body ut_suite_manager is
       
       if l_annotation_data.package_annotations.exists('displayname') then
         l_suite_name         := ut_annotations.get_annotation_param(l_annotation_data.package_annotations('displayname'), 1);
+      elsif l_annotation_data.package_annotations('suite').count>0 then
+        l_suite_name         := ut_annotations.get_annotation_param(l_annotation_data.package_annotations('suite'), 1);
       end if;
 
       if l_annotation_data.package_annotations.exists('suitepath') then
@@ -129,6 +131,8 @@ create or replace package body ut_suite_manager is
             
             if l_proc_annotations.exists('displayname') then
               l_displayname := ut_annotations.get_annotation_param(l_proc_annotations('displayname'), 1);
+            elsif l_proc_annotations('test').count>0 then
+              l_displayname := ut_annotations.get_annotation_param(l_proc_annotations('test'), 1);
             end if;
 
             if l_proc_annotations.exists('rollback') then

--- a/tests/helpers/test_package_1.pck
+++ b/tests/helpers/test_package_1.pck
@@ -12,9 +12,10 @@ create or replace package test_package_1 is
   procedure global_teardown;
 
   --%test
+  --%displayname(Test1 from test package 1)
   procedure test1;
 
-  --%test
+  --%test(Test2 from test package 1)
   --%beforetest(test2_setup)
   --%aftertest(test2_teardown)
   procedure test2;

--- a/tests/ut_suite_manager/ut_suite_manager.configure_execution_by_path.PrepareRunnerForTheTopPackageByName.sql
+++ b/tests/ut_suite_manager/ut_suite_manager.configure_execution_by_path.PrepareRunnerForTheTopPackageByName.sql
@@ -22,6 +22,22 @@ begin
   
   ut.expect(l_test1_suite.name).to_equal('test_package_1');
   ut.expect(l_test1_suite.items.count).to_equal(3);
+  ut.expect(l_test1_suite.before_each is not null).to_be_true;
+  
+  ut.expect(l_test1_suite.items(1).name).to_equal('test1');
+  ut.expect(l_test1_suite.items(1).description).to_equal('Test1 from test package 1');
+  ut.expect(treat(l_test1_suite.items(1) as ut_test).before_test.is_defined).to_be_false;
+  ut.expect(treat(l_test1_suite.items(1) as ut_test).after_test.is_defined).to_be_false;
+  ut.expect(treat(l_test1_suite.items(1) as ut_test).ignore_flag).to_equal(0);
+  
+  ut.expect(l_test1_suite.items(2).name).to_equal('test2');
+  ut.expect(l_test1_suite.items(2).description).to_equal('Test2 from test package 1');
+  ut.expect(treat(l_test1_suite.items(2) as ut_test).before_test.is_defined).to_be_true;
+  ut.expect(treat(l_test1_suite.items(2) as ut_test).after_test.is_defined).to_be_true;
+  ut.expect(treat(l_test1_suite.items(2) as ut_test).ignore_flag).to_equal(0);
+  
+  -- temporary behavior.
+  -- decided that when executed by package, not path, only that package has to execute
   l_test2_suite :=  treat(l_test1_suite.items(3) as ut_suite);
   
   ut.expect(l_test2_suite.name).to_equal('test_package_2');
@@ -30,6 +46,18 @@ begin
   
   if ut_assert_processor.get_aggregate_asserts_result = ut_utils.tr_success then
     :test_result := ut_utils.tr_success;
+  else
+    declare
+      l_results ut_assert_results;
+    begin
+      l_results := ut_assert_processor.get_asserts_results;
+      for i in 1..l_results.count loop
+        if l_results(i).result > ut_utils.tr_success then
+          dbms_output.put_line(l_results(i).get_result_clob);
+        end if;
+      end loop;
+    end;
+
   end if;
 
 end;

--- a/tests/ut_suite_manager/ut_suite_manager.configure_execution_by_path.PrepareRunnerForTheTopPackageProcedureByPath.sql
+++ b/tests/ut_suite_manager/ut_suite_manager.configure_execution_by_path.PrepareRunnerForTheTopPackageProcedureByPath.sql
@@ -26,6 +26,7 @@ begin
   l_test_proc := treat(l_test1_suite.items(1) as ut_test);   
   
   ut.expect(l_test_proc.name).to_equal('test2');
+  ut.expect(l_test_proc.description).to_equal('Test2 from test package 1');
   ut.expect(l_test_proc.before_test is not null).to_be_true;
   ut.expect(l_test_proc.after_test is not null).to_be_true;
   


### PR DESCRIPTION
Restored old syntax as a way to define test/suite name additional to `%displayname`
If defined both `%displayname` is used