### PR TITLE
Package body cache is now invalidated after every test run.

### DIFF
--- a/source/api/ut_runner.pkb
+++ b/source/api/ut_runner.pkb
@@ -49,8 +49,8 @@ create or replace package body ut_runner is
     l_current ut_utils.t_version := ut_utils.to_version(coalesce(a_current,version()));
   begin
     if l_requested.major = l_current.major
-       and (l_requested.minor < l_current.minor
-            or l_requested.minor = l_current.minor and l_requested.bugfix <= l_current.bugfix) then
+       and (l_requested.minor < l_current.minor or l_requested.minor is null
+            or l_requested.minor = l_current.minor and (l_requested.bugfix <= l_current.bugfix or l_requested.bugfix is null)) then
       l_result := true;
     end if;
     return ut_utils.boolean_to_int(l_result);
@@ -86,10 +86,12 @@ create or replace package body ut_runner is
 
       ut_utils.cleanup_temp_tables;
       ut_output_buffer.close(l_listener.reporters);
-    exception
+      ut_metadata.reset_source_definition_cache;
+      exception
       when others then
         ut_utils.cleanup_temp_tables;
         ut_output_buffer.close(l_listener.reporters);
+        ut_metadata.reset_source_definition_cache;
         dbms_output.put_line(dbms_utility.format_error_backtrace);
         dbms_output.put_line(dbms_utility.format_error_stack);
         raise;

--- a/source/core/ut_metadata.pkb
+++ b/source/core/ut_metadata.pkb
@@ -159,6 +159,12 @@ create or replace package body ut_metadata as
     return l_line;
   end;
 
+  procedure reset_source_definition_cache is
+  begin
+    g_source_cache := null;
+    g_cached_object := null;
+  end;
+
   function get_dba_view(a_view_name varchar2) return varchar2 is
     l_invalid_object_name exception;
     l_result              varchar2(128) := lower(a_view_name);
@@ -170,5 +176,6 @@ create or replace package body ut_metadata as
     when l_invalid_object_name then
       return replace(l_result,'dba_','all_');
   end;
+
 end;
 /

--- a/source/core/ut_metadata.pks
+++ b/source/core/ut_metadata.pks
@@ -79,6 +79,9 @@ create or replace package ut_metadata authid current_user as
   */
   function get_source_definition_line(a_owner varchar2, a_object_name varchar2, a_line_no integer) return varchar2;
 
+
+  procedure reset_source_definition_cache;
+
   /*
     function: get_dba_view
 

--- a/test/ut_runner/test_ut_runner.pks
+++ b/test/ut_runner/test_ut_runner.pks
@@ -15,8 +15,8 @@ create or replace package test_ut_runner is
   --%test(version_compatibility_check raises exception when invalid version passed)
   procedure version_comp_check_exception;
 
-  --%test(version_compatibility_check raises exception when invalid version passed)
-  procedure version_comp_check_exception;
+  --%test(run resets cache of package body after every run)
+  procedure run_reset_package_body_cache;
 
 end;
 /


### PR DESCRIPTION
Fixed issues with self-testing.
Fixed issues with version compare for short version numbers.