### PR TITLE
Fix problem with identifying annotations when windows newline is used

### DIFF
--- a/source/core/ut_annotations.pkb
+++ b/source/core/ut_annotations.pkb
@@ -68,7 +68,7 @@ create or replace package body ut_annotations as
       l_comment := a_comments(l_comment_index);
 
       -- strip everything except the annotation itself (spaces and others)
-      l_annotation_str := regexp_substr(trim(translate(l_comment, chr(10)||chr(13), ' ')), c_annotation_pattern, 1, 1, modifier => 'i');
+      l_annotation_str := regexp_substr(l_comment, c_annotation_pattern, 1, 1, modifier => 'i');
       if l_annotation_str is not null then
 
         l_annotation_params.delete;

--- a/source/core/ut_annotations.pkb
+++ b/source/core/ut_annotations.pkb
@@ -68,7 +68,7 @@ create or replace package body ut_annotations as
       l_comment := a_comments(l_comment_index);
 
       -- strip everything except the annotation itself (spaces and others)
-      l_annotation_str := regexp_substr(l_comment, c_annotation_pattern, 1, 1, modifier => 'i');
+      l_annotation_str := regexp_substr(trim(translate(l_comment, chr(10)||chr(13), ' ')), c_annotation_pattern, 1, 1, modifier => 'i');
       if l_annotation_str is not null then
 
         l_annotation_params.delete;

--- a/source/core/ut_metadata.pkb
+++ b/source/core/ut_metadata.pkb
@@ -128,7 +128,7 @@ create or replace package body ut_metadata as
      -- we fetch the source explicitly as dbms_preprocessor is very sow on 12.1 and 12.2 when grabbing the sources.
      l_lines := sys.dbms_preprocessor.get_post_processed_source(l_lines);
      for i in 1..l_lines.count loop
-       ut_utils.append_to_clob(l_source, l_lines(i));
+       ut_utils.append_to_clob(l_source, replace(l_lines(i), chr(13)||chr(10), chr(10)));
      end loop;
     return l_source;
   end;

--- a/tests/RunAll.sql
+++ b/tests/RunAll.sql
@@ -48,7 +48,8 @@ exec ut_coverage.coverage_start_develop();
 @@lib/RunTest.sql ut_annotations/ut_annotations.parse_package_annotations.ParsePackageLevelAnnotationMultilineDeclare.sql
 @@lib/RunTest.sql ut_annotations/ut_annotations.parse_package_annotations.ParsePackageLevelAnnotationWithKeyValue.sql
 @@lib/RunTest.sql ut_annotations/ut_annotations.parse_package_annotations.ParsePackageLevelAnnotationWithMultilineComment.sql
-@@lib/RunTest.sql ut_annotations/ut_annotations.parse_package_annotations.spaceBeforeAnnotationParams.sql
+@@lib/RunTest.sql ut_annotations/ut_annotations.parse_package_annotations.spaceBeforeAnnotationParams.SQL
+@@lib/RunTest.sql ut_annotations/ut_annotations.parse_package_annotations.ParseAnnotationWithWindowsNewline.sql
 @@lib/RunTest.sql ut_expectation_processor/who_called_expectation.parseStackTrace.sql
 @@lib/RunTest.sql ut_expectation_processor/who_called_expectation.parseStackTraceWith0x.sql
 @@ut_expectations/ut.expect.not_to_be_null.sql

--- a/tests/RunAll.sql
+++ b/tests/RunAll.sql
@@ -48,7 +48,7 @@ exec ut_coverage.coverage_start_develop();
 @@lib/RunTest.sql ut_annotations/ut_annotations.parse_package_annotations.ParsePackageLevelAnnotationMultilineDeclare.sql
 @@lib/RunTest.sql ut_annotations/ut_annotations.parse_package_annotations.ParsePackageLevelAnnotationWithKeyValue.sql
 @@lib/RunTest.sql ut_annotations/ut_annotations.parse_package_annotations.ParsePackageLevelAnnotationWithMultilineComment.sql
-@@lib/RunTest.sql ut_annotations/ut_annotations.parse_package_annotations.spaceBeforeAnnotationParams.SQL
+@@lib/RunTest.sql ut_annotations/ut_annotations.parse_package_annotations.spaceBeforeAnnotationParams.sql
 @@lib/RunTest.sql ut_annotations/ut_annotations.parse_package_annotations.ParseAnnotationWithWindowsNewline.sql
 @@lib/RunTest.sql ut_expectation_processor/who_called_expectation.parseStackTrace.sql
 @@lib/RunTest.sql ut_expectation_processor/who_called_expectation.parseStackTraceWith0x.sql

--- a/tests/ut_annotations/ut_annotations.parse_package_annotations.ParseAnnotationWithWindowsNewline.sql
+++ b/tests/ut_annotations/ut_annotations.parse_package_annotations.ParseAnnotationWithWindowsNewline.sql
@@ -1,0 +1,37 @@
+PROMPT Parse package level annotations with windows newline
+
+--Arrange
+declare
+  l_source clob;
+  l_parsing_result ut_annotations.typ_annotated_package;
+  l_expected ut_annotations.typ_annotated_package;
+  l_ann_param ut_annotations.typ_annotation_param;
+
+begin
+  l_source := 'PACKAGE test_tt AS
+  -- %suite
+  -- %displayname(Name of suite)' || chr(13) || chr(10) 
+|| '  -- %suitepath(all.globaltests)
+END;';
+
+--Act
+  l_parsing_result := ut_annotations.parse_package_annotations(l_source);
+
+--Assert
+  l_ann_param := null;
+  l_ann_param.val := 'Name of suite';
+  l_expected.package_annotations('suite').params := cast( null as ut_annotations.tt_annotation_params);
+  l_expected.package_annotations('displayname').params(1) := l_ann_param;
+
+  l_ann_param := null;
+  l_ann_param.val := 'all.globaltests';
+  l_expected.package_annotations('suitepath').params(1) := l_ann_param;
+
+  check_annotation_parsing(l_expected, l_parsing_result);
+
+  if ut_expectation_processor.get_status = ut_utils.tr_success then
+    :test_result := ut_utils.tr_success;
+  end if;
+
+end;
+/


### PR DESCRIPTION
Had this strange behaviour today in a project where I develop on a windows machine using dbForge