### PR TITLE
Bugfix/fixed missing bild no in version

### DIFF
--- a/.travis/build_release_archive.sh
+++ b/.travis/build_release_archive.sh
@@ -9,7 +9,10 @@ mv -f .gitattributes.release .gitattributes
 git add .
 git commit -m "tmp commit for building a release archive"
 
-git archive --prefix="utPLSQL${UTPLSQL_BUILD_VERSION}"/ -o "utPLSQL${UTPLSQL_BUILD_VERSION}".zip    --format=zip    HEAD
-git archive --prefix="utPLSQL${UTPLSQL_BUILD_VERSION}"/ -o "utPLSQL${UTPLSQL_BUILD_VERSION}".tar.gz --format=tar.gz HEAD
+# git archive --prefix="utPLSQL${UTPLSQL_BUILD_VERSION}"/ -o "utPLSQL${UTPLSQL_BUILD_VERSION}".zip    --format=zip    HEAD
+# git archive --prefix="utPLSQL${UTPLSQL_BUILD_VERSION}"/ -o "utPLSQL${UTPLSQL_BUILD_VERSION}".tar.gz --format=tar.gz HEAD
+
+git archive --prefix=utPLSQL/ -o utPLSQL.zip    --format=zip    HEAD
+git archive --prefix=utPLSQL/ -o utPLSQL.tar.gz --format=tar.gz HEAD
 
 

--- a/.travis/get_project_build_version.sh
+++ b/.travis/get_project_build_version.sh
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-echo `sed -r "s/(v?[0-9]+\.)([0-9]+\.)([0-9]+)(-.*)/\1\2\3\.${UTPLSQL_BUILD_NO}\4/" <<< "${UTPLSQL_VERSION}"`
+echo `sed -r "s/(v?[0-9]+\.)([0-9]+\.)([0-9]+)(-.*)?/\1\2\3\.${UTPLSQL_BUILD_NO}\4/" <<< "${UTPLSQL_VERSION}"`


### PR DESCRIPTION
- Fixed issue, where version number does not include the build number.
- Cleanup of release archive name
   - Removed version number from archive name and archive directory.
   - This change is intended to simplify automation for download and isntallation of latest utPLSQL version.
   - The unzip/install scripts can now assume that archive name is `utPSLQL.[zip|tar.gz]` and all the sources are in `utPLSQL/source` directory