### PR TITLE
Added override user/password/tablespace for install_headless

### DIFF
--- a/source/create_utplsql_owner.sql
+++ b/source/create_utplsql_owner.sql
@@ -25,6 +25,8 @@ define ut3_user       = &1
 define ut3_password   = &2
 define ut3_tablespace = &3
 
+prompt Creating utPLSQL user &&ut3_user
+
 create user &ut3_user identified by &ut3_password default tablespace &ut3_tablespace quota unlimited on &ut3_tablespace;
 
 grant create session, create sequence, create procedure, create type, create table, create view, create synonym to &ut3_user;

--- a/source/install.sql
+++ b/source/install.sql
@@ -20,7 +20,7 @@
 spool install.log
 
 prompt &&line_separator
-prompt Installing utPLSQL v3 framework
+prompt Installing utPLSQL v3 framework into &&ut3_owner schema
 prompt &&line_separator
 
 whenever sqlerror exit failure rollback

--- a/source/install_headless.sql
+++ b/source/install_headless.sql
@@ -14,9 +14,25 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
-define ut3_owner      = ut3
-define ut3_password   = XNtxj8eEgA6X6b6f
-define ut3_tablespace = users
+set echo off
+set verify off
+column 1 new_value 1 noprint
+column 2 new_value 2 noprint
+column 3 new_value 3 noprint
+select null as "1", null as "2" , null as "3" from dual where 1=0;
+column sep new_value sep noprint
+select '--------------------------------------------------------------' as sep from dual;
+
+spool params.sql.tmp
+
+column ut3_owner      new_value ut3_owner      noprint
+column ut3_password   new_value ut3_password   noprint
+column ut3_tablespace new_value ut3_tablespace noprint
+
+select coalesce('&&1','UT3') ut3_owner,
+  coalesce('&&2','XNtxj8eEgA6X6b6f') ut3_password,
+  coalesce('&&3','users') ut3_tablespace from dual;
+
 
 @@create_utplsql_owner.sql &&ut3_owner &&ut3_password &&ut3_tablespace
 @@install.sql &&ut3_owner


### PR DESCRIPTION
This is change allows us to easily install two versions of utPLSQL v3 side by side using headless install.
We can now install develop version into `ut3_develop` and official release into `ut3` schema.
That should open doors for self-testing of utPLSQL v3 using previously released version.