### PR TITLE
dbms_lob_read_multibyte/Fix multibyte issue with dbms_lob.read

### DIFF
--- a/source/core/ut_utils.pkb
+++ b/source/core/ut_utils.pkb
@@ -211,7 +211,7 @@ create or replace package body ut_utils is
     return l_result;
   end;
 
-  function clob_to_table(a_clob clob, a_max_amount integer := 32767, a_delimiter varchar2:= chr(10)) return ut_varchar2_list is
+  function clob_to_table(a_clob clob, a_max_amount integer := 24575, a_delimiter varchar2:= chr(10)) return ut_varchar2_list is
     l_offset         integer := 1;
     l_length         integer := dbms_lob.getlength(a_clob);
     l_amount         integer;

--- a/source/core/ut_utils.pkb
+++ b/source/core/ut_utils.pkb
@@ -211,7 +211,7 @@ create or replace package body ut_utils is
     return l_result;
   end;
 
-  function clob_to_table(a_clob clob, a_max_amount integer := 24575, a_delimiter varchar2:= chr(10)) return ut_varchar2_list is
+  function clob_to_table(a_clob clob, a_max_amount integer := 8191, a_delimiter varchar2:= chr(10)) return ut_varchar2_list is
     l_offset         integer := 1;
     l_length         integer := dbms_lob.getlength(a_clob);
     l_amount         integer;

--- a/source/core/ut_utils.pks
+++ b/source/core/ut_utils.pks
@@ -171,20 +171,20 @@ create or replace package ut_utils authid definer is
      Parameters:
           a_clob - the text to be split.
           a_delimiter - the delimiter character or string (default chr(10) )
-          a_max_amount - the maximum length of returned string (default 24575)
+          a_max_amount - the maximum length of returned string (default 8191)
 
      Returns:
         ut_varchar2_list - table of string
 
    Splits a given string into table of string by delimiter.
-   Default value of a_max_amount is 24575 because of code can contains multibyte character.
+   Default value of a_max_amount is 8191 because of code can contains multibyte character. 
    The delimiter gets removed.
    If null passed as any of the parameters, empty table is returned.
    If split text is longer than a_max_amount it gets split into pieces of a_max_amount.
    If no text between delimiters found then an empty row is returned, example:
      string_to_table( 'a,,b', ',' ) gives table ut_varchar2_list( 'a', null, 'b' );
   */
-  function clob_to_table(a_clob clob, a_max_amount integer := 24575, a_delimiter varchar2:= chr(10)) return ut_varchar2_list;
+  function clob_to_table(a_clob clob, a_max_amount integer := 8191, a_delimiter varchar2:= chr(10)) return ut_varchar2_list;
 
   function table_to_clob(a_text_table ut_varchar2_list, a_delimiter varchar2:= chr(10)) return clob;
 

--- a/source/core/ut_utils.pks
+++ b/source/core/ut_utils.pks
@@ -171,19 +171,20 @@ create or replace package ut_utils authid definer is
      Parameters:
           a_clob - the text to be split.
           a_delimiter - the delimiter character or string (default chr(10) )
-          a_max_amount - the maximum length of returned string (default 32767)
+          a_max_amount - the maximum length of returned string (default 24575)
 
      Returns:
         ut_varchar2_list - table of string
 
    Splits a given string into table of string by delimiter.
+   Default value of a_max_amount is 24575 because of code can contains multibyte character.
    The delimiter gets removed.
    If null passed as any of the parameters, empty table is returned.
    If split text is longer than a_max_amount it gets split into pieces of a_max_amount.
    If no text between delimiters found then an empty row is returned, example:
      string_to_table( 'a,,b', ',' ) gives table ut_varchar2_list( 'a', null, 'b' );
   */
-  function clob_to_table(a_clob clob, a_max_amount integer := 32767, a_delimiter varchar2:= chr(10)) return ut_varchar2_list;
+  function clob_to_table(a_clob clob, a_max_amount integer := 24575, a_delimiter varchar2:= chr(10)) return ut_varchar2_list;
 
   function table_to_clob(a_text_table ut_varchar2_list, a_delimiter varchar2:= chr(10)) return clob;
 

