### PR TITLE
Fixed coverage reporting for labelled `end loop` block.

### DIFF
--- a/source/core/coverage/ut_coverage.pkb
+++ b/source/core/coverage/ut_coverage.pkb
@@ -67,7 +67,7 @@ create or replace package body ut_coverage is
                      ) and
                      regexp_like(
                         s.text,
-                        '^\s*(((not)?\s*(overriding|final|instantiable)\s*)*(static|constructor|member)?\s*(procedure|function)|package(\s+body)|begin|end(\s+\S+)?\s*;)', 'i'
+                        '^([\t ]*(((not)?\s*(overriding|final|instantiable)[\t ]*)*(static|constructor|member)?[\t ]*(procedure|function)|package([\t ]+body)|begin|end([\t ]+\S+)*[ \t]*;))', 'i'
                      )
                     then 'Y'
                  end as to_be_skipped


### PR DESCRIPTION
Resolves #539 
