### PR TITLE
Feature/dba views if accessible

### DIFF
--- a/source/core/coverage/ut_coverage.pkb
+++ b/source/core/coverage/ut_coverage.pkb
@@ -31,6 +31,7 @@ create or replace package body ut_coverage is
   function get_populate_sources_tmp_sql(a_coverage_options ut_coverage_options) return varchar2 is
     l_result varchar2(32767);
     l_full_name varchar2(100);
+    l_view_name      varchar2(200) := ut_metadata.get_dba_view('dba_source');
   begin
     if a_coverage_options.file_mappings is not null and a_coverage_options.file_mappings.count > 0 then
       l_full_name := 'f.file_name';
@@ -48,7 +49,7 @@ create or replace package body ut_coverage is
                  coalesce(
                    case when type!='TRIGGER' then 0 end,
                    (select min(t.line) - 1
-                      from all_source t
+                      from ]'||l_view_name||q'[ t
                      where t.owner = s.owner and t.type = s.type and t.name = s.name
                        and regexp_like( t.text, '[A-Za-z0-9$#_]*(begin|declare|compound).*','i'))
                  ) as line,
@@ -69,7 +70,7 @@ create or replace package body ut_coverage is
                      )
                     then 'Y'
                  end as to_be_skipped
-            from all_source s]';
+            from ]'||l_view_name||q'[ s]';
     if a_coverage_options.file_mappings is not null and a_coverage_options.file_mappings.count > 0 then
       l_result := l_result || '
             join table(:file_mappings) f

--- a/source/core/ut_metadata.pks
+++ b/source/core/ut_metadata.pks
@@ -79,5 +79,12 @@ create or replace package ut_metadata authid current_user as
   */
   function get_source_definition_line(a_owner varchar2, a_object_name varchar2, a_line_no integer) return varchar2;
 
+  /*
+    function: get_dba_view
+
+    return the dba_xxx view name if it is accessible or all_xxx view otherwise
+  */
+  function get_dba_view(a_view_name varchar2) return varchar2;
+
 end ut_metadata;
 /

--- a/source/core/ut_suite_manager.pkb
+++ b/source/core/ut_suite_manager.pkb
@@ -34,12 +34,14 @@ create or replace package body ut_suite_manager is
 
   function get_schema_info(a_owner_name varchar2) return t_schema_info is
     l_info t_schema_info;
+    l_view_name      varchar2(200) := ut_metadata.get_dba_view('all_objects');
   begin
+    execute immediate q'[
     select nvl(max(t.last_ddl_time), date '4999-12-31'), count(*)
-      into l_info
-      from all_objects t
-     where t.owner = a_owner_name
-       and t.object_type in ('PACKAGE');
+      from ]'||l_view_name||q'[ t
+     where t.owner = :a_owner_name
+       and t.object_type in ('PACKAGE')]'
+    into l_info using a_owner_name;
     return l_info;
   end;
 
@@ -206,6 +208,15 @@ create or replace package body ut_suite_manager is
     l_root       varchar2(4000 char);
     l_root_suite ut_logical_suite;
 
+    type t_object_name is record(
+      owner all_objects.owner%type,
+      object_name all_objects.object_name%type
+    );
+    type t_object_names is table of t_object_name;
+
+    l_object_names t_object_names;
+    l_view_name      varchar2(200) := ut_metadata.get_dba_view('dba_objects');
+
     l_schema_suites tt_schema_suites;
 
     procedure put(a_root_suite in out nocopy ut_logical_suite, a_path varchar2, a_suite ut_logical_suite, a_parent_path varchar2 default null) is
@@ -270,14 +281,13 @@ create or replace package body ut_suite_manager is
 
   begin
     -- form the single-dimension list of suites constructed from parsed packages
-    for rec in (select t.owner
-                      ,t.object_name
-                  from all_objects t
-                 where t.owner = a_owner_name
-                   and t.status = 'VALID' -- scan only valid specifications
-                   and t.object_type in ('PACKAGE')) loop
+    execute immediate
+      'select t.owner, t.object_name from '||l_view_name||' t '
+      ||q'[ where t.owner = :a_owner_name and t.status = 'VALID' and t.object_type in ('PACKAGE')]'
+      bulk collect into l_object_names using a_owner_name;
+    for i in 1 .. cardinality(l_object_names) loop
       -- parse the source of the package
-      l_suite := config_package(rec.owner, rec.object_name);
+      l_suite := config_package(l_object_names(i).owner, l_object_names(i).object_name);
 
       if l_suite is not null then
         l_all_suites(l_suite.path) := l_suite;


### PR DESCRIPTION
This change is adding few performance improvements:
- cache on source of package, when expectations fail
- usage of dba views if they are available
- explicit fetch of package specification for dbms_preprocessor as the preprocessor is slow on 12.1 and 12.2 when readding source from database.