### PR TITLE
Changed data-type used for schema_names filtering.

### DIFF
--- a/source/api/ut_runner.pkb
+++ b/source/api/ut_runner.pkb
@@ -57,7 +57,6 @@ create or replace package body ut_runner is
   ) is
     l_items_to_run  ut_run;
     l_listener      ut_event_listener;
-    l_coverage_options ut_coverage_options;
   begin
     ut_output_buffer.cleanup_buffer();
 
@@ -67,13 +66,15 @@ create or replace package body ut_runner is
     else
       l_listener := ut_event_listener(a_reporters);
     end if;
-    l_coverage_options := ut_coverage_options(
-      schema_names    => a_coverage_schemes,
-      exclude_objects => to_ut_object_list(a_exclude_objects),
-      include_objects => to_ut_object_list(a_include_objects),
-      file_mappings   => set(a_source_file_mappings)
+    l_items_to_run := ut_run(
+      ut_suite_manager.configure_execution_by_path(a_paths),
+      a_paths,
+      ut_utils.convert_collection(a_coverage_schemes),
+      to_ut_object_list(a_exclude_objects),
+      to_ut_object_list(a_include_objects),
+      set(a_source_file_mappings),
+      set(a_test_file_mappings)
     );
-    l_items_to_run := ut_run( ut_suite_manager.configure_execution_by_path(a_paths), a_paths, l_coverage_options, set(a_test_file_mappings) );
     l_items_to_run.do_execute(l_listener);
 
     cleanup_temp_tables;

--- a/source/core/coverage/ut_coverage.pkb
+++ b/source/core/coverage/ut_coverage.pkb
@@ -149,10 +149,10 @@ create or replace package body ut_coverage is
     type t_source_lines is table of binary_integer;
     l_source_lines     t_source_lines;
     line_no            binary_integer;
-    l_schema_names     ut_varchar2_list;
+    l_schema_names     ut_varchar2_rows;
     l_query            varchar2(32767);
   begin
-    l_schema_names := coalesce(a_coverage_options.schema_names, ut_varchar2_list(sys_context('USERENV','CURRENT_SCHEMA')));
+    l_schema_names := coalesce(a_coverage_options.schema_names, ut_varchar2_rows(sys_context('USERENV','CURRENT_SCHEMA')));
 
     if not ut_coverage_helper.is_develop_mode() then
       --skip all the utplsql framework objects and all the unit test packages that could potentially be reported by coverage.

--- a/source/core/coverage/ut_coverage_reporter_base.tpb
+++ b/source/core/coverage/ut_coverage_reporter_base.tpb
@@ -17,7 +17,6 @@ create or replace type body ut_coverage_reporter_base is
   */
 
   overriding final member procedure before_calling_run(self in out nocopy ut_coverage_reporter_base, a_run ut_run) as
-    l_schema_names ut_varchar2_list := a_run.get_run_schemes();
   begin
     (self as ut_reporter_base).before_calling_run(a_run);
     ut_coverage.coverage_start();

--- a/source/core/types/ut_coverage_options.tps
+++ b/source/core/types/ut_coverage_options.tps
@@ -16,7 +16,7 @@ create or replace type ut_coverage_options as object (
   limitations under the License.
   */
 
-  schema_names     ut_varchar2_list,
+  schema_names     ut_varchar2_rows,
   exclude_objects  ut_object_names,
   include_objects  ut_object_names,
   file_mappings    ut_file_mappings

--- a/source/core/types/ut_run.tps
+++ b/source/core/types/ut_run.tps
@@ -24,13 +24,19 @@ create or replace type ut_run under ut_suite_item (
   coverage_options               ut_coverage_options,
   test_file_mappings             ut_file_mappings,
   constructor function ut_run(
-    self in out nocopy ut_run, a_items ut_suite_items, a_run_paths ut_varchar2_list := null,
-    a_coverage_options ut_coverage_options := null, a_test_file_mappings ut_file_mappings := null
+    self in out nocopy ut_run,
+    a_items                 ut_suite_items,
+    a_run_paths             ut_varchar2_list := null,
+    a_schema_names          ut_varchar2_rows := null,
+    a_exclude_objects       ut_object_names := null,
+    a_include_objects       ut_object_names := null,
+    a_project_file_mappings ut_file_mappings := null,
+    a_test_file_mappings    ut_file_mappings := null
   ) return self as result,
   overriding member function  do_execute(self in out nocopy ut_run, a_listener in out nocopy ut_event_listener_base) return boolean,
   overriding member procedure calc_execution_result(self in out nocopy ut_run),
   overriding member procedure mark_as_errored(self in out nocopy ut_run, a_listener in out nocopy ut_event_listener_base, a_error_stack_trace varchar2),
-  member function get_run_schemes return ut_varchar2_list,
+  member function get_run_schemes return ut_varchar2_rows,
   overriding member function get_error_stack_traces return ut_varchar2_list,
   overriding member function get_serveroutputs return clob
 )

--- a/source/core/ut_output_buffer.pkb
+++ b/source/core/ut_output_buffer.pkb
@@ -17,12 +17,12 @@ create or replace package body ut_output_buffer is
   */
 
   procedure send_line(a_reporter ut_reporter_base, a_text varchar2) is
-    l_text_list  ut_varchar2_list;
+    l_text_list  ut_varchar2_rows;
     pragma autonomous_transaction;
   begin
     if a_reporter is not null and a_reporter.reporter_id is not null and a_reporter.start_date is not null and a_text is not null then
       if length(a_text) > ut_utils.gc_max_storage_varchar2_len then
-        l_text_list := ut_utils.clob_to_table(a_text, ut_utils.gc_max_storage_varchar2_len);
+        l_text_list := ut_utils.convert_collection(ut_utils.clob_to_table(a_text, ut_utils.gc_max_storage_varchar2_len));
         insert /*+ append */
           into ut_output_buffer_tmp(start_date, reporter_id, message_id, text)
         select a_reporter.start_date, a_reporter.reporter_id, ut_message_id_seq.nextval, t.column_value

--- a/source/core/ut_suite_manager.pkb
+++ b/source/core/ut_suite_manager.pkb
@@ -340,7 +340,7 @@ create or replace package body ut_suite_manager is
     end if;
   end get_schema_suites;
 
-  function get_schema_ut_packages(a_schema_names ut_varchar2_list) return ut_object_names is
+  function get_schema_ut_packages(a_schema_names ut_varchar2_rows) return ut_object_names is
     l_schema_ut_packages ut_object_names := ut_object_names();
     l_schema_suites      tt_schema_suites;
     l_iter               varchar2(4000);

--- a/source/core/ut_suite_manager.pks
+++ b/source/core/ut_suite_manager.pks
@@ -20,7 +20,7 @@ create or replace package ut_suite_manager authid current_user is
 
   procedure config_schema(a_owner_name varchar2);
 
-  function get_schema_ut_packages(a_schema_names ut_varchar2_list) return ut_object_names;
+  function get_schema_ut_packages(a_schema_names ut_varchar2_rows) return ut_object_names;
 
   --INTERNAL USE
   function configure_execution_by_path(a_paths in ut_varchar2_list) return ut_suite_items;

--- a/source/core/ut_utils.pkb
+++ b/source/core/ut_utils.pkb
@@ -328,5 +328,18 @@ create or replace package body ut_utils is
     end if;
   end;
 
+  function convert_collection(a_collection ut_varchar2_list) return ut_varchar2_rows is
+    l_result ut_varchar2_rows;
+  begin
+    if a_collection is not null then
+      l_result := ut_varchar2_rows();
+      for i in 1 .. a_collection.count loop
+        l_result.extend();
+        l_result(i) := substr(a_collection(i),1,gc_max_storage_varchar2_len);
+      end loop;
+    end if;
+    return l_result;
+  end;
+
 end ut_utils;
 /

--- a/source/core/ut_utils.pks
+++ b/source/core/ut_utils.pks
@@ -177,7 +177,7 @@ create or replace package ut_utils authid definer is
         ut_varchar2_list - table of string
 
    Splits a given string into table of string by delimiter.
-   Default value of a_max_amount is 8191 because of code can contains multibyte character. 
+   Default value of a_max_amount is 8191 because of code can contains multibyte character.
    The delimiter gets removed.
    If null passed as any of the parameters, empty table is returned.
    If split text is longer than a_max_amount it gets split into pieces of a_max_amount.
@@ -211,6 +211,8 @@ create or replace package ut_utils authid definer is
 
   procedure append_to_clob(a_src_clob in out nocopy clob, a_new_data clob);
   procedure append_to_clob(a_src_clob in out nocopy clob, a_new_data varchar2);
+
+  function convert_collection(a_collection ut_varchar2_list) return ut_varchar2_rows;
 
 end ut_utils;
 /

--- a/tests/RunAll.sql
+++ b/tests/RunAll.sql
@@ -502,7 +502,7 @@ begin
     'source/reporters/ut_xunit_reporter.tpb',
     'source/reporters/ut_xunit_reporter.tps');
 
-  l_test_run := ut_run(ut_suite_items(), null, ut_coverage_options(null,null,null,ut_file_mapper.build_file_mappings( user,l_project_file_list)));
+  l_test_run := ut_run(a_items => ut_suite_items(), a_project_file_mappings => ut_file_mapper.build_file_mappings( user,l_project_file_list));
 
   --run for the first time to gather coverage and timings on reporters too
   l_reporter := ut_coverage_html_reporter(a_project_name => 'utPLSQL v3');

--- a/tests/ut_suite_manager/ut_suite_manager.get_schema_ut_packages.IncludesPackagesWithSutePath.sql
+++ b/tests/ut_suite_manager/ut_suite_manager.get_schema_ut_packages.IncludesPackagesWithSutePath.sql
@@ -16,7 +16,7 @@ begin
     ut_object_name(user,'TEST_REPORTERS_1'),
     ut_object_name(user,'TEST_REPORTERS')
   );
-  l_actual := ut_suite_manager.get_schema_ut_packages(ut_varchar2_list(user));
+  l_actual := ut_suite_manager.get_schema_ut_packages(ut_varchar2_rows(user));
   if l_actual = l_expected then
     :test_result := ut_utils.tr_success;
   else


### PR DESCRIPTION
Resolves #368
Refactored ut_runner and ut_run, so that the ut_coverage_options are built in ut_run.
The previous implementation was confusing.
Changed data-type of send_line to avoid similar issue.