### PR TITLE
Hided output table under view to be EBR-ready

### DIFF
--- a/docs/userguide/install.md
+++ b/docs/userguide/install.md
@@ -19,6 +19,7 @@ The installation user/schema must have the following Oracle system permissions d
   - CREATE PROCEDURE
   - CREATE TYPE
   - CREATE TABLE
+  - CREATE VIEW
   - CREATE SYNONYM
   - ALTER SESSION
   

--- a/source/core/ut_output_buffer_tmp.sql
+++ b/source/core/ut_output_buffer_tmp.sql
@@ -1,4 +1,4 @@
-create table ut_output_buffer_tmp(
+create table ut_output_buffer_tmp$(
   /*
   utPLSQL - Version X.X.X.X
   Copyright 2016 - 2017 utPLSQL Project
@@ -27,4 +27,37 @@ create table ut_output_buffer_tmp(
 ) nologging nomonitoring initrans 100
 ;
 
-create index ut_output_buffer_tmp_i on ut_output_buffer_tmp(start_date) initrans 100 nologging;
+create index ut_output_buffer_tmp_i on ut_output_buffer_tmp$(start_date) initrans 100 nologging;
+
+-- This is needed to be EBR ready as editioning view can only be created by edition enabled user
+declare
+  ex_nonedition_user exception;
+  ex_view_doesnt_exist exception;
+  pragma exception_init(ex_nonedition_user,-42314);
+  pragma exception_init(ex_view_doesnt_exist,-942);
+begin
+  begin
+    execute immediate 'drop view ut_output_buffer_tmp';
+  exception
+    when ex_view_doesnt_exist then
+      null;
+  end;
+  
+  execute immediate 'create or replace editioning view ut_output_buffer_tmp as
+select reporter_id
+      ,message_id
+      ,text
+      ,is_finished
+      ,start_date
+  from ut_output_buffer_tmp$';
+exception 
+  when ex_nonedition_user then
+    execute immediate 'create or replace view ut_output_buffer_tmp as
+select reporter_id
+      ,message_id
+      ,text
+      ,is_finished
+      ,start_date
+  from ut_output_buffer_tmp$';
+end;
+/

--- a/source/core/ut_output_buffer_tmp.sql
+++ b/source/core/ut_output_buffer_tmp.sql
@@ -44,6 +44,19 @@ begin
   end;
   
   execute immediate 'create or replace editioning view ut_output_buffer_tmp as
+/*
+utPLSQL - Version X.X.X.X
+Copyright 2016 - 2017 utPLSQL Project
+Licensed under the Apache License, Version 2.0 (the "License"):
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 select reporter_id
       ,message_id
       ,text
@@ -53,6 +66,19 @@ select reporter_id
 exception 
   when ex_nonedition_user then
     execute immediate 'create or replace view ut_output_buffer_tmp as
+/*
+utPLSQL - Version X.X.X.X
+Copyright 2016 - 2017 utPLSQL Project
+Licensed under the Apache License, Version 2.0 (the "License"):
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 select reporter_id
       ,message_id
       ,text

--- a/source/create_utplsql_owner.sql
+++ b/source/create_utplsql_owner.sql
@@ -27,7 +27,7 @@ define ut3_tablespace = &3
 
 create user &ut3_user identified by &ut3_password default tablespace &ut3_tablespace quota unlimited on &ut3_tablespace;
 
-grant create session, create sequence, create procedure, create type, create table, create synonym to &ut3_user;
+grant create session, create sequence, create procedure, create type, create table, create view, create synonym to &ut3_user;
 
 grant execute on dbms_lock to &ut3_user;
 


### PR DESCRIPTION
This is needed to be EBR ready. A user might want to test new version of the framework in another edition to not break current state. We have to support that.