### PR TITLE
Improvements and refactoring of `ut_annotation_parser`

### DIFF
--- a/source/core/annotations/ut_annotation_manager.pkb
+++ b/source/core/annotations/ut_annotation_manager.pkb
@@ -79,7 +79,7 @@ create or replace package body ut_annotation_manager as
          where s.type = :a_object_type
            and s.owner = :a_object_owner
            and s.name
-            in (select /*+ cardinality( x ]'||l_card||q'[ )*/
+            in (select /*+ cardinality( t ]'||l_card||q'[ )*/
                        x.name
                   from table(:a_objects_to_refresh) t
                   join ]'||l_sources_view||q'[ x

--- a/test/ut_annotation_parser/test_annotation_parser.pkb
+++ b/test/ut_annotation_parser/test_annotation_parser.pkb
@@ -26,13 +26,14 @@ create or replace package body test_annotation_parser is
       ut3.ut_annotation(1,'suite',null, null),
       ut3.ut_annotation(2,'displayname','Name of suite',null),
       ut3.ut_annotation(3,'suitepath','all.globaltests',null),
+      ut3.ut_annotation(4,'ann1','Name of suite',null),
       ut3.ut_annotation(5,'ann2','some_value','foo')
     );
 
     ut.expect(anydata.convertCollection(l_actual)).to_equal(anydata.convertCollection(l_expected));
   end;
 
-  procedure ignore_floating_annotations is
+  procedure include_floating_annotations is
     l_source    clob;
     l_actual    ut3.ut_annotations;
     l_expected  ut3.ut_annotations;
@@ -63,7 +64,11 @@ create or replace package body test_annotation_parser is
       ut3.ut_annotation( 1, 'suite', null, null ),
       ut3.ut_annotation( 2, 'displayname', 'Name of suite', null ),
       ut3.ut_annotation( 3, 'suitepath', 'all.globaltests', null ),
+      ut3.ut_annotation( 4, 'ann1', 'Name of suite', null ),
+      ut3.ut_annotation( 5, 'ann2', 'all.globaltests', null ),
       ut3.ut_annotation( 6, 'test', null, 'foo'),
+      ut3.ut_annotation( 7, 'ann3', 'Name of suite', null ),
+      ut3.ut_annotation( 8, 'ann4', 'all.globaltests', null ),
       ut3.ut_annotation( 9, 'test', null, 'bar')
     );
 

--- a/test/ut_annotation_parser/test_annotation_parser.pks
+++ b/test/ut_annotation_parser/test_annotation_parser.pks
@@ -3,10 +3,10 @@ create or replace package test_annotation_parser is
   --%suite(ut_annotation_parser)
   --%suitepath(utplsql.core)
 
-  --%test(Ignores procedure level annotations if mixed with comments)
+  --%test(Treats procedure level annotations as package level, if mixed with comments)
   procedure test_proc_comments;
-  --%test(Ignores floating annotations between procedures and package)
-  procedure ignore_floating_annotations;
+  --%test(Includes floating annotations between procedures and package)
+  procedure include_floating_annotations;
   --%test(Parses complex annotations on procedures and functions)
   procedure parse_complex_with_functions;
   --%test(Parses package annotations without any procedure annotations)


### PR DESCRIPTION
- Partly resolves #516 - ORA-00001: unique constraint (UT3.UT_ANNOTATION_CACHE_PK) violated. The exception will not occur anymore, but such suite will not be executed.
- Allows for "floating" annotations