### PR TITLE
Added outputs to the reporters. Moved *each to ut_test

### DIFF
--- a/docs/userguide/exception-reporting.md
+++ b/docs/userguide/exception-reporting.md
@@ -13,7 +13,7 @@ Test execution can fail for different reasons. The failures on different excepti
 * A test package that is raising an exception in `%beforetest` - the `%test` is reported as failed  with exception, `%test` is not executed. The `%aftertest`, `%aftereach` and `%afterall` blocks are getting executed to allow cleanup of whatever was done in `%before...` blocks
 * A test package that is raising an exception in `%test` - the `%test` is reported as failed with exception. The execution of other blocks continues normally
 * A test package that is raising an exception in `%aftertest` - the `%test` is reported as failed with exception. The execution of other blocks continues normally
-* A test package that is raising an exception in `%aftereach` - all blocks of the package are executed, as ehe `%aftereach` is a closing block for an individual test. Exception in `%aftereach` is not affecting test results. For every failed execution of `%aftereach` a warning with exception stacktrace is displayed in the summary
+* A test package that is raising an exception in `%aftereach` - each `%test` is reported as failed with exception.
 * A test package that is raising an exception in `%afterall` - all blocks of  the package are executed, as the `%afterall` is the last step of package execution. Exception in `%afterall` is not affecting test results. A warning with exception stacktrace is displayed in the summary
 
 
@@ -77,29 +77,32 @@ Finished in ,045523 seconds
 Example of reporting with exception thrown in `%aftereach`:
 ```
 Remove rooms by name
-  Removes a room without content in it
-  Does not remove room when it has content
-  Raises exception when null room name given
+  Removes a room without content in it (FAILED - 1)
+  Does not remove room when it has content (FAILED - 2)
+  Raises exception when null room name given (FAILED - 3)
  
-Warnings:
+Failures:
  
-  1) test_remove_rooms_by_name - Aftereach procedure failed:
-       ORA-20001: Test exception
-       ORA-06512: at "UT3.TEST_REMOVE_ROOMS_BY_NAME", line 31
-       ORA-06512: at line 6
- 
-  2) test_remove_rooms_by_name - Aftereach procedure failed:
-       ORA-20001: Test exception
-       ORA-06512: at "UT3.TEST_REMOVE_ROOMS_BY_NAME", line 31
-       ORA-06512: at line 6
- 
-  3) test_remove_rooms_by_name - Aftereach procedure failed:
-       ORA-20001: Test exception
-       ORA-06512: at "UT3.TEST_REMOVE_ROOMS_BY_NAME", line 31
-       ORA-06512: at line 6
- 
-Finished in ,05071 seconds
-3 tests, 0 failed, 0 errored, 0 ignored. 3 warning(s)
+  1) remove_empty_room
+        
+        error: ORA-20001: Test exception
+               ORA-06512: at "UT3.TEST_REMOVE_ROOMS_BY_NAME", line 31
+               ORA-06512: at line 6
+       
+  2) room_with_content
+        
+        error: ORA-20001: Test exception
+               ORA-06512: at "UT3.TEST_REMOVE_ROOMS_BY_NAME", line 31
+               ORA-06512: at line 6
+       
+  3) null_room_name
+        
+        error: ORA-20001: Test exception
+               ORA-06512: at "UT3.TEST_REMOVE_ROOMS_BY_NAME", line 31
+               ORA-06512: at line 6
+       
+Finished in ,034863 seconds
+3 tests, 0 failed, 3 errored, 0 ignored.
 ```
 
 Example of reporting with exception thrown in `%afterall`:

--- a/examples/demo_expectations.pck
+++ b/examples/demo_expectations.pck
@@ -32,11 +32,11 @@ create or replace package demo_expectations is
   procedure demo_to_be_null_failure;
 
   -- %test
-  -- %displayname(demo of failure for to_be_null expectation )
+  -- %displayname(demo of success for to_be_null expectation )
   procedure demo_to_be_null_success;
 
   -- %test
-  -- %displayname(demo of success for to_be_not_null expectation )
+  -- %displayname(demo of failure for to_be_not_null expectation )
   procedure demo_to_be_not_null_failure;
 
   -- %test

--- a/source/api/ut_runner.pkb
+++ b/source/api/ut_runner.pkb
@@ -37,6 +37,8 @@ create or replace package body ut_runner is
   exception
     when others then
       ut_output_buffer.close(l_listener.reporters);
+      dbms_output.put_line(dbms_utility.format_error_backtrace);
+      dbms_output.put_line(dbms_utility.format_error_stack);
       raise;
   end;
 

--- a/source/core/types/ut_event_listener.tpb
+++ b/source/core/types/ut_event_listener.tpb
@@ -43,7 +43,7 @@ create or replace type body ut_event_listener is
         elsif a_event_name = ut_utils.gc_before_all then
           self.reporters(i).before_calling_before_all(treat(a_item as ut_logical_suite));
         elsif a_event_name = ut_utils.gc_before_each then
-          self.reporters(i).before_calling_before_each(treat(a_item as ut_logical_suite));
+          self.reporters(i).before_calling_before_each(treat(a_item as ut_test));
         elsif a_event_name = ut_utils.gc_test then
           self.reporters(i).before_calling_test(treat(a_item as ut_test));
         elsif a_event_name = ut_utils.gc_before_test then
@@ -53,7 +53,7 @@ create or replace type body ut_event_listener is
         elsif a_event_name = ut_utils.gc_after_test then
           self.reporters(i).before_calling_after_test(treat(a_item as ut_test));
         elsif a_event_name = ut_utils.gc_after_each then
-          self.reporters(i).before_calling_after_each(treat(a_item as ut_logical_suite));
+          self.reporters(i).before_calling_after_each(treat(a_item as ut_test));
         elsif a_event_name = ut_utils.gc_after_all then
           self.reporters(i).before_calling_after_all(treat(a_item as ut_logical_suite));
         else
@@ -67,7 +67,7 @@ create or replace type body ut_event_listener is
         elsif a_event_name = ut_utils.gc_before_all then
           self.reporters(i).after_calling_before_all(treat(a_item as ut_logical_suite));
         elsif a_event_name = ut_utils.gc_before_each then
-          self.reporters(i).after_calling_before_each(treat(a_item as ut_logical_suite));
+          self.reporters(i).after_calling_before_each(treat(a_item as ut_test));
         elsif a_event_name = ut_utils.gc_test then
           self.reporters(i).after_calling_test(treat(a_item as ut_test));
         elsif a_event_name = ut_utils.gc_before_test then
@@ -77,7 +77,7 @@ create or replace type body ut_event_listener is
         elsif a_event_name = ut_utils.gc_after_test then
           self.reporters(i).after_calling_after_test(treat(a_item as ut_test));
         elsif a_event_name = ut_utils.gc_after_each then
