### PR TITLE
Fixed stack parsing when test failed with `ut.fail` 

### DIFF
--- a/source/core/ut_expectation_processor.pkb
+++ b/source/core/ut_expectation_processor.pkb
@@ -130,14 +130,15 @@ create or replace package body ut_expectation_processor as
     -- in 12.2 format_call_stack reportes not only package name, but also the procedure name
     -- when 11g and 12c reports only package name
     c_expectation_search_pattern constant varchar2(500) := 
-    '(^.*\.((UT_EXPECTATION[A-Z0-9#_$]*)|(UT)|(UTASSERT2?))(\.[A-Z0-9#_$]+)?$\s)+\s*(.*)';
+    '(^.*\.(UT_EXPECTATION[A-Z0-9#_$]*|UT|UTASSERT2?)(\.[A-Z0-9#_$]+)?$\s)+(.*)';
   begin
-    l_caller_stack_line    := regexp_substr( c_call_stack, c_expectation_search_pattern, 1, 1, 'm', 7);
-    l_line_no              := to_number( regexp_substr(l_caller_stack_line,'^\dx[0-9a-f]+\s+(\d+)',subexpression => 1) );
-    l_caller_type_and_name    := substr( l_caller_stack_line, 23 );
+    dbms_output.put_line(c_call_stack);
+    l_caller_stack_line    := regexp_substr( c_call_stack, c_expectation_search_pattern, 1, 1, 'm', 4);
+    l_line_no              := to_number( regexp_substr(l_caller_stack_line,'0x[0-9a-f]+\s+(\d+)',subexpression => 1) );
+    l_caller_type_and_name    := trim(regexp_substr(l_caller_stack_line,'0x[0-9a-f]+\s+\d+\s+(.+)',subexpression => 1));
     if l_caller_stack_line like '%.%' then
-      l_owner       := regexp_substr(l_caller_stack_line,'\s([A-Za-z0-9$#_]+)\.([A-Za-z0-9$#_]|\.)+$',subexpression => 1);
-      l_object_name := regexp_substr(l_caller_stack_line,'\s([A-Za-z0-9$#_]+)\.(([A-Za-z0-9$#_]|\.)+)$',subexpression => 2);
+      l_owner       := regexp_substr(l_caller_stack_line,'([A-Za-z0-9$#_]+)\.([A-Za-z0-9$#_]|\.)+',subexpression => 1);
+      l_object_name := regexp_substr(l_caller_stack_line,'([A-Za-z0-9$#_]+)\.(([A-Za-z0-9$#_]|\.)+)',subexpression => 2);
     end if;
     return
       case when l_owner is not null and l_object_name is not null and l_line_no is not null then

--- a/source/core/ut_expectation_processor.pkb
+++ b/source/core/ut_expectation_processor.pkb
@@ -129,9 +129,9 @@ create or replace package body ut_expectation_processor as
     l_object_name                varchar2(1000);   
     -- in 12.2 format_call_stack reportes not only package name, but also the procedure name
     -- when 11g and 12c reports only package name
-    c_expectation_search_pattern constant varchar2(500) := '(.*\.UT_EXPECTATION_RESULT\s+)(.*\.UT_EXPECTATION[A-Z0-9#_$]*(\.[A-Za-z0-9$#_]+)?.*\s+)+(.*)\s';
+    c_expectation_search_pattern constant varchar2(500) := '(.*\.UT_EXPECTATION_RESULT\s+)(.*\.UT_EXPECTATION[A-Z0-9#_$]*(\.[A-Za-z0-9$#_]+)?.*\s+)+(.*UT\.FAIL\s+)?(.*)\s';
   begin
-    l_caller_stack_line    := regexp_substr( c_call_stack, c_expectation_search_pattern, 1, 1, 'm', 4);
+    l_caller_stack_line    := regexp_substr( c_call_stack, c_expectation_search_pattern, 1, 1, 'm', 5);
     l_line_no              := to_number( regexp_substr(l_caller_stack_line,'^\dx[0-9a-f]+\s+(\d+)',subexpression => 1) );
     l_caller_type_and_name    := substr( l_caller_stack_line, 23 );
     if l_caller_stack_line like '%.%' then

--- a/source/core/ut_expectation_processor.pkb
+++ b/source/core/ut_expectation_processor.pkb
@@ -129,9 +129,10 @@ create or replace package body ut_expectation_processor as
     l_object_name                varchar2(1000);   
     -- in 12.2 format_call_stack reportes not only package name, but also the procedure name
     -- when 11g and 12c reports only package name
