### PR TITLE
Added `all_expectations` as an attribute for `ut_test` class.

### DIFF
--- a/source/core/types/ut_test.tpb
+++ b/source/core/types/ut_test.tpb
@@ -30,6 +30,8 @@ create or replace type body ut_test as
     self.item := ut_executable(self, a_name, ut_utils.gc_test_execute);
     self.after_test := ut_executable(self, a_after_test_proc_name, ut_utils.gc_after_test);
     self.after_each := ut_executable(self, a_after_each_proc_name, ut_utils.gc_after_each);
+    self.all_expectations    := ut_expectation_results();
+    self.failed_expectations := ut_expectation_results();
     return;
   end;
 
@@ -37,10 +39,12 @@ create or replace type body ut_test as
   begin
     self.before_each := ut_executable(self, a_before_each_proc_name, ut_utils.gc_before_each);
   end;
+
   member procedure set_aftereach(self in out nocopy ut_test, a_after_each_proc_name varchar2) is
   begin
     self.after_each := ut_executable(self, a_after_each_proc_name, ut_utils.gc_after_each);
   end;
+
   member function is_valid(self in out nocopy ut_test) return boolean is
     l_is_valid boolean;
   begin
@@ -114,8 +118,9 @@ create or replace type body ut_test as
       self.result := ut_utils.tr_error;
     end if;
     --expectation results need to be part of test results
-    self.expectations_count := ut_expectation_processor.get_expectations_count();
+    self.all_expectations    := ut_expectation_processor.get_all_expectations();
     self.failed_expectations := ut_expectation_processor.get_failed_expectations();
+    ut_expectation_processor.clear_expectations();
     self.results_count.set_counter_values(self.result);
   end;
 

--- a/source/core/types/ut_test.tps
+++ b/source/core/types/ut_test.tps
@@ -40,14 +40,20 @@ create or replace type ut_test under ut_suite_item (
   */
   after_each ut_executable,
   /**
-  * The list of failed expectation results as well as database errors encountered while invoking
-  * The test procedure and the before_test/after_test blocks
+  * The list of all expectations results as well as database errors encountered while invoking
+  * the test procedure and the before_test/after_test blocks
+  */
+  all_expectations    ut_expectation_results,
+
+  /**
+  * The list of failed expectations results as well as database errors encountered while invoking
+  * the test procedure and the before_test/after_test blocks
   */
   failed_expectations ut_expectation_results,
   /**
-  * The count of all expectations executed in the test
+  * Holds information about error stacktrace from parent execution (suite)
+  * Will get populated on exceptions in before-all calls
   */
-  expectations_count integer,
   parent_error_stack_trace varchar2(4000),
   constructor function ut_test(
     self in out nocopy ut_test, a_object_owner varchar2 := null, a_object_name varchar2, a_name varchar2, a_description varchar2 := null,

--- a/source/core/ut_expectation_processor.pkb
+++ b/source/core/ut_expectation_processor.pkb
@@ -52,10 +52,11 @@ create or replace package body ut_expectation_processor as
     g_expectations_called.delete;
   end;
 
-  function get_expectations_count return integer is
+  function get_all_expectations return ut_expectation_results is
   begin
-    return g_expectations_called.count;
-  end;
+    ut_utils.debug_log('ut_expectation_processor.get_all_expectations: g_expectations_called.count='||g_expectations_called.count);
+    return g_expectations_called;
+  end get_all_expectations;
 
   function get_failed_expectations return ut_expectation_results is
     l_expectations_results ut_expectation_results := ut_expectation_results();
@@ -68,7 +69,6 @@ create or replace package body ut_expectation_processor as
       end if;
     end loop;
     ut_utils.debug_log('ut_expectation_processor.get_failed_expectations: l_expectations_results.count='||g_expectations_called.count);
-    clear_expectations();
     return l_expectations_results;
   end get_failed_expectations;
 

--- a/source/core/ut_expectation_processor.pks
+++ b/source/core/ut_expectation_processor.pks
@@ -28,7 +28,7 @@ create or replace package ut_expectation_processor authid current_user as
 
   procedure clear_expectations;
 
-  function get_expectations_count return integer;
+  function get_all_expectations return ut_expectation_results;
 
   function get_failed_expectations return ut_expectation_results;
 

--- a/source/reporters/ut_xunit_reporter.tpb
+++ b/source/reporters/ut_xunit_reporter.tpb
@@ -37,7 +37,7 @@ create or replace type body ut_xunit_reporter is
       l_output clob;
     begin
       self.print_text('<testcase classname="' || dbms_xmlgen.convert(get_path(a_test.path, a_test.name)) || '" ' || ' assertions="' ||
-                      nvl(a_test.expectations_count,0) || '"' || self.get_common_item_attributes(a_test) || case when
+                      nvl(a_test.all_expectations.count,0) || '"' || self.get_common_item_attributes(a_test) || case when
                       a_test.result != ut_utils.tr_success then
                       ' status="' || ut_utils.test_result_to_char(a_test.result) || '"' end || '>');
       if a_test.result = ut_utils.tr_disabled then


### PR DESCRIPTION
Removed `expectations_count` as it can now be obtained from `all_expectations.count`
`ut_expectation_processor` now holds all expectation results.
`ut_test` is nor responsible for clearing the state of `ut_expectation_processor` after reading expectations results.