### PR TITLE
Added buffering of dbms_output before the run.

### DIFF
--- a/source/api/ut_runner.pkb
+++ b/source/api/ut_runner.pkb
@@ -66,6 +66,7 @@ create or replace package body ut_runner is
   begin
     begin
       ut_output_buffer.cleanup_buffer();
+      ut_utils.save_dbms_output_to_cache();
 
       ut_console_reporter_base.set_color_enabled(a_color_console);
       if a_reporters is null or a_reporters.count = 0 then
@@ -87,11 +88,13 @@ create or replace package body ut_runner is
       ut_utils.cleanup_temp_tables;
       ut_output_buffer.close(l_listener.reporters);
       ut_metadata.reset_source_definition_cache;
+      ut_utils.read_cache_to_dbms_output();
       exception
       when others then
         ut_utils.cleanup_temp_tables;
         ut_output_buffer.close(l_listener.reporters);
         ut_metadata.reset_source_definition_cache;
+        ut_utils.read_cache_to_dbms_output();
         dbms_output.put_line(dbms_utility.format_error_backtrace);
         dbms_output.put_line(dbms_utility.format_error_stack);
         raise;

--- a/source/core/ut_dbms_output_cache.sql
+++ b/source/core/ut_dbms_output_cache.sql
@@ -1,0 +1,23 @@
+create global temporary table ut_dbms_output_cache(
+  /*
+  utPLSQL - Version X.X.X.X
+  Copyright 2016 - 2017 utPLSQL Project
+  Licensed under the Apache License, Version 2.0 (the "License"):
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  */
+  /*
+  * This table is not a global temporary table as it needs to allow cross-session data exchange
+  * It is used however as a temporary table with multiple writers.
+  * This is why it has very high initrans and has nologging
+  */
+  seq_no         number(20,0) not null,
+  text           varchar2(4000),
+  constraint ut_dbms_output_cache_pk primary key(seq_no)
+) on commit preserve rows;

--- a/source/core/ut_utils.pks
+++ b/source/core/ut_utils.pks
@@ -257,5 +257,20 @@ create or replace package ut_utils authid definer is
   */
   function to_version(a_version_no varchar2) return t_version;
 
+
+  /**
+  * Saves data from dbms_output buffer into a global temporary table (cache)
+  *   used to store dbms_output buffer captured before the run
+  *
+  */
+  procedure save_dbms_output_to_cache;
+
+  /**
+  * Reads data from global temporary table (cache) abd puts it back into dbms_output
+  *   used to recover dbms_output buffer data after a run is complete
+  *
+  */
+  procedure read_cache_to_dbms_output;
+
 end ut_utils;
 /

--- a/source/install.sql
+++ b/source/install.sql
@@ -32,6 +32,9 @@ alter session set current_schema = &&ut3_owner;
 alter session set plsql_warnings = 'ENABLE:ALL', 'DISABLE:(5004,5018,6000,6001,6003,6009,6010,7206)';
 --set define off
 
+--dbms_output buffer cache table
+@@install_component.sql 'core/ut_dbms_output_cache.sql'
+
 --common utilities
 @@install_component.sql 'core/types/ut_varchar2_list.tps'
 @@install_component.sql 'core/types/ut_varchar2_rows.tps'

--- a/source/uninstall.sql
+++ b/source/uninstall.sql
@@ -78,6 +78,8 @@ drop package ut_suite_manager;
 
 drop package ut;
 
+drop table ut_dbms_output_cache;
+
 drop type ut_expectation_yminterval force;
 
 drop type ut_expectation_varchar2 force;

--- a/test/ut_runner/test_ut_runner.pkb
+++ b/test/ut_runner/test_ut_runner.pkb
@@ -97,5 +97,33 @@ end;';
     drop_test_package();
   end;
 
+  procedure run_keep_dbms_output_buffer is
+    l_expected         dbmsoutput_linesarray;
+    l_actual           dbmsoutput_linesarray;
+    l_lines            number := 100;
+  begin
+    --Arrange
+    create_test_spec();
+    create_test_body(0);
+    l_expected := dbmsoutput_linesarray(
+        'A text placed into DBMS_OUTPUT',
+        'Another line',
+        lpad('A very long line',10000,'a')
+    );
+    dbms_output.enable;
+    dbms_output.put_line(l_expected(1));
+    dbms_output.put_line(l_expected(2));
+    dbms_output.put_line(l_expected(3));
+    --Act
+    ut3.ut.run('test_cache');
+
+    --Assert
+    dbms_output.get_lines(lines => l_actual, numlines => l_lines);
+    for i in 1 .. l_expected.count loop
+      ut.expect(l_actual(i)).to_equal(l_expected(i));
+    end loop;
+    drop_test_package();
+  end;
+
 end;
 /

--- a/test/ut_runner/test_ut_runner.pks
+++ b/test/ut_runner/test_ut_runner.pks
@@ -18,5 +18,8 @@ create or replace package test_ut_runner is
   --%test(run resets cache of package body after every run)
   procedure run_reset_package_body_cache;
 
+  --%test(does not consume dbms_output from before the run)
+  procedure run_keep_dbms_output_buffer;
+
 end;
 /


### PR DESCRIPTION
`dbms_output` buffer content is now cached before the run starts.
The outcomes from the output are spooled back to the buffer at the end of the run.
That results in the outputs getting shown in the right order when executing `ut.run` in a PLSQL block that has some buffered data already.
Resolves #482