### PR TITLE
Resolves #374

### DIFF
--- a/source/core/types/ut_logical_suite.tpb
+++ b/source/core/types/ut_logical_suite.tpb
@@ -62,23 +62,13 @@ create or replace type body ut_logical_suite as
     a_listener.fire_before_event(ut_utils.gc_suite,self);
     self.start_time := current_timestamp;
 
-    if self.get_disabled_flag() then
-      self.result := ut_utils.tr_disabled;
-      self.end_time := self.start_time;
-      ut_utils.debug_log('ut_logical_suite.execute - disabled');
-    else
+    for i in 1 .. self.items.count loop
+      -- execute the item (test or suite)
+      self.items(i).do_execute(a_listener);
+    end loop;
 
-      self.start_time := current_timestamp;
-
-      for i in 1 .. self.items.count loop
-        -- execute the item (test or suite)
-        self.items(i).do_execute(a_listener);
-      end loop;
-
-      self.calc_execution_result();
-      self.end_time := current_timestamp;
-
-    end if;
+    self.calc_execution_result();
+    self.end_time := current_timestamp;
 
     a_listener.fire_after_event(ut_utils.gc_suite,self);
 

--- a/source/core/types/ut_suite.tpb
+++ b/source/core/types/ut_suite.tpb
@@ -57,8 +57,9 @@ create or replace type body ut_suite  as
     self.start_time := current_timestamp;
 
     if self.get_disabled_flag() then
-      self.result := ut_utils.tr_disabled;
-      self.end_time := self.start_time;
+      for i in 1 .. self.items.count loop
+        self.items(i).do_execute(a_listener);
+      end loop;
       ut_utils.debug_log('ut_suite.execute - disabled');
     else
 
@@ -87,11 +88,9 @@ create or replace type body ut_suite  as
       else
         propagate_error(ut_utils.table_to_clob(self.get_error_stack_traces()));
       end if;
-
-      self.calc_execution_result();
-      self.end_time := current_timestamp;
-
     end if;
+    self.calc_execution_result();
+    self.end_time := current_timestamp;
     a_listener.fire_after_event(ut_utils.gc_suite,self);
 
     return l_suite_step_without_errors;

--- a/source/core/ut_suite_manager.pkb
+++ b/source/core/ut_suite_manager.pkb
@@ -176,7 +176,7 @@ create or replace package body ut_suite_manager is
                              ,a_description           => l_displayname
                              ,a_path                  => l_suite.path || '.' || l_proc_name
                              ,a_rollback_type         => l_rollback_type
-                             ,a_disabled_flag         => l_proc_annotations.exists('disabled')
+                             ,a_disabled_flag         => l_annotation_data.package_annotations.exists('disabled') or l_proc_annotations.exists('disabled')
                              ,a_before_test_proc_name => l_beforetest_procedure
                              ,a_after_test_proc_name  => l_aftertest_procedure
                              ,a_before_each_proc_name => l_default_setup_proc
@@ -416,8 +416,6 @@ create or replace package body ut_suite_manager is
       l_item_name   varchar2(32767);
 
     begin
-      a_suite.set_disabled_flag(false);
-
       if a_path is not null and a_suite is not null and a_suite is of (ut_logical_suite) then
         l_suite := treat(a_suite as ut_logical_suite);
 


### PR DESCRIPTION
The `--%disabled` annotation was ignoring a suite instead of reporting all the tests from the suite as (IGNORED).
This is now resolved by:
 - Propagating the disabled flag each child item (at build stage)
 - Processing each child item and evaluating the disabled flag (at execute stage)