### PR TITLE
Resolves issues with stacktrace not getting parsed

### DIFF
--- a/source/core/types/ut_expectation_result.tpb
+++ b/source/core/types/ut_expectation_result.tpb
@@ -23,7 +23,7 @@ create or replace type body ut_expectation_result is
     self.description     := a_description;
     self.message := a_message;
     if self.status = ut_utils.tr_failure then
-      self.caller_info   := ut_expectation_processor.who_called_expectation();
+      self.caller_info   := ut_expectation_processor.who_called_expectation(dbms_utility.format_call_stack());
     end if;
     return;
   end;

--- a/source/core/ut_expectation_processor.pks
+++ b/source/core/ut_expectation_processor.pks
@@ -44,7 +44,7 @@ create or replace package ut_expectation_processor authid current_user as
   -- if found, it returns a text:
   --   at: owner.name:line "source code line text"
   -- The text is to be consumed by expectation result
-  function who_called_expectation return varchar2;
+  function who_called_expectation(a_call_stack varchar2) return varchar2;
 
 end;
 /

--- a/tests/RunAll.sql
+++ b/tests/RunAll.sql
@@ -48,6 +48,8 @@ exec ut_coverage.coverage_start_develop();
 @@lib/RunTest.sql ut_annotations/ut_annotations.parse_package_annotations.ParsePackageLevelAnnotationWithKeyValue.sql
 @@lib/RunTest.sql ut_annotations/ut_annotations.parse_package_annotations.ParsePackageLevelAnnotationWithMultilineComment.sql
 @@lib/RunTest.sql ut_annotations/ut_annotations.parse_package_annotations.spaceBeforeAnnotationParams.sql
+@@lib/RunTest.sql ut_expectation_processor/who_called_expectation.parseStackTrace.sql
+@@lib/RunTest.sql ut_expectation_processor/who_called_expectation.parseStackTraceWith0x.sql
 @@ut_expectations/ut.expect.not_to_be_null.sql
 @@lib/RunTest.sql ut_expectations/ut.expect.to_be_false.GivesFailureWhenExpessionIsNotBoolean.sql
 @@lib/RunTest.sql ut_expectations/ut.expect.to_be_false.GivesFailureWhenExpessionIsNull.sql

--- a/tests/ut_expectation_processor/who_called_expectation.parseStackTrace.sql
+++ b/tests/ut_expectation_processor/who_called_expectation.parseStackTrace.sql
@@ -1,0 +1,34 @@
+declare
+  l_stack_trace varchar2(4000);
+  l_source_line varchar2(4000);
+begin
+l_stack_trace := q'[----- PL/SQL Call Stack -----
+  object      line  object
+  handle    number  name
+34f88e4420       124  package body SCH_TEST.UT_EXPECTATION_PROCESSOR
+353dfeb2f8        26  SCH_TEST.UT_EXPECTATION_RESULT
+cba249ce0       112  SCH_TEST.UT_EXPECTATION
+3539881cf0        21  SCH_TEST.UT_EXPECTATION_NUMBER
+351a608008        28  package body SCH_TEST.TPKG_PRIOR_YEAR_GENERATION
+351a6862b8         6  anonymous block
+351fe31010      1825  package body SYS.DBMS_SQL
+20befbe4d8       129  SCH_TEST.UT_EXECUTABLE
+20befbe4d8        65  SCH_TEST.UT_EXECUTABLE
+34f8ab7cd8        80  SCH_TEST.UT_TEST
+34f8ab98f0        48  SCH_TEST.UT_SUITE_ITEM
+34f8ab9b10        74  SCH_TEST.UT_SUITE
+34f8ab98f0        48  SCH_TEST.UT_SUITE_ITEM
+cba24bfd0        75  SCH_TEST.UT_LOGICAL_SUITE
+353dfecf30        59  SCH_TEST.UT_RUN
+34f8ab98f0        48  SCH_TEST.UT_SUITE_ITEM
+357f5421e8        77  package body SCH_TEST.UT_RUNNER
+357f5421e8       111  package body SCH_TEST.UT_RUNNER
+20be951ab0       292  package body SCH_TEST.UT
+20be951ab0       320  package body SCH_TEST.UT
+]';
+  l_source_line := ut_expectation_processor.WHO_CALLED_EXPECTATION(l_stack_trace);
+  if l_source_line like 'at "SCH_TEST.TPKG_PRIOR_YEAR_GENERATION", line 28 %' then
+    :test_result := ut_utils.tr_success;
+  end if;
+end;
+/

--- a/tests/ut_expectation_processor/who_called_expectation.parseStackTraceWith0x.sql
+++ b/tests/ut_expectation_processor/who_called_expectation.parseStackTraceWith0x.sql
@@ -1,0 +1,28 @@
+declare
+  l_stack_trace varchar2(4000);
+  l_source_line varchar2(4000);
+begin
+l_stack_trace := q'[----- PL/SQL Call Stack -----
+  object      line  object
+  handle    number  name
+0x80e701d8        26  UT3.UT_EXPECTATION_RESULT
+0x85e10150       112  UT3.UT_EXPECTATION
+0x8b54bad8        21  UT3.UT_EXPECTATION_NUMBER
+0x85cfd238        20  package body UT3.UT_EXAMPLETEST
+0x85def380         6  anonymous block
+0x85e93750      1825  package body SYS.DBMS_SQL
+0x80f4f608       129  UT3.UT_EXECUTABLE
+0x80f4f608        65  UT3.UT_EXECUTABLE
+0x8a116010        76  UT3.UT_TEST
+0x8a3348a0        48  UT3.UT_SUITE_ITEM
+0x887e9948        67  UT3.UT_LOGICAL_SUITE
+0x8a26de20        59  UT3.UT_RUN
+0x8a3348a0        48  UT3.UT_SUITE_ITEM
+0x838d17c0        28  anonymous block
+]';
+  l_source_line := ut_expectation_processor.WHO_CALLED_EXPECTATION(l_stack_trace);
+  if l_source_line like 'at "UT3.UT_EXAMPLETEST", line 20 %' then
+    :test_result := ut_utils.tr_success;
+  end if;
+end;
+/


### PR DESCRIPTION
The `who_called_expectation` is now more relaxed on the stacktrace format.
Resolves #401