-    c_expectation_search_pattern constant varchar2(500) := '(.*\.UT_EXPECTATION_RESULT\s+)(.*\.UT_EXPECTATION[A-Z0-9#_$]*(\.[A-Za-z0-9$#_]+)?.*\s+)+(.*\.UT(\.FAIL)?\s+)?(.*)\s';
+    c_expectation_search_pattern constant varchar2(500) := 
+    '(.*\.UT_EXPECTATION_RESULT\s+)(.*\.UT_EXPECTATION[A-Z0-9#_$]*(\.[A-Za-z0-9$#_]+)?.*?)+(.*\.UT(\.FAIL)?\s+)?(.*\.UTASSERT2?(\.[A-Za-z0-9$#_]+)?.*?$\s+)*(.*?$)';
   begin
-    l_caller_stack_line    := regexp_substr( c_call_stack, c_expectation_search_pattern, 1, 1, 'm', 6);
+    l_caller_stack_line    := regexp_substr( c_call_stack, c_expectation_search_pattern, 1, 1, 'mn', 8);
     l_line_no              := to_number( regexp_substr(l_caller_stack_line,'^\dx[0-9a-f]+\s+(\d+)',subexpression => 1) );
     l_caller_type_and_name    := substr( l_caller_stack_line, 23 );
     if l_caller_stack_line like '%.%' then

--- a/source/core/ut_expectation_processor.pkb
+++ b/source/core/ut_expectation_processor.pkb
@@ -130,7 +130,7 @@ create or replace package body ut_expectation_processor as
     -- in 12.2 format_call_stack reportes not only package name, but also the procedure name
     -- when 11g and 12c reports only package name
     c_expectation_search_pattern constant varchar2(500) := 
-    '(^.*\.(UT_EXPECTATION[A-Z0-9#_$]*|UT|UTASSERT2?)(\.[A-Z0-9#_$]+)?$\s)+(.*)';
+    '(.*\.(UT_EXPECTATION[A-Z0-9#_$]*|UT|UTASSERT2?)(\.[A-Z0-9#_$]+)?\s+)+(.*)';
   begin
     dbms_output.put_line(c_call_stack);
     l_caller_stack_line    := regexp_substr( c_call_stack, c_expectation_search_pattern, 1, 1, 'm', 4);

--- a/source/core/ut_expectation_processor.pkb
+++ b/source/core/ut_expectation_processor.pkb
@@ -129,9 +129,9 @@ create or replace package body ut_expectation_processor as
     l_object_name                varchar2(1000);   
     -- in 12.2 format_call_stack reportes not only package name, but also the procedure name
     -- when 11g and 12c reports only package name
-    c_expectation_search_pattern constant varchar2(500) := '(.*\.UT_EXPECTATION_RESULT\s+)(.*\.UT_EXPECTATION[A-Z0-9#_$]*(\.[A-Za-z0-9$#_]+)?.*\s+)+(.*UT\.FAIL\s+)?(.*)\s';
+    c_expectation_search_pattern constant varchar2(500) := '(.*\.UT_EXPECTATION_RESULT\s+)(.*\.UT_EXPECTATION[A-Z0-9#_$]*(\.[A-Za-z0-9$#_]+)?.*\s+)+(.*\.UT(\.FAIL)?\s+)?(.*)\s';
   begin
-    l_caller_stack_line    := regexp_substr( c_call_stack, c_expectation_search_pattern, 1, 1, 'm', 5);
+    l_caller_stack_line    := regexp_substr( c_call_stack, c_expectation_search_pattern, 1, 1, 'm', 6);
     l_line_no              := to_number( regexp_substr(l_caller_stack_line,'^\dx[0-9a-f]+\s+(\d+)',subexpression => 1) );
     l_caller_type_and_name    := substr( l_caller_stack_line, 23 );
     if l_caller_stack_line like '%.%' then

--- a/source/core/ut_expectation_processor.pkb
+++ b/source/core/ut_expectation_processor.pkb
@@ -130,9 +130,9 @@ create or replace package body ut_expectation_processor as
     -- in 12.2 format_call_stack reportes not only package name, but also the procedure name
     -- when 11g and 12c reports only package name
     c_expectation_search_pattern constant varchar2(500) := 
-    '(.*\.UT_EXPECTATION_RESULT\s+)(.*\.UT_EXPECTATION[A-Z0-9#_$]*(\.[A-Za-z0-9$#_]+)?.*?)+(.*\.UT(\.FAIL)?\s+)?(.*\.UTASSERT2?(\.[A-Za-z0-9$#_]+)?.*?$\s+)*(.*?$)';
+    '(^.*\.((UT_EXPECTATION[A-Z0-9#_$]*)|(UT)|(UTASSERT2?))(\.[A-Z0-9#_$]+)?$\s)+\s*(.*)';
   begin
-    l_caller_stack_line    := regexp_substr( c_call_stack, c_expectation_search_pattern, 1, 1, 'mn', 8);
+    l_caller_stack_line    := regexp_substr( c_call_stack, c_expectation_search_pattern, 1, 1, 'm', 7);
     l_line_no              := to_number( regexp_substr(l_caller_stack_line,'^\dx[0-9a-f]+\s+(\d+)',subexpression => 1) );
     l_caller_type_and_name    := substr( l_caller_stack_line, 23 );
     if l_caller_stack_line like '%.%' then