--- a/tests/RunAll.sql
+++ b/tests/RunAll.sql
@@ -227,6 +227,7 @@ exec ut_coverage.coverage_start_develop();
 @@lib/RunTest.sql ut_test_suite/ut_test_suite.Rollback_type.ManualOnFailure.sql
 
 @@ut_utils/ut_utils.clob_to_table.sql
+@@ut_utils/ut_utils.clob_to_table_multibyte.sql
 @@ut_utils/ut_utils.table_to_clob.sql
 @@lib/RunTest.sql ut_utils/ut_utils.append_to_clob.worksWithMultiByteChars.sql
 @@lib/RunTest.sql ut_utils/ut_utils.test_result_to_char.RunsWithInvalidValues.sql

--- a/tests/ut_utils/ut_utils.clob_to_table_multibyte.sql
+++ b/tests/ut_utils/ut_utils.clob_to_table_multibyte.sql
@@ -1,23 +1,22 @@
 --Arrange
 declare
   l_varchar2_byte_limit integer := 32767;
-  l_workaround_byte_limit integer := 24575;
+  l_workaround_byte_limit integer := 8191;
   l_singlebyte_string_max_size varchar2(32767 char) := rpad('x',l_varchar2_byte_limit,'x');
   l_twobyte_character char(1 char) := 'ж';
   l_clob_multibyte clob := l_twobyte_character||l_singlebyte_string_max_size; --here we have 32769(2+32767) bytes and 32768 chars
   l_expected ut_varchar2_list := ut_varchar2_list();
   l_result   ut_varchar2_list;
 begin
-  l_expected.extend(2);
+  l_expected.extend(1);
   l_expected(1) := l_twobyte_character||substr(l_singlebyte_string_max_size,1,l_workaround_byte_limit-1);
-  l_expected(2) := substr(l_singlebyte_string_max_size,l_workaround_byte_limit-1+1);
 --Act
   l_result :=  ut_utils.clob_to_table(l_clob_multibyte);
 --Assert
-  if l_result = l_expected then
+  if l_result(1) = l_expected(1) then
     :test_result := ut_utils.tr_success;
   else
-    dbms_output.put_line('expected: lengths '||length(l_expected(1))||' and '||length(l_expected(2))||', got lengths: '||length(l_result(1))||' and '||length(l_result(2)));
+    dbms_output.put_line('expected: 1st string length '||length(l_expected(1))||', got 1st string length: '||length(l_result(1)));
   end if;
 end;
 /

--- a/tests/ut_utils/ut_utils.clob_to_table_multibyte.sql
+++ b/tests/ut_utils/ut_utils.clob_to_table_multibyte.sql
@@ -1,0 +1,23 @@
+--Arrange
+declare
+  l_varchar2_byte_limit integer := 32767;
+  l_workaround_byte_limit integer := 24575;
+  l_singlebyte_string_max_size varchar2(32767 char) := rpad('x',l_varchar2_byte_limit,'x');
+  l_twobyte_character char(1 char) := 'ж';
+  l_clob_multibyte clob := l_twobyte_character||l_singlebyte_string_max_size; --here we have 32769(2+32767) bytes and 32768 chars
+  l_expected ut_varchar2_list := ut_varchar2_list();
+  l_result   ut_varchar2_list;
+begin
+  l_expected.extend(2);
+  l_expected(1) := l_twobyte_character||substr(l_singlebyte_string_max_size,1,l_workaround_byte_limit-1);
+  l_expected(2) := substr(l_singlebyte_string_max_size,l_workaround_byte_limit-1+1);
+--Act
+  l_result :=  ut_utils.clob_to_table(l_clob_multibyte);
+--Assert
+  if l_result = l_expected then
+    :test_result := ut_utils.tr_success;
+  else
+    dbms_output.put_line('expected: lengths '||length(l_expected(1))||' and '||length(l_expected(2))||', got lengths: '||length(l_result(1))||' and '||length(l_result(2)));
+  end if;
+end;
+/


### PR DESCRIPTION
Use (3/4) * 32767 instead of 32767 as buffer default size for dbms_lob.read