-          self.reporters(i).after_calling_after_each(treat(a_item as ut_logical_suite));
+          self.reporters(i).after_calling_after_each(treat(a_item as ut_test));
         elsif a_event_name = ut_utils.gc_after_all then
           self.reporters(i).after_calling_after_all(treat(a_item as ut_logical_suite));
         else

--- a/source/core/types/ut_executable.tps
+++ b/source/core/types/ut_executable.tps
@@ -22,16 +22,19 @@ create or replace type ut_executable force authid current_user as object(
   owner_name            varchar2(250 char),
   object_name           varchar2(250 char),
   procedure_name        varchar2(250 char),
+  error_backtrace       varchar2(4000),
+  error_stack           varchar2(4000),
+  serveroutput          clob,
 	constructor function ut_executable( self in out nocopy ut_executable, a_context ut_suite_item, a_procedure_name varchar2, a_associated_event_name varchar2) return self as result,
   member function is_valid return boolean,
   member function is_defined return boolean,
   member function form_name return varchar2,
-  member procedure do_execute(self in ut_executable, a_item in out nocopy ut_suite_item, a_listener in out nocopy ut_event_listener_base),
+  member procedure do_execute(self in out nocopy ut_executable, a_item in out nocopy ut_suite_item, a_listener in out nocopy ut_event_listener_base),
   /**
   * executes the defines executable
   * returns true if executed without exceptions
   * returns false if exceptions were raised
   */
-  member function do_execute(self in ut_executable, a_item in out nocopy ut_suite_item, a_listener in out nocopy ut_event_listener_base) return boolean
+  member function do_execute(self in out nocopy ut_executable, a_item in out nocopy ut_suite_item, a_listener in out nocopy ut_event_listener_base) return boolean
 ) final
 /

--- a/source/core/types/ut_reporter_base.tpb
+++ b/source/core/types/ut_reporter_base.tpb
@@ -55,11 +55,11 @@ create or replace type body ut_reporter_base is
     null;
   end;
 
-  member procedure before_calling_before_each(self in out nocopy ut_reporter_base, a_suite in ut_logical_suite) is
+  member procedure before_calling_before_each(self in out nocopy ut_reporter_base, a_suite in ut_test) is
   begin
     null;
   end;
-  member procedure after_calling_before_each (self in out nocopy ut_reporter_base, a_suite in ut_logical_suite) is
+  member procedure after_calling_before_each (self in out nocopy ut_reporter_base, a_suite in ut_test) is
   begin
     null;
   end;
@@ -103,11 +103,11 @@ create or replace type body ut_reporter_base is
   end;
 
   --suite hooks continued
-  member procedure before_calling_after_each(self in out nocopy ut_reporter_base, a_suite in ut_logical_suite) is
+  member procedure before_calling_after_each(self in out nocopy ut_reporter_base, a_suite in ut_test) is
   begin
     null;
   end;
-  member procedure after_calling_after_each (self in out nocopy ut_reporter_base, a_suite in ut_logical_suite) is
+  member procedure after_calling_after_each (self in out nocopy ut_reporter_base, a_suite in ut_test) is
   begin
     null;
   end;