--- a/source/core/ut_expectation_processor.pkb
+++ b/source/core/ut_expectation_processor.pkb
@@ -132,7 +132,6 @@ create or replace package body ut_expectation_processor as
     c_expectation_search_pattern constant varchar2(500) := 
     '(.*\.(UT_EXPECTATION[A-Z0-9#_$]*|UT|UTASSERT2?)(\.[A-Z0-9#_$]+)?\s+)+(.*)';
   begin
-    dbms_output.put_line(c_call_stack);
     l_caller_stack_line    := regexp_substr( c_call_stack, c_expectation_search_pattern, 1, 1, 'm', 4);
     l_line_no              := to_number( regexp_substr(l_caller_stack_line,'0x[0-9a-f]+\s+(\d+)',subexpression => 1) );
     l_caller_type_and_name    := trim(regexp_substr(l_caller_stack_line,'0x[0-9a-f]+\s+\d+\s+(.+)',subexpression => 1));

--- a/tests/RunAll.sql
+++ b/tests/RunAll.sql
@@ -101,6 +101,8 @@ exec ut_coverage.coverage_start_develop();
 @@lib/RunTest.sql ut_expectations/ut.expect.to_match.FailsForUnsupportedDatatype.sql
 @@lib/RunTest.sql ut_expectations/ut_data_value_object.compare.Gives0WhenComparingIdenticalObjects.sql
 @@lib/RunTest.sql ut_expectations/ut_expectation_processor.nulls_are_equal.raisesExceptionWhenTryingToSetNullValue.sql
+@@lib/RunTest.sql ut_expectations/ut_expectation_processor.stackOnFailedTest.sql
+@@lib/RunTest.sql ut_expectations/ut_expectation_processor.stackOnUtFail.sql
 
 @@ut_matchers/be_between.sql
 @@ut_matchers/be_empty.sql

--- a/tests/ut_expectations/ut_expectation_processor.stackOnFailedTest.sql
+++ b/tests/ut_expectations/ut_expectation_processor.stackOnFailedTest.sql
@@ -1,0 +1,41 @@
+set termout off
+create or replace package tst_stack_on_failed_test as
+  --%suite
+
+  --%test
+  procedure test;
+end;
+/
+
+create or replace package body tst_stack_on_failed_test as
+  procedure test is begin ut.expect(1).to_equal(2); end;
+end;
+/
+
+set termout on
+
+declare
+  l_test_report ut_varchar2_list;
+  l_output_data       ut_varchar2_list;
+  l_output            varchar2(32767);
+  l_expected          varchar2(32767);
+begin
+  l_expected := q'[%Failures:%at "UT3.TST_STACK_ON_FAIL%", line 2%]';
+
+  --act
+  select *
+  bulk collect into l_output_data
+  from table(ut.run('tst_stack_on_failed_test',ut_documentation_reporter()));
+
+  l_output := ut_utils.table_to_clob(l_output_data);
+
+  --assert
+  if l_output like l_expected then
+    :test_result := ut_utils.tr_success;
+  else
+    dbms_output.put_line('Actual:"'||l_output||'"');
+  end if;
+end;
+/
+
+drop package tst_stack_on_failed_test;

--- a/tests/ut_expectations/ut_expectation_processor.stackOnUtFail.sql
+++ b/tests/ut_expectations/ut_expectation_processor.stackOnUtFail.sql
@@ -1,0 +1,41 @@
+set termout off
+create or replace package tst_stack_on_fail as
+  --%suite
+
+  --%test
+  procedure test;
+end;
+/
+
+create or replace package body tst_stack_on_fail as
+  procedure test is begin ut.fail('test failure'); end;
+end;
+/
+
+set termout on
+
+declare
+  l_test_report ut_varchar2_list;
+  l_output_data       ut_varchar2_list;
+  l_output            varchar2(32767);
+  l_expected          varchar2(32767);
+begin
+  l_expected := q'[%Failures:%at "UT3.TST_STACK_ON_FAIL%", line 2%]';
+
+  --act
+  select *
+  bulk collect into l_output_data
+  from table(ut.run('tst_stack_on_fail',ut_documentation_reporter()));
+
+  l_output := ut_utils.table_to_clob(l_output_data);
+
+  --assert
+  if l_output like l_expected then
+    :test_result := ut_utils.tr_success;
+  else
+    dbms_output.put_line('Actual:"'||l_output||'"');
+  end if;
+end;
+/
+
+drop package tst_stack_on_fail;


### PR DESCRIPTION
Fixed stack parsing when test failed with `ut.fail`  or by broken expectation
Address #378 