--- a/source/core/types/ut_reporter_base.tps
+++ b/source/core/types/ut_reporter_base.tps
@@ -32,8 +32,8 @@ create or replace type ut_reporter_base authid current_user as object(
   member procedure before_calling_before_all(self in out nocopy ut_reporter_base, a_suite in ut_logical_suite),
   member procedure after_calling_before_all (self in out nocopy ut_reporter_base, a_suite in ut_logical_suite),
 
-  member procedure before_calling_before_each(self in out nocopy ut_reporter_base, a_suite in ut_logical_suite),
-  member procedure after_calling_before_each (self in out nocopy ut_reporter_base, a_suite in ut_logical_suite),
+  member procedure before_calling_before_each(self in out nocopy ut_reporter_base, a_suite in ut_test),
+  member procedure after_calling_before_each (self in out nocopy ut_reporter_base, a_suite in ut_test),
 
   -- test hooks
   member procedure before_calling_test(self in out nocopy ut_reporter_base, a_test in ut_test),
@@ -50,8 +50,8 @@ create or replace type ut_reporter_base authid current_user as object(
   member procedure after_calling_test(self in out nocopy ut_reporter_base, a_test in ut_test),
 
   --suite hooks continued
-  member procedure before_calling_after_each(self in out nocopy ut_reporter_base, a_suite in ut_logical_suite),
-  member procedure after_calling_after_each (self in out nocopy ut_reporter_base, a_suite in ut_logical_suite),
+  member procedure before_calling_after_each(self in out nocopy ut_reporter_base, a_suite in ut_test),
+  member procedure after_calling_after_each (self in out nocopy ut_reporter_base, a_suite in ut_test),
 
   member procedure before_calling_after_all(self in out nocopy ut_reporter_base, a_suite in ut_logical_suite),
   member procedure after_calling_after_all (self in out nocopy ut_reporter_base, a_suite in ut_logical_suite),

--- a/source/core/types/ut_suite.tps
+++ b/source/core/types/ut_suite.tps
@@ -20,16 +20,7 @@ create or replace type ut_suite  under ut_logical_suite (
   * Procedure exists within the package of the suite
   */
   before_all   ut_executable,
-  /**
-  * The procedure to be invoked before each of the child items of the suite (executed each time for each item)
-  * Procedure exists within the package of the suite
-  */
-  before_each  ut_executable,
-  /**
-  * The procedure to be invoked after each of the child items of the suite (executed each time for each item)
-  * Procedure exists within the package of the suite
-  */
-  after_each   ut_executable,
+
   /**
   * The procedure to be invoked after all of the items of the suite (executed once)
   * Procedure exists within the package of the suite
@@ -38,7 +29,7 @@ create or replace type ut_suite  under ut_logical_suite (
   constructor function ut_suite (
     self in out nocopy ut_suite , a_object_owner varchar2 := null, a_object_name varchar2, a_name varchar2, a_path varchar2, a_description varchar2 := null,
     a_rollback_type integer := null, a_ignore_flag boolean := false, a_before_all_proc_name varchar2 := null,
-    a_after_all_proc_name varchar2 := null, a_before_each_proc_name varchar2 := null, a_after_each_proc_name varchar2 := null
+    a_after_all_proc_name varchar2 := null
   ) return self as result,
   overriding member function is_valid return boolean,
   /**

--- a/source/core/types/ut_test.tps
+++ b/source/core/types/ut_test.tps
@@ -15,6 +15,11 @@ create or replace type ut_test under ut_suite_item (
   See the License for the specific language governing permissions and
   limitations under the License.
   */
+  /*
+  * The procedure to be invoked before invoking the test and before_test  procedure.
+  * Procedure exists within the same package as the test itself and is similar for all tests in the suite
+  */
+  before_each ut_executable,
   /**
   * The procedure to be invoked before invoking the test
   * Procedure exists within the same package as the test itself
@@ -29,6 +34,11 @@ create or replace type ut_test under ut_suite_item (
   * Procedure exists within the same package as the test itself
   */
   after_test  ut_executable,
+  /*
+  * The procedure to be invoked after invoking the test and after_test  procedure.
+  * Procedure exists within the same package as the test itself and is similar for all tests in the suite
+  */
+  after_each ut_executable,
   /**
   * The list of assert results as well as database errors encountered while invoking
   * The test procedure and the before_test/after_test blocks
@@ -36,7 +46,9 @@ create or replace type ut_test under ut_suite_item (
   results     ut_assert_results,
   constructor function ut_test(
     self in out nocopy ut_test, a_object_owner varchar2 := null, a_object_name varchar2, a_name varchar2, a_description varchar2 := null,
-    a_path varchar2 := null, a_rollback_type integer := null, a_ignore_flag boolean := false, a_before_test_proc_name varchar2 := null, a_after_test_proc_name varchar2 := null
+    a_path varchar2 := null, a_rollback_type integer := null, a_ignore_flag boolean := false, 
+    a_before_each_proc_name varchar2 := null, a_before_test_proc_name varchar2 := null,
+    a_after_test_proc_name varchar2 := null, a_after_each_proc_name varchar2 := null
   ) return self as result,
   member function is_valid return boolean,
   overriding member function do_execute(self in out nocopy ut_test, a_listener in out nocopy ut_event_listener_base) return boolean,

--- a/source/core/ut_output_buffer.pkb
+++ b/source/core/ut_output_buffer.pkb
@@ -102,8 +102,8 @@ create or replace package body ut_output_buffer is
     l_lines := ut_output_buffer.get_lines_cursor(a_reporter_id, a_timeout_sec);
     loop
       fetch l_lines into l_line;
-      dbms_output.put_line(l_line);
       exit when l_lines%notfound;
+      dbms_output.put_line(l_line);
     end loop;
     close l_lines;
   end;

--- a/source/core/ut_suite_manager.pkb
+++ b/source/core/ut_suite_manager.pkb
@@ -120,9 +120,7 @@ create or replace package body ut_suite_manager is
           a_rollback_type         => l_suite_rollback,
           a_ignore_flag           => l_annotation_data.package_annotations.exists('disabled'),
           a_before_all_proc_name  => l_suite_setup_proc,
-          a_after_all_proc_name   => l_suite_teardown_proc,
-          a_before_each_proc_name => l_default_setup_proc,
-          a_after_each_proc_name  => l_default_teardown_proc
+          a_after_all_proc_name   => l_suite_teardown_proc
       );
 
 
@@ -174,7 +172,9 @@ create or replace package body ut_suite_manager is
                 a_rollback_type => l_rollback_type,
                 a_ignore_flag   => l_proc_annotations.exists('disabled'),
                 a_before_test_proc_name => l_setup_procedure,
-                a_after_test_proc_name  => l_teardown_procedure
+                a_after_test_proc_name  => l_teardown_procedure,
+                a_before_each_proc_name => l_default_setup_proc,
+                a_after_each_proc_name  => l_default_teardown_proc
             );
 
             l_suite.add_item(l_test);
@@ -418,13 +418,13 @@ create or replace package body ut_suite_manager is
       end if;
     end skip_by_path;
 
-    function package_exists_in_cur_schema(p_package_name varchar2) return boolean is
+    function package_exists_in_cur_schema(a_package_name varchar2) return boolean is
       l_cnt number;
     begin
       select count(*)
         into l_cnt
         from all_objects t
-       where t.object_name = upper(p_package_name)
+       where t.object_name = upper(a_package_name)
          and t.object_type = 'PACKAGE'
          and t.owner = c_current_schema;
       return l_cnt > 0;

--- a/source/core/ut_suite_manager.pkb
+++ b/source/core/ut_suite_manager.pkb
@@ -129,26 +129,26 @@ create or replace package body ut_suite_manager is
         l_proc_annotations := l_annotation_data.procedure_annotations(i).annotations;
         if l_proc_annotations.exists('test') then
           declare
-            l_setup_procedure     varchar2(30 char);
-            l_teardown_procedure  varchar2(30 char);
-            l_rollback_annotation varchar2(4000);
-            l_rollback_type       integer := l_suite_rollback;
-            l_displayname         varchar2(4000);
+            l_beforetest_procedure varchar2(30 char);
+            l_aftertest_procedure  varchar2(30 char);
+            l_rollback_annotation  varchar2(4000);
+            l_rollback_type        integer := l_suite_rollback;
+            l_displayname          varchar2(4000);
           begin
             if l_proc_annotations.exists('beforetest') then
-              l_setup_procedure := ut_annotations.get_annotation_param(l_proc_annotations('beforetest'), 1);
+              l_beforetest_procedure := ut_annotations.get_annotation_param(l_proc_annotations('beforetest'), 1);
             end if;
-
+          
             if l_proc_annotations.exists('aftertest') then
-              l_teardown_procedure := ut_annotations.get_annotation_param(l_proc_annotations('aftertest'), 1);
+              l_aftertest_procedure := ut_annotations.get_annotation_param(l_proc_annotations('aftertest'), 1);
             end if;
-
+          
             if l_proc_annotations.exists('displayname') then
               l_displayname := ut_annotations.get_annotation_param(l_proc_annotations('displayname'), 1);
-            elsif l_proc_annotations('test').count>0 then
+            elsif l_proc_annotations('test').count > 0 then
               l_displayname := ut_annotations.get_annotation_param(l_proc_annotations('test'), 1);
             end if;
-
+          
             if l_proc_annotations.exists('rollback') then
               l_rollback_annotation := ut_annotations.get_annotation_param(l_proc_annotations('rollback'), 1);
               l_rollback_type       := case lower(l_rollback_annotation)
@@ -162,21 +162,19 @@ create or replace package body ut_suite_manager is
                                           l_suite_rollback
                                        end;
             end if;
-
-            l_test := ut_test(
-                a_object_owner  => l_owner_name,
-                a_object_name   => l_object_name,
-                a_name          => l_proc_name,
-                a_description   => l_displayname,
-                a_path          => l_suite.path || '.' || l_proc_name,
-                a_rollback_type => l_rollback_type,
-                a_ignore_flag   => l_proc_annotations.exists('disabled'),
-                a_before_test_proc_name => l_setup_procedure,
-                a_after_test_proc_name  => l_teardown_procedure,
-                a_before_each_proc_name => l_default_setup_proc,
-                a_after_each_proc_name  => l_default_teardown_proc
-            );
-
+          
+            l_test := ut_test(a_object_owner          => l_owner_name
+                             ,a_object_name           => l_object_name
+                             ,a_name                  => l_proc_name
+                             ,a_description           => l_displayname
+                             ,a_path                  => l_suite.path || '.' || l_proc_name
+                             ,a_rollback_type         => l_rollback_type
+                             ,a_ignore_flag           => l_proc_annotations.exists('disabled')
+                             ,a_before_test_proc_name => l_beforetest_procedure
+                             ,a_after_test_proc_name  => l_aftertest_procedure
+                             ,a_before_each_proc_name => l_default_setup_proc
+                             ,a_after_each_proc_name  => l_default_teardown_proc);
+          
             l_suite.add_item(l_test);
           end;
         end if;

--- a/source/reporters/ut_documentation_reporter.tpb
+++ b/source/reporters/ut_documentation_reporter.tpb
@@ -2,13 +2,13 @@ create or replace type body ut_documentation_reporter is
   /*
   utPLSQL - Version X.X.X.X
   Copyright 2016 - 2017 utPLSQL Project
-
+  
   Licensed under the Apache License, Version 2.0 (the "License"):
   you may not use this file except in compliance with the License.
   You may obtain a copy of the License at
-
+  
       http://www.apache.org/licenses/LICENSE-2.0
-
+  
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -29,6 +29,18 @@ create or replace type body ut_documentation_reporter is
     return rpad(' ', self.lvl * 2);
   end tab;
 
+  member procedure print_output(a_executable ut_executable) is
+    l_lines ut_varchar2_list;
+  begin
+    if a_executable is not null and a_executable.is_defined and a_executable.serveroutput is not null and
+       dbms_lob.getlength(a_executable.serveroutput) > 0 then
+      l_lines := ut_utils.clob_to_table(a_executable.serveroutput);
+      for i in 1 .. l_lines.count loop
+        self.print_text(l_lines(i));
+      end loop;
+    end if;
+  end;
+
   overriding member procedure print_text(self in out nocopy ut_documentation_reporter, a_text varchar2) is
   begin
     if a_text is not null then
@@ -38,25 +50,15 @@ create or replace type body ut_documentation_reporter is
 
   overriding member procedure before_calling_suite(self in out nocopy ut_documentation_reporter, a_suite ut_logical_suite) as
   begin
-    self.print_text( coalesce( a_suite.description, a_suite.name ) );
+    self.print_text(coalesce(a_suite.description, a_suite.name));
     lvl := lvl + 1;
   end;
 
   overriding member procedure after_calling_test(self in out nocopy ut_documentation_reporter, a_test ut_test) as
     l_message varchar2(4000);
-    
-    procedure print_output(a_exectable ut_executable) is
-      l_lines ut_varchar2_list;
-    begin
-      if a_exectable is not null and a_exectable.is_defined and a_exectable.serveroutput is not null and dbms_lob.getlength(a_exectable.serveroutput) > 0 then
-        l_lines := ut_utils.clob_to_table(a_exectable.serveroutput);
-        for i in 1..l_lines.count loop
-          self.print_text(l_lines(i));
-        end loop;
-      end if;
-    end;
+  
   begin
-    l_message := coalesce( a_test.description, a_test.name );
+    l_message := coalesce(a_test.description, a_test.name);
     --if test failed, then add it to the failures list, print failure with number
     if a_test.result = ut_utils.tr_ignore then
       self.print_yellow_text(l_message || ' (IGNORED)');
@@ -64,15 +66,24 @@ create or replace type body ut_documentation_reporter is
       self.print_green_text(l_message);
     elsif a_test.result > ut_utils.tr_success then
       failed_test_running_count := failed_test_running_count + 1;
-      self.print_red_text(l_message || ' (FAILED - '||failed_test_running_count||')');
+      self.print_red_text(l_message || ' (FAILED - ' || failed_test_running_count || ')');
     end if;
-    
+  
     -- reproduce the output from before/after procedures and the test
     print_output(a_test.before_each);
     print_output(a_test.before_test);
     print_output(a_test.item);
     print_output(a_test.after_test);
     print_output(a_test.after_each);
+  end;
+
+  overriding member procedure after_calling_after_all(self in out nocopy ut_documentation_reporter, a_suite in ut_logical_suite) is
+  begin
+    self.print_output(treat(a_suite as ut_suite).after_all);
+  end;
+  overriding member procedure after_calling_before_all(self in out nocopy ut_documentation_reporter, a_suite in ut_logical_suite) is
+  begin
+    self.print_output(treat(a_suite as ut_suite).before_all);
   end;
 
   overriding member procedure after_calling_suite(self in out nocopy ut_documentation_reporter, a_suite ut_logical_suite) as
@@ -85,7 +96,7 @@ create or replace type body ut_documentation_reporter is
 
   overriding member procedure after_calling_run(self in out nocopy ut_documentation_reporter, a_run in ut_run) as
     l_summary_text varchar2(4000);
-    l_warnings ut_varchar2_list := ut_varchar2_list();
+    l_warnings     ut_varchar2_list := ut_varchar2_list();
     procedure print_failure_for_assert(a_assert ut_assert_result) is
       l_lines ut_varchar2_list;
     begin
@@ -96,12 +107,13 @@ create or replace type body ut_documentation_reporter is
       self.print_cyan_text(a_assert.caller_info);
       self.print_text(' ');
     end;
-
+  
     procedure print_failures_for_test(a_test ut_test, a_failure_no in out nocopy integer) is
     begin
       if a_test.result > ut_utils.tr_success then
         a_failure_no := a_failure_no + 1;
-        self.print_text(lpad(a_failure_no, length(failed_test_running_count)+2,' ')||') '||nvl( a_test.name, a_test.item.form_name ));
+        self.print_text(lpad(a_failure_no, length(failed_test_running_count) + 2, ' ') || ') ' ||
+                        nvl(a_test.name, a_test.item.form_name));
         self.lvl := self.lvl + 3;
         for j in 1 .. a_test.results.count loop
           if a_test.results(j).result > ut_utils.tr_success then
@@ -111,79 +123,81 @@ create or replace type body ut_documentation_reporter is
         lvl := lvl - 3;
       end if;
     end;
-
+  
     procedure print_failures_from_suite(a_suite ut_logical_suite, a_failure_no in out nocopy integer) is
     begin
       for i in 1 .. a_suite.items.count loop
-        if a_suite.items(i) is of (ut_logical_suite) then
-          print_failures_from_suite(treat( a_suite.items(i) as ut_logical_suite), a_failure_no);
-        elsif a_suite.items(i) is of (ut_test) then
+        if a_suite.items(i) is of(ut_logical_suite) then
+          print_failures_from_suite(treat(a_suite.items(i) as ut_logical_suite), a_failure_no);
+        elsif a_suite.items(i) is of(ut_test) then
           print_failures_for_test(treat(a_suite.items(i) as ut_test), a_failure_no);
         end if;
       end loop;
     end;
-
+  
     procedure print_failures_details(a_run in ut_run) is
       l_failure_no integer := 0;
     begin
       if a_run.results_count.failure_count > 0 or a_run.results_count.errored_count > 0 then
-
-        self.print_text( 'Failures:' );
-        self.print_text( ' ' );
+      
+        self.print_text('Failures:');
+        self.print_text(' ');
         for i in 1 .. a_run.items.count loop
           print_failures_from_suite(treat(a_run.items(i) as ut_logical_suite), l_failure_no);
         end loop;
       end if;
     end;
-    
-    procedure print_warnings(a_run in ut_run) is     
+  
+    procedure print_warnings(a_run in ut_run) is
       procedure gather_warnings(a_item ut_suite_item) is
         l_suite ut_logical_suite;
       begin
         --process warnings of child items first
         if a_item is of(ut_logical_suite) then
           l_suite := treat(a_item as ut_logical_suite);
-          for item_ind in 1..l_suite.items.count loop
+          for item_ind in 1 .. l_suite.items.count loop
             gather_warnings(l_suite.items(item_ind));
           end loop;
         end if;
-        
+      
         --then process self warnings
         if a_item.warnings is not null and a_item.warnings.count > 0 then
-          for warn_ind in 1..a_item.warnings.count loop
+          for warn_ind in 1 .. a_item.warnings.count loop
             l_warnings.extend;
-            l_warnings(l_warnings.last) := '  '||l_warnings.last||') '||a_item.path||' - '||
-            regexp_replace(a_item.warnings(warn_ind),'('||chr(10)||'|'||chr(13)||')','\1       ');
+            l_warnings(l_warnings.last) := '  ' || l_warnings.last || ') ' || a_item.path || ' - ' ||
+                                           regexp_replace(a_item.warnings(warn_ind)
+                                                         ,'(' || chr(10) || '|' || chr(13) || ')'
+                                                         ,'\1       ');
           end loop;
         end if;
       end;
     begin
-      if a_run.items is not null and a_run.items.count >0 then
-        for run_item in 1..a_run.items.count loop
+      if a_run.items is not null and a_run.items.count > 0 then
+        for run_item in 1 .. a_run.items.count loop
           gather_warnings(a_run.items(run_item));
         end loop;
       end if;
-      
-      if l_warnings.count>0 then
-        self.print_text( 'Warnings:' );
-        self.print_text( ' ' );
+    
+      if l_warnings.count > 0 then
+        self.print_text('Warnings:');
+        self.print_text(' ');
         for i in 1 .. l_warnings.count loop
           self.print_text(l_warnings(i));
           self.print_text(' ');
         end loop;
       end if;
     end;
-
+  
   begin
     print_failures_details(a_run);
     print_warnings(a_run);
-    self.print_text( 'Finished in '||a_run.execution_time||' seconds' );
-    l_summary_text :=
-      a_run.results_count.total_count || ' tests, '
-      ||a_run.results_count.failure_count||' failed, '
-      ||a_run.results_count.errored_count||' errored, '
-      ||a_run.results_count.ignored_count||' ignored.'||
-      case when l_warnings.count>0 then ' '||l_warnings.count||' warning(s)' end;
+    self.print_text('Finished in ' || a_run.execution_time || ' seconds');
+    l_summary_text := a_run.results_count.total_count || ' tests, ' || a_run.results_count.failure_count || ' failed, ' ||
+                      a_run.results_count.errored_count || ' errored, ' || a_run.results_count.ignored_count ||
+                      ' ignored.' || case
+                        when l_warnings.count > 0 then
+                         ' ' || l_warnings.count || ' warning(s)'
+                      end;
     if a_run.results_count.failure_count > 0 then
       self.print_red_text(l_summary_text);
     else

--- a/source/reporters/ut_documentation_reporter.tpb
+++ b/source/reporters/ut_documentation_reporter.tpb
@@ -66,6 +66,8 @@ create or replace type body ut_documentation_reporter is
       failed_test_running_count := failed_test_running_count + 1;
       self.print_red_text(l_message || ' (FAILED - '||failed_test_running_count||')');
     end if;
+    
+    -- reproduce the output from before/after procedures and the test
     print_output(a_test.before_each);
     print_output(a_test.before_test);
     print_output(a_test.item);

--- a/source/reporters/ut_documentation_reporter.tpb
+++ b/source/reporters/ut_documentation_reporter.tpb
@@ -44,6 +44,17 @@ create or replace type body ut_documentation_reporter is
 
   overriding member procedure after_calling_test(self in out nocopy ut_documentation_reporter, a_test ut_test) as
     l_message varchar2(4000);
+    
+    procedure print_output(a_exectable ut_executable) is
+      l_lines ut_varchar2_list;
+    begin
+      if a_exectable is not null and a_exectable.is_defined and a_exectable.serveroutput is not null and dbms_lob.getlength(a_exectable.serveroutput) > 0 then
+        l_lines := ut_utils.clob_to_table(a_exectable.serveroutput);
+        for i in 1..l_lines.count loop
+          self.print_text(l_lines(i));
+        end loop;
+      end if;
+    end;
   begin
     l_message := coalesce( a_test.description, a_test.name );
     --if test failed, then add it to the failures list, print failure with number
@@ -55,6 +66,11 @@ create or replace type body ut_documentation_reporter is
       failed_test_running_count := failed_test_running_count + 1;
       self.print_red_text(l_message || ' (FAILED - '||failed_test_running_count||')');
     end if;
+    print_output(a_test.before_each);
+    print_output(a_test.before_test);
+    print_output(a_test.item);
+    print_output(a_test.after_test);
+    print_output(a_test.after_each);
   end;
 
   overriding member procedure after_calling_suite(self in out nocopy ut_documentation_reporter, a_suite ut_logical_suite) as

--- a/source/reporters/ut_documentation_reporter.tps
+++ b/source/reporters/ut_documentation_reporter.tps
@@ -19,10 +19,13 @@ create or replace type ut_documentation_reporter force under ut_console_reporter
   failed_test_running_count integer,
   constructor function ut_documentation_reporter(self in out nocopy ut_documentation_reporter) return self as result,
   member function tab(self in ut_documentation_reporter) return varchar2,
+  member procedure print_output(a_executable ut_executable),
 
   overriding member procedure print_text(self in out nocopy ut_documentation_reporter, a_text varchar2),
   overriding member procedure before_calling_suite(self in out nocopy ut_documentation_reporter, a_suite ut_logical_suite),
   overriding member procedure after_calling_test(self in out nocopy ut_documentation_reporter, a_test ut_test),
+  overriding member procedure after_calling_after_all (self in out nocopy ut_documentation_reporter, a_suite in ut_logical_suite),
+  overriding member procedure after_calling_before_all (self in out nocopy ut_documentation_reporter, a_suite in ut_logical_suite),
   overriding member procedure after_calling_suite(self in out nocopy ut_documentation_reporter, a_suite ut_logical_suite),
   overriding member procedure after_calling_run(self in out nocopy ut_documentation_reporter, a_run in ut_run)
 

--- a/source/reporters/ut_teamcity_reporter.tpb
+++ b/source/reporters/ut_teamcity_reporter.tpb
@@ -44,7 +44,7 @@ create or replace type body ut_teamcity_reporter is
 
     l_test_full_name := lower(a_test.item.owner_name)||'.'||lower(a_test.item.object_name)||'.'||lower(a_test.item.procedure_name);
 
-    self.print_text(ut_teamcity_reporter_helper.test_started(a_test_name => l_test_full_name));
+    self.print_text(ut_teamcity_reporter_helper.test_started(a_test_name => l_test_full_name,a_capture_standard_output => true));
 
   end;
 

--- a/tests/RunAll.sql
+++ b/tests/RunAll.sql
@@ -151,6 +151,7 @@ create table ut$test_table (val varchar2(1));
 @@lib/RunTest.sql ut_test/ut_test.BeforeEachExecuted.sql
 @@lib/RunTest.sql ut_test/ut_test.BeforeEachProcedureNameInvalid.sql
 @@lib/RunTest.sql ut_test/ut_test.BeforeEachProcedureNameNull.sql
+@@lib/RunTest.sql ut_test/ut_test.TestOutputGathering.sql
 
 @@lib/RunTest.sql ut_test_suite/ut_test_suite.ErrorsATestWhenAfterTestFails.sql
 @@lib/RunTest.sql ut_test_suite/ut_test_suite.ErrorsATestWhenBeforeTestFails.sql

--- a/tests/RunAll.sql
+++ b/tests/RunAll.sql
@@ -145,6 +145,12 @@ create table ut$test_table (val varchar2(1));
 @@lib/RunTest.sql ut_test/ut_test.TeardownProcedureNameInvalid.sql
 @@lib/RunTest.sql ut_test/ut_test.TeardownProcedureNameNull.sql
 @@lib/RunTest.sql ut_test/ut_test.IgnoreTollbackToSavepointException.sql
+@@lib/RunTest.sql ut_test/ut_test.AfterEachExecuted.sql
+@@lib/RunTest.sql ut_test/ut_test.AfterEachProcedureNameInvalid.sql
+@@lib/RunTest.sql ut_test/ut_test.AfterEachProcedureNameNull.sql
+@@lib/RunTest.sql ut_test/ut_test.BeforeEachExecuted.sql
+@@lib/RunTest.sql ut_test/ut_test.BeforeEachProcedureNameInvalid.sql
+@@lib/RunTest.sql ut_test/ut_test.BeforeEachProcedureNameNull.sql
 
 @@lib/RunTest.sql ut_test_suite/ut_test_suite.ErrorsATestWhenAfterTestFails.sql
 @@lib/RunTest.sql ut_test_suite/ut_test_suite.ErrorsATestWhenBeforeTestFails.sql

--- a/tests/RunAll.sql
+++ b/tests/RunAll.sql
@@ -152,6 +152,7 @@ create table ut$test_table (val varchar2(1));
 @@lib/RunTest.sql ut_test/ut_test.BeforeEachProcedureNameInvalid.sql
 @@lib/RunTest.sql ut_test/ut_test.BeforeEachProcedureNameNull.sql
 @@lib/RunTest.sql ut_test/ut_test.TestOutputGathering.sql
+@@lib/RunTest.sql ut_test/ut_test.TestOutputGatheringForTeamcity.sql
 
 @@lib/RunTest.sql ut_test_suite/ut_test_suite.ErrorsATestWhenAfterTestFails.sql
 @@lib/RunTest.sql ut_test_suite/ut_test_suite.ErrorsATestWhenBeforeTestFails.sql

--- a/tests/helpers/ut_example_tests.pkb
+++ b/tests/helpers/ut_example_tests.pkb
@@ -11,12 +11,25 @@ as
  begin
     g_char := null;
  end;
+ 
+ procedure beforeeach as
+ begin
+   g_number2 := 0;
+ end;
+
+ procedure aftereach
+ as
+ begin
+    g_char2 := 'F';
+ end;
 
  procedure ut_passing_test
  as
  begin
     g_number := g_number + 1;
+    g_number2 := g_number2 + 1;
     g_char := 'a';
+    g_char2 := 'a';
     ut.expect(1,'Test 1 Should Pass').to_equal(1);
  end;
  

--- a/tests/helpers/ut_example_tests.pks
+++ b/tests/helpers/ut_example_tests.pks
@@ -1,9 +1,13 @@
 create or replace package ut_example_tests
 as
  g_number  number;
+ g_number2  number;
  g_char    varchar2(1);
+ g_char2    varchar2(1);
  procedure setup;
  procedure teardown;
+ procedure beforeeach;
+ procedure aftereach;
  procedure ut_passing_test;
  procedure ut_commit_test;
 end;

--- a/tests/ut_suite_manager/ut_suite_manager.configure_execution_by_path.PrepareRunnerForTheTopPackageByName.sql
+++ b/tests/ut_suite_manager/ut_suite_manager.configure_execution_by_path.PrepareRunnerForTheTopPackageByName.sql
@@ -22,18 +22,19 @@ begin
   
   ut.expect(l_test1_suite.name).to_equal('test_package_1');
   ut.expect(l_test1_suite.items.count).to_equal(3);
-  ut.expect(l_test1_suite.before_each is not null).to_be_true;
   
   ut.expect(l_test1_suite.items(1).name).to_equal('test1');
   ut.expect(l_test1_suite.items(1).description).to_equal('Test1 from test package 1');
   ut.expect(treat(l_test1_suite.items(1) as ut_test).before_test.is_defined).to_be_false;
   ut.expect(treat(l_test1_suite.items(1) as ut_test).after_test.is_defined).to_be_false;
+  ut.expect(treat(l_test1_suite.items(1) as ut_test).before_each.is_defined).to_be_true;
   ut.expect(treat(l_test1_suite.items(1) as ut_test).ignore_flag).to_equal(0);
   
   ut.expect(l_test1_suite.items(2).name).to_equal('test2');
   ut.expect(l_test1_suite.items(2).description).to_equal('Test2 from test package 1');
   ut.expect(treat(l_test1_suite.items(2) as ut_test).before_test.is_defined).to_be_true;
   ut.expect(treat(l_test1_suite.items(2) as ut_test).after_test.is_defined).to_be_true;
+  ut.expect(treat(l_test1_suite.items(2) as ut_test).before_each.is_defined).to_be_true;
   ut.expect(treat(l_test1_suite.items(2) as ut_test).ignore_flag).to_equal(0);
   
   -- temporary behavior.

--- a/tests/ut_suite_manager/ut_suite_manager.configure_execution_by_path.PrepareRunnerForTheTopPackageByNameCurUser.sql
+++ b/tests/ut_suite_manager/ut_suite_manager.configure_execution_by_path.PrepareRunnerForTheTopPackageByNameCurUser.sql
@@ -22,18 +22,19 @@ begin
   
   ut.expect(l_test1_suite.name).to_equal('test_package_1');
   ut.expect(l_test1_suite.items.count).to_equal(3);
-  ut.expect(l_test1_suite.before_each is not null).to_be_true;
   
   ut.expect(l_test1_suite.items(1).name).to_equal('test1');
   ut.expect(l_test1_suite.items(1).description).to_equal('Test1 from test package 1');
   ut.expect(treat(l_test1_suite.items(1) as ut_test).before_test.is_defined).to_be_false;
   ut.expect(treat(l_test1_suite.items(1) as ut_test).after_test.is_defined).to_be_false;
+  ut.expect(treat(l_test1_suite.items(1) as ut_test).before_each.is_defined).to_be_true;
   ut.expect(treat(l_test1_suite.items(1) as ut_test).ignore_flag).to_equal(0);
   
   ut.expect(l_test1_suite.items(2).name).to_equal('test2');
   ut.expect(l_test1_suite.items(2).description).to_equal('Test2 from test package 1');
   ut.expect(treat(l_test1_suite.items(2) as ut_test).before_test.is_defined).to_be_true;
   ut.expect(treat(l_test1_suite.items(2) as ut_test).after_test.is_defined).to_be_true;
+  ut.expect(treat(l_test1_suite.items(2) as ut_test).before_each.is_defined).to_be_true;
   ut.expect(treat(l_test1_suite.items(2) as ut_test).ignore_flag).to_equal(0);
   
   -- temporary behavior.

--- a/tests/ut_test/ut_test.AfterEachExecuted.sql
+++ b/tests/ut_test/ut_test.AfterEachExecuted.sql
@@ -1,0 +1,20 @@
+PROMPT Invoke aftereach procedure
+
+--Arrange
+declare
+  simple_test ut_test := ut_test(
+    a_object_name         => 'ut_example_tests'
+    ,a_name     => 'ut_passing_test'
+    ,a_after_each_proc_name => 'aftereach'
+  );
+  listener ut_event_listener := ut_event_listener(ut_reporters());
+begin
+--Act
+  simple_test.do_execute(listener);
+--Assert
+  if simple_test.result = ut_utils.tr_success and ut_example_tests.g_char2 = 'F' then
+    :test_result := ut_utils.tr_success;
+  end if;
+end;
+/
+

--- a/tests/ut_test/ut_test.AfterEachProcedureNameInvalid.sql
+++ b/tests/ut_test/ut_test.AfterEachProcedureNameInvalid.sql
@@ -1,0 +1,21 @@
+PROMPT Does not execute test and reports error when test aftereach procedure name for a test is invalid
+
+--Arrange
+declare
+  simple_test ut_test := ut_test(
+    a_after_each_proc_name => 'invalid setup name'
+    ,a_object_name => 'ut_example_tests'
+    ,a_name => 'ut_exampletest'
+  );
+  listener ut_event_listener := ut_event_listener(ut_reporters());
+begin
+  ut_example_tests.g_char := 'x';
+  ut_example_tests.g_char2 := 'x';
+--Act
+  simple_test.do_execute(listener);
+--Assert
+  if ut_example_tests.g_char2 = 'x' and simple_test.result = ut_utils.tr_error then
+    :test_result := ut_utils.tr_success;
+  end if;
+end;
+/

--- a/tests/ut_test/ut_test.AfterEachProcedureNameNull.sql
+++ b/tests/ut_test/ut_test.AfterEachProcedureNameNull.sql
@@ -1,0 +1,21 @@
+PROMPT Does not invoke aftereach procedure when aftereach procedure name for a test is null
+
+--Arrange
+declare
+  simple_test ut_test := ut_test(
+    a_after_each_proc_name => null
+    ,a_object_name => 'ut_example_tests'
+    ,a_name => 'ut_passing_test'
+  );
+  listener ut_event_listener := ut_event_listener(ut_reporters());
+begin
+--Act
+  simple_test.do_execute(listener);
+--Assert
+  if ut_example_tests.g_char2 = 'a' then
+    :test_result := ut_utils.tr_success;
+  else
+    dbms_output.put_line('expected: ut_example_tests.g_char = ''a'', got: '||ut_example_tests.g_char2 );
+  end if;
+end;
+/

--- a/tests/ut_test/ut_test.BeforeEachExecuted.sql
+++ b/tests/ut_test/ut_test.BeforeEachExecuted.sql
@@ -1,0 +1,21 @@
+PROMPT Invoke beforeeach procedure
+
+--Arrange
+declare
+  simple_test ut_test := ut_test(
+    a_object_name            => 'ut_example_tests'
+    ,a_name        => 'ut_passing_test'
+    ,a_before_each_proc_name => 'beforeeach'
+  );
+  listener ut_event_listener := ut_event_listener(ut_reporters());
+begin
+  ut_example_tests.g_number2 := null;
+--Act
+  simple_test.do_execute(listener);
+--Assert
+  if ut_example_tests.g_number2 = 1 then
+    :test_result := ut_utils.tr_success;
+  end if;
+end;
+/
+

--- a/tests/ut_test/ut_test.BeforeEachProcedureNameInvalid.sql
+++ b/tests/ut_test/ut_test.BeforeEachProcedureNameInvalid.sql
@@ -1,0 +1,20 @@
+PROMPT Does not execute test and reports error when test beforeeach procedure name for a test is invalid
+
+--Arrange
+declare
+  simple_test ut_test := ut_test(
+     a_before_each_proc_name => 'invalid setup name'
+    ,a_object_name => 'ut_example_tests'
+    ,a_name => 'ut_exampletest'
+  );
+  listener ut_event_listener := ut_event_listener(ut_reporters());
+begin
+  ut_example_tests.g_char2 := null;
+--Act
+  simple_test.do_execute(listener);
+--Assert
+  if simple_test.result = ut_utils.tr_error and ut_example_tests.g_char2 is null then
+    :test_result := ut_utils.tr_success;
+  end if;
+end;
+/

--- a/tests/ut_test/ut_test.BeforeEachProcedureNameNull.sql
+++ b/tests/ut_test/ut_test.BeforeEachProcedureNameNull.sql
@@ -1,0 +1,22 @@
+PROMPT Does not invoke setup procedure when beforeeach procedure name for a test is null
+
+--Arrange
+declare
+  simple_test ut_test := ut_test(
+     a_before_each_proc_name => null
+    ,a_object_name => 'ut_example_tests'
+    ,a_name => 'ut_passing_test'
+  );
+  listener ut_event_listener := ut_event_listener(ut_reporters());
+begin
+  ut_example_tests.g_number2 := null;
+--Act
+  simple_test.do_execute(listener);
+--Assert
+  if ut_example_tests.g_number2 is null then
+    :test_result := ut_utils.tr_success;
+  else
+    dbms_output.put_line('expected: ut_example_tests.g_number is null, got: '||ut_example_tests.g_number2 );
+  end if;
+end;
+/

--- a/tests/ut_test/ut_test.TestOutputGathering.sql
+++ b/tests/ut_test/ut_test.TestOutputGathering.sql
@@ -1,0 +1,84 @@
+create or replace package ut_output_tests
+as
+ --%suite
+  
+ --%beforeeach
+ procedure beforeeach;
+ 
+ --%aftereach
+ procedure aftereach;
+ 
+ --%test
+ --%beforetest(beforetest)
+ --%aftertest(aftertest)
+ procedure ut_passing_test;
+ 
+ procedure beforetest;
+ 
+ procedure aftertest;
+ 
+end;
+/
+
+create or replace package body ut_output_tests
+as
+
+ procedure beforetest as
+ begin
+   dbms_output.put_line('<!beforetest!>');
+ end;
+
+ procedure aftertest
+ as
+ begin
+   dbms_output.put_line('<!aftertest!>');
+ end;
+ 
+ procedure beforeeach as
+ begin
+   dbms_output.put_line('<!beforeeach!>');
+ end;
+
+ procedure aftereach
+ as
+ begin
+   dbms_output.put_line('<!aftereach!>');
+ end;
+
+ procedure ut_passing_test
+ as
+ begin
+   dbms_output.put_line('<!thetest!>');
+   ut.expect(1,'Test 1 Should Pass').to_equal(1);
+ end;
+
+end;
+/
+
+declare
+  l_output_data       dbms_output.chararr;
+  l_num_lines         integer := 100000;
+begin
+  --act
+  ut.run('ut_output_tests');
+
+  --assert
+  dbms_output.get_lines( l_output_data, l_num_lines);
+  for i in 1 .. l_num_lines loop
+    if l_output_data(i) like '%<!beforeeach!>%<!beforetest!>%<!thetest!>%<!aftertest!>%<!aftereach!>%1 tests, 0 failed, 0 errored%' then
+      :test_result := ut_utils.tr_success;
+    end if;
+  end loop;
+
+  if :test_result != ut_utils.tr_success or :test_result is null then
+    for i in 1 .. l_num_lines loop
+      dbms_output.put_line(l_output_data(i));
+    end loop;
+    dbms_output.put_line('Failed: Wrong output');
+  end if;
+end;
+/
+
+drop package ut_output_tests
+/
+

--- a/tests/ut_test/ut_test.TestOutputGathering.sql
+++ b/tests/ut_test/ut_test.TestOutputGathering.sql
@@ -17,6 +17,11 @@ as
  
  procedure aftertest;
  
+ --%beforeall
+ procedure beforeall;
+ --%afterall 
+ procedure afterall;
+ 
 end;
 /
 
@@ -51,6 +56,16 @@ as
    dbms_output.put_line('<!thetest!>');
    ut.expect(1,'Test 1 Should Pass').to_equal(1);
  end;
+ 
+ procedure beforeall is
+ begin
+   dbms_output.put_line('<!beforeall!>');
+ end;
+
+ procedure afterall is
+ begin
+   dbms_output.put_line('<!afterall!>');
+ end;
 
 end;
 /
@@ -70,7 +85,7 @@ begin
     dbms_lob.append(l_output,l_output_data(i));
   end loop;
   
-  if l_output like '%<!beforeeach!>%<!beforetest!>%<!thetest!>%<!aftertest!>%<!aftereach!>%1 tests, 0 failed, 0 errored%' then
+  if l_output like '%<!beforeall!>%<!beforeeach!>%<!beforetest!>%<!thetest!>%<!aftertest!>%<!aftereach!>%<!afterall!>%1 tests, 0 failed, 0 errored%' then
     :test_result := ut_utils.tr_success;
   end if;
 

--- a/tests/ut_test/ut_test.TestOutputGatheringForTeamcity.sql
+++ b/tests/ut_test/ut_test.TestOutputGatheringForTeamcity.sql
@@ -17,39 +17,53 @@ as
  
  procedure aftertest;
  
+ --%beforeall
+ procedure beforeall;
+ --%afterall 
+ procedure afterall;
+ 
 end;
 /
 
 create or replace package body ut_output_tests
 as
 
- procedure beforetest as
+ procedure beforetest is
  begin
    dbms_output.put_line('<!beforetest!>');
  end;
 
  procedure aftertest
- as
+ is
  begin
    dbms_output.put_line('<!aftertest!>');
  end;
  
- procedure beforeeach as
+ procedure beforeeach is
  begin
    dbms_output.put_line('<!beforeeach!>');
  end;
 
- procedure aftereach
- as
+ procedure aftereach is
  begin
    dbms_output.put_line('<!aftereach!>');
  end;
 
  procedure ut_passing_test
- as
+ is
  begin
    dbms_output.put_line('<!thetest!>');
    ut.expect(1,'Test 1 Should Pass').to_equal(1);
+ end;
+ 
+ procedure beforeall is
+ begin
+   dbms_output.put_line('<!beforeall!>');
+ end;
+
+ procedure afterall is
+ begin
+   dbms_output.put_line('<!afterall!>');
  end;
 
 end;

--- a/tests/ut_test/ut_test.TestOutputGatheringForTeamcity.sql
+++ b/tests/ut_test/ut_test.TestOutputGatheringForTeamcity.sql
@@ -61,7 +61,7 @@ declare
   l_output            clob;
 begin
   --act
-  ut.run('ut_output_tests');
+  ut.run('ut_output_tests',ut_teamcity_reporter);
 
   --assert
   dbms_output.get_lines( l_output_data, l_num_lines);
@@ -69,8 +69,7 @@ begin
   for i in 1 .. l_num_lines loop
     dbms_lob.append(l_output,l_output_data(i));
   end loop;
-  
-  if l_output like '%<!beforeeach!>%<!beforetest!>%<!thetest!>%<!aftertest!>%<!aftereach!>%1 tests, 0 failed, 0 errored%' then
+  if l_output like '%##teamcity[testStarted%<!beforeeach!>%<!beforetest!>%<!thetest!>%<!aftertest!>%<!aftereach!>%##teamcity[testFinished%' then
     :test_result := ut_utils.tr_success;
   end if;
 

--- a/tests/ut_test_suite/ut_test_suite.ReportsWarningsATestWhenAfterEachFails.sql
+++ b/tests/ut_test_suite/ut_test_suite.ReportsWarningsATestWhenAfterEachFails.sql
@@ -25,7 +25,7 @@ begin
   dbms_output.get_lines( l_output_data, l_num_lines);
   if failing_after_each.gv_glob_val = 2 then
     for i in 1 .. l_num_lines loop
-      if l_output_data(i) like '%2 tests, 2 failed, 0 errored% 2 warning%' then
+      if l_output_data(i) like '%2 tests, 0 failed, 2 errored%' then
         :test_result := ut_utils.tr_success;
       end if;
     end loop;


### PR DESCRIPTION
Now `ut_executable` stores the stderr, stdout of the execution wich can be used by reporters.
`ut_documentations_reporter` prints the output of its steps along with test results (in future we might disable that by parameter)
`ut_teamcity_reporter` also reports output and stderr according to the Teamcity messaging format.
Added new tests to check new behavior

Moved beforeeach/aftereach executables from `ut_suite` to `ut_test`, fixed the behavior on failure.


