### PR TITLE
Aligned ut_documentation_reporter with disabled annotation

### DIFF
--- a/source/reporters/ut_documentation_reporter.tpb
+++ b/source/reporters/ut_documentation_reporter.tpb
@@ -53,7 +53,7 @@ create or replace type body ut_documentation_reporter is
     l_message := coalesce(a_test.description, a_test.name)||' ['||round(a_test.execution_time,3)||' sec]';
     --if test failed, then add it to the failures list, print failure with number
     if a_test.result = ut_utils.tr_disabled then
-      self.print_yellow_text(l_message || ' (IGNORED)');
+      self.print_yellow_text(l_message || ' (DISABLED)');
     elsif a_test.result = ut_utils.tr_success then
       self.print_green_text(l_message);
     elsif a_test.result > ut_utils.tr_success then

--- a/source/reporters/ut_documentation_reporter.tpb
+++ b/source/reporters/ut_documentation_reporter.tpb
@@ -1,4 +1,4 @@
-create or replace type body ut_documentation_reporter is
+create or replace type body     ut_documentation_reporter is
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2017 utPLSQL Project

--- a/source/reporters/ut_documentation_reporter.tpb
+++ b/source/reporters/ut_documentation_reporter.tpb
@@ -1,4 +1,4 @@
-create or replace type body     ut_documentation_reporter is
+create or replace type body ut_documentation_reporter is
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2017 utPLSQL Project

--- a/test/core/expectations/test_expect_not_to_be_null.pkb
+++ b/test/core/expectations/test_expect_not_to_be_null.pkb
@@ -34,7 +34,7 @@ is
         --Act
         execute immediate expectations_helpers.unary_expectation_block('not_to_be_null', 'blob', 'to_blob(''abc'')');
         --Assert
-        ut.expect(anydata.convertCollection(ut3.ut_expectation_processor.get_failed_expectations())).to_be_empty();
+        ut.expect(expectations_helpers.get_failed_expect_as_anydata()).to_be_empty();
     end;
 
     procedure blob_0_length
@@ -43,7 +43,7 @@ is
         --Act
         execute immediate expectations_helpers.unary_expectation_block('not_to_be_null', 'blob', 'empty_blob()');
         --Assert
-        ut.expect(anydata.convertCollection(ut3.ut_expectation_processor.get_failed_expectations())).to_be_empty();
+        ut.expect(expectations_helpers.get_failed_expect_as_anydata()).to_be_empty();
     end;
 
     procedure boolean_not_null
@@ -52,7 +52,7 @@ is
         --Act
         execute immediate expectations_helpers.unary_expectation_block('not_to_be_null', 'boolean', 'true');
         --Assert
-        ut.expect(anydata.convertCollection(ut3.ut_expectation_processor.get_failed_expectations())).to_be_empty();
+        ut.expect(expectations_helpers.get_failed_expect_as_anydata()).to_be_empty();
     end;
 
     procedure clob_not_null
@@ -61,7 +61,7 @@ is
         --Act
         execute immediate expectations_helpers.unary_expectation_block('not_to_be_null', 'clob', 'to_clob(''abc'')');
         --Assert
-        ut.expect(anydata.convertCollection(ut3.ut_expectation_processor.get_failed_expectations())).to_be_empty();
+        ut.expect(expectations_helpers.get_failed_expect_as_anydata()).to_be_empty();
     end;
 
 
@@ -71,7 +71,7 @@ is
         --Act
         execute immediate expectations_helpers.unary_expectation_block('not_to_be_null', 'clob', 'empty_clob()');
         --Assert
-        ut.expect(anydata.convertCollection(ut3.ut_expectation_processor.get_failed_expectations())).to_be_empty();
+        ut.expect(expectations_helpers.get_failed_expect_as_anydata()).to_be_empty();
     end;
 
     procedure date_not_null
@@ -80,7 +80,7 @@ is
         --Act
         execute immediate expectations_helpers.unary_expectation_block('not_to_be_null', 'date', 'sysdate');
         --Assert
-        ut.expect(anydata.convertCollection(ut3.ut_expectation_processor.get_failed_expectations())).to_be_empty();
+        ut.expect(expectations_helpers.get_failed_expect_as_anydata()).to_be_empty();
     end;
 
     procedure number_not_null
@@ -89,7 +89,7 @@ is
         --Act
         execute immediate expectations_helpers.unary_expectation_block('not_to_be_null', 'number', '1234');
         --Assert
-        ut.expect(anydata.convertCollection(ut3.ut_expectation_processor.get_failed_expectations())).to_be_empty();
+        ut.expect(expectations_helpers.get_failed_expect_as_anydata()).to_be_empty();
     end;
 
     procedure timestamp_not_null
@@ -98,7 +98,7 @@ is
         --Act
         execute immediate expectations_helpers.unary_expectation_block('not_to_be_null', 'timestamp', 'systimestamp');
         --Assert
-        ut.expect(anydata.convertCollection(ut3.ut_expectation_processor.get_failed_expectations())).to_be_empty();
+        ut.expect(expectations_helpers.get_failed_expect_as_anydata()).to_be_empty();
     end;
 
     procedure timestamp_with_ltz_not_null
@@ -107,7 +107,7 @@ is
         --Act
         execute immediate expectations_helpers.unary_expectation_block('not_to_be_null', 'timestamp with local time zone', 'systimestamp');
         --Assert
-        ut.expect(anydata.convertCollection(ut3.ut_expectation_processor.get_failed_expectations())).to_be_empty();
+        ut.expect(expectations_helpers.get_failed_expect_as_anydata()).to_be_empty();
     end;
 
     procedure timestamp_with_tz_not_null
@@ -116,7 +116,7 @@ is
         --Act
         execute immediate expectations_helpers.unary_expectation_block('not_to_be_null', 'timestamp with time zone', 'systimestamp');
         --Assert
-        ut.expect(anydata.convertCollection(ut3.ut_expectation_processor.get_failed_expectations())).to_be_empty();
+        ut.expect(expectations_helpers.get_failed_expect_as_anydata()).to_be_empty();
     end;
 
     procedure varchar2_not_null
@@ -125,7 +125,7 @@ is
         --Act
         execute immediate expectations_helpers.unary_expectation_block('not_to_be_null', 'varchar2(4000)', '''abc''');
         --Assert
-        ut.expect(anydata.convertCollection(ut3.ut_expectation_processor.get_failed_expectations())).to_be_empty();
+        ut.expect(expectations_helpers.get_failed_expect_as_anydata()).to_be_empty();
     end;
 
     procedure initialized_object
@@ -135,7 +135,7 @@ is
         execute immediate expectations_helpers.unary_expectation_object_block('not_to_be_null', gc_object_name,
                                                                                 gc_object_name||'(1)', 'object');
         --Assert
-        ut.expect(anydata.convertCollection(ut3.ut_expectation_processor.get_failed_expectations())).to_be_empty();
+        ut.expect(expectations_helpers.get_failed_expect_as_anydata()).to_be_empty();
     end;
 
     procedure initialized_nested_table
@@ -145,7 +145,7 @@ is
         execute immediate expectations_helpers.unary_expectation_object_block('not_to_be_null', gc_nested_table_name,
                                                                                 gc_nested_table_name||'()', 'collection');
         --Assert
-        ut.expect(anydata.convertCollection(ut3.ut_expectation_processor.get_failed_expectations())).to_be_empty();
+        ut.expect(expectations_helpers.get_failed_expect_as_anydata()).to_be_empty();
     end;
 
     procedure initialized_varray
@@ -155,7 +155,7 @@ is
         execute immediate expectations_helpers.unary_expectation_object_block('not_to_be_null', gc_varray_name,
                                                                                 gc_varray_name||'()', 'collection');
         --Assert
-        ut.expect(anydata.convertCollection(ut3.ut_expectation_processor.get_failed_expectations())).to_be_empty();
+        ut.expect(expectations_helpers.get_failed_expect_as_anydata()).to_be_empty();
     end;
 
     procedure null_blob
@@ -164,7 +164,7 @@ is
         --Act
         execute immediate expectations_helpers.unary_expectation_block('not_to_be_null', 'blob', 'null');
         --Assert
-        ut.expect(anydata.convertCollection(ut3.ut_expectation_processor.get_failed_expectations())).not_to_be_empty();
+        ut.expect(expectations_helpers.get_failed_expect_as_anydata()).not_to_be_empty();
     end;
 
     procedure null_boolean
@@ -173,7 +173,7 @@ is
         --Act
         execute immediate expectations_helpers.unary_expectation_block('not_to_be_null', 'boolean', 'null');
         --Assert
-        ut.expect(anydata.convertCollection(ut3.ut_expectation_processor.get_failed_expectations())).not_to_be_empty();
+        ut.expect(expectations_helpers.get_failed_expect_as_anydata()).not_to_be_empty();
     end;
 
 
@@ -183,7 +183,7 @@ is
         --Act
         execute immediate expectations_helpers.unary_expectation_block('not_to_be_null', 'clob', 'null');
         --Assert
-        ut.expect(anydata.convertCollection(ut3.ut_expectation_processor.get_failed_expectations())).not_to_be_empty();
+        ut.expect(expectations_helpers.get_failed_expect_as_anydata()).not_to_be_empty();
     end;
 
 
@@ -193,7 +193,7 @@ is
         --Act
         execute immediate expectations_helpers.unary_expectation_block('not_to_be_null', 'date', 'null');
         --Assert
-        ut.expect(anydata.convertCollection(ut3.ut_expectation_processor.get_failed_expectations())).not_to_be_empty();
+        ut.expect(expectations_helpers.get_failed_expect_as_anydata()).not_to_be_empty();
     end;
 
 
@@ -203,7 +203,7 @@ is
         --Act
         execute immediate expectations_helpers.unary_expectation_block('not_to_be_null', 'number', 'null');
         --Assert
-        ut.expect(anydata.convertCollection(ut3.ut_expectation_processor.get_failed_expectations())).not_to_be_empty();
+        ut.expect(expectations_helpers.get_failed_expect_as_anydata()).not_to_be_empty();
     end;
 
 
@@ -213,7 +213,7 @@ is
         --Act
         execute immediate expectations_helpers.unary_expectation_block('not_to_be_null', 'timestamp', 'null');
         --Assert
-        ut.expect(anydata.convertCollection(ut3.ut_expectation_processor.get_failed_expectations())).not_to_be_empty();
+        ut.expect(expectations_helpers.get_failed_expect_as_anydata()).not_to_be_empty();
     end;
 
 
@@ -223,7 +223,7 @@ is
         --Act
         execute immediate expectations_helpers.unary_expectation_block('not_to_be_null', 'timestamp with local time zone', 'null');
         --Assert
-        ut.expect(anydata.convertCollection(ut3.ut_expectation_processor.get_failed_expectations())).not_to_be_empty();
+        ut.expect(expectations_helpers.get_failed_expect_as_anydata()).not_to_be_empty();
     end;
 
 
@@ -233,7 +233,7 @@ is
         --Act
         execute immediate expectations_helpers.unary_expectation_block('not_to_be_null', 'timestamp with time zone', 'null');
         --Assert
-        ut.expect(anydata.convertCollection(ut3.ut_expectation_processor.get_failed_expectations())).not_to_be_empty();
+        ut.expect(expectations_helpers.get_failed_expect_as_anydata()).not_to_be_empty();
     end;
 
 
@@ -243,7 +243,7 @@ is
         --Act
         execute immediate expectations_helpers.unary_expectation_block('not_to_be_null', 'varchar2(4000)', 'null');
         --Assert
-        ut.expect(anydata.convertCollection(ut3.ut_expectation_processor.get_failed_expectations())).not_to_be_empty();
+        ut.expect(expectations_helpers.get_failed_expect_as_anydata()).not_to_be_empty();
     end;
 
     procedure null_anydata
@@ -252,7 +252,7 @@ is
         --Act
         execute immediate expectations_helpers.unary_expectation_block('not_to_be_null', 'anydata', 'null');
         --Assert
-        ut.expect(anydata.convertCollection(ut3.ut_expectation_processor.get_failed_expectations())).not_to_be_empty();
+        ut.expect(expectations_helpers.get_failed_expect_as_anydata()).not_to_be_empty();
     end;
 
     procedure uninit_object_in_anydata
@@ -262,7 +262,7 @@ is
         execute immediate expectations_helpers.unary_expectation_object_block('not_to_be_null', gc_object_name,
                                                                                 'null', 'object');
         --Assert
-        ut.expect(anydata.convertCollection(ut3.ut_expectation_processor.get_failed_expectations())).not_to_be_empty();
+        ut.expect(expectations_helpers.get_failed_expect_as_anydata()).not_to_be_empty();
     end;
 
     procedure uninit_nested_table_in_anydata
@@ -272,7 +272,7 @@ is
         execute immediate expectations_helpers.unary_expectation_object_block('not_to_be_null', gc_nested_table_name,
                                                                                 'null', 'collection');
         --Assert
-        ut.expect(anydata.convertCollection(ut3.ut_expectation_processor.get_failed_expectations())).not_to_be_empty();
+        ut.expect(expectations_helpers.get_failed_expect_as_anydata()).not_to_be_empty();
     end;
 
     procedure uninit_varray_in_anydata
@@ -282,7 +282,7 @@ is
         execute immediate expectations_helpers.unary_expectation_object_block('not_to_be_null', gc_varray_name,
                                                                                 'null', 'collection');
         --Assert
-        ut.expect(anydata.convertCollection(ut3.ut_expectation_processor.get_failed_expectations())).not_to_be_empty();
+        ut.expect(expectations_helpers.get_failed_expect_as_anydata()).not_to_be_empty();
     end;
 end test_expect_not_to_be_null;
 /

--- a/test/core/expectations/test_expect_to_be_not_null.pkb
+++ b/test/core/expectations/test_expect_to_be_not_null.pkb
@@ -34,7 +34,7 @@ is
         --Act
         execute immediate expectations_helpers.unary_expectation_block('to_be_not_null', 'blob', 'to_blob(''abc'')');
         --Assert
-        ut.expect(anydata.convertCollection(ut3.ut_expectation_processor.get_failed_expectations())).to_be_empty();
+        ut.expect(expectations_helpers.get_failed_expect_as_anydata()).to_be_empty();
     end;
 
     procedure blob_0_length
@@ -43,7 +43,7 @@ is
         --Act
         execute immediate expectations_helpers.unary_expectation_block('to_be_not_null', 'blob', 'empty_blob()');
         --Assert
-        ut.expect(anydata.convertCollection(ut3.ut_expectation_processor.get_failed_expectations())).to_be_empty();
+        ut.expect(expectations_helpers.get_failed_expect_as_anydata()).to_be_empty();
     end;
 
     procedure boolean_not_null
@@ -52,7 +52,7 @@ is
         --Act
         execute immediate expectations_helpers.unary_expectation_block('to_be_not_null', 'boolean', 'true');
         --Assert
-        ut.expect(anydata.convertCollection(ut3.ut_expectation_processor.get_failed_expectations())).to_be_empty();
+        ut.expect(expectations_helpers.get_failed_expect_as_anydata()).to_be_empty();
     end;
 
     procedure clob_not_null
@@ -61,7 +61,7 @@ is
         --Act
         execute immediate expectations_helpers.unary_expectation_block('to_be_not_null', 'clob', 'to_clob(''abc'')');
         --Assert
-        ut.expect(anydata.convertCollection(ut3.ut_expectation_processor.get_failed_expectations())).to_be_empty();
+        ut.expect(expectations_helpers.get_failed_expect_as_anydata()).to_be_empty();
     end;
 
 
@@ -71,7 +71,7 @@ is
         --Act
         execute immediate expectations_helpers.unary_expectation_block('to_be_not_null', 'clob', 'empty_clob()');
         --Assert
-        ut.expect(anydata.convertCollection(ut3.ut_expectation_processor.get_failed_expectations())).to_be_empty();
+        ut.expect(expectations_helpers.get_failed_expect_as_anydata()).to_be_empty();
     end;
 
     procedure date_not_null
@@ -80,7 +80,7 @@ is
         --Act
         execute immediate expectations_helpers.unary_expectation_block('to_be_not_null', 'date', 'sysdate');
         --Assert
-        ut.expect(anydata.convertCollection(ut3.ut_expectation_processor.get_failed_expectations())).to_be_empty();
+        ut.expect(expectations_helpers.get_failed_expect_as_anydata()).to_be_empty();
     end;
 
     procedure number_not_null
@@ -89,7 +89,7 @@ is
         --Act
         execute immediate expectations_helpers.unary_expectation_block('to_be_not_null', 'number', '1234');
         --Assert
-        ut.expect(anydata.convertCollection(ut3.ut_expectation_processor.get_failed_expectations())).to_be_empty();
+        ut.expect(expectations_helpers.get_failed_expect_as_anydata()).to_be_empty();
     end;
 
     procedure timestamp_not_null
@@ -98,7 +98,7 @@ is
         --Act
         execute immediate expectations_helpers.unary_expectation_block('to_be_not_null', 'timestamp', 'systimestamp');
         --Assert
-        ut.expect(anydata.convertCollection(ut3.ut_expectation_processor.get_failed_expectations())).to_be_empty();
+        ut.expect(expectations_helpers.get_failed_expect_as_anydata()).to_be_empty();
     end;
 
     procedure timestamp_with_ltz_not_null
@@ -107,7 +107,7 @@ is
         --Act
         execute immediate expectations_helpers.unary_expectation_block('to_be_not_null', 'timestamp with local time zone', 'systimestamp');
         --Assert
-        ut.expect(anydata.convertCollection(ut3.ut_expectation_processor.get_failed_expectations())).to_be_empty();
+        ut.expect(expectations_helpers.get_failed_expect_as_anydata()).to_be_empty();
     end;
 
     procedure timestamp_with_tz_not_null
@@ -116,7 +116,7 @@ is
         --Act
         execute immediate expectations_helpers.unary_expectation_block('to_be_not_null', 'timestamp with time zone', 'systimestamp');
         --Assert
-        ut.expect(anydata.convertCollection(ut3.ut_expectation_processor.get_failed_expectations())).to_be_empty();
+        ut.expect(expectations_helpers.get_failed_expect_as_anydata()).to_be_empty();
     end;
 
     procedure varchar2_not_null
@@ -125,7 +125,7 @@ is
         --Act
         execute immediate expectations_helpers.unary_expectation_block('to_be_not_null', 'varchar2(4000)', '''abc''');
         --Assert
-        ut.expect(anydata.convertCollection(ut3.ut_expectation_processor.get_failed_expectations())).to_be_empty();
+        ut.expect(expectations_helpers.get_failed_expect_as_anydata()).to_be_empty();
     end;
 
     procedure initialized_object
@@ -135,7 +135,7 @@ is
         execute immediate expectations_helpers.unary_expectation_object_block('to_be_not_null', gc_object_name,
                                                                                 gc_object_name||'(1)', 'object');
         --Assert
-        ut.expect(anydata.convertCollection(ut3.ut_expectation_processor.get_failed_expectations())).to_be_empty();
+        ut.expect(expectations_helpers.get_failed_expect_as_anydata()).to_be_empty();
     end;
 
     procedure initialized_nested_table
@@ -145,7 +145,7 @@ is
         execute immediate expectations_helpers.unary_expectation_object_block('to_be_not_null', gc_nested_table_name,
                                                                                 gc_nested_table_name||'()', 'collection');
         --Assert
-        ut.expect(anydata.convertCollection(ut3.ut_expectation_processor.get_failed_expectations())).to_be_empty();
+        ut.expect(expectations_helpers.get_failed_expect_as_anydata()).to_be_empty();
     end;
 
     procedure initialized_varray
@@ -155,7 +155,7 @@ is
         execute immediate expectations_helpers.unary_expectation_object_block('to_be_not_null', gc_varray_name,
                                                                                 gc_varray_name||'()', 'collection');
         --Assert
-        ut.expect(anydata.convertCollection(ut3.ut_expectation_processor.get_failed_expectations())).to_be_empty();
+        ut.expect(expectations_helpers.get_failed_expect_as_anydata()).to_be_empty();
     end;
 
     procedure null_blob
@@ -164,7 +164,7 @@ is
         --Act
         execute immediate expectations_helpers.unary_expectation_block('to_be_not_null', 'blob', 'null');
         --Assert
-        ut.expect(anydata.convertCollection(ut3.ut_expectation_processor.get_failed_expectations())).not_to_be_empty();
+        ut.expect(expectations_helpers.get_failed_expect_as_anydata()).not_to_be_empty();
     end;
 
     procedure null_boolean
@@ -173,7 +173,7 @@ is
         --Act
         execute immediate expectations_helpers.unary_expectation_block('to_be_not_null', 'boolean', 'null');
         --Assert
-        ut.expect(anydata.convertCollection(ut3.ut_expectation_processor.get_failed_expectations())).not_to_be_empty();
+        ut.expect(expectations_helpers.get_failed_expect_as_anydata()).not_to_be_empty();
     end;
 
 
@@ -183,7 +183,7 @@ is
         --Act
         execute immediate expectations_helpers.unary_expectation_block('to_be_not_null', 'clob', 'null');
         --Assert
-        ut.expect(anydata.convertCollection(ut3.ut_expectation_processor.get_failed_expectations())).not_to_be_empty();
+        ut.expect(expectations_helpers.get_failed_expect_as_anydata()).not_to_be_empty();
     end;
 
 
@@ -193,7 +193,7 @@ is
         --Act
         execute immediate expectations_helpers.unary_expectation_block('to_be_not_null', 'date', 'null');
         --Assert
-        ut.expect(anydata.convertCollection(ut3.ut_expectation_processor.get_failed_expectations())).not_to_be_empty();
+        ut.expect(expectations_helpers.get_failed_expect_as_anydata()).not_to_be_empty();
     end;
 
 
@@ -203,7 +203,7 @@ is
         --Act
         execute immediate expectations_helpers.unary_expectation_block('to_be_not_null', 'number', 'null');
         --Assert
-        ut.expect(anydata.convertCollection(ut3.ut_expectation_processor.get_failed_expectations())).not_to_be_empty();
+        ut.expect(expectations_helpers.get_failed_expect_as_anydata()).not_to_be_empty();
     end;
 
 
@@ -213,7 +213,7 @@ is
         --Act
         execute immediate expectations_helpers.unary_expectation_block('to_be_not_null', 'timestamp', 'null');
         --Assert
-        ut.expect(anydata.convertCollection(ut3.ut_expectation_processor.get_failed_expectations())).not_to_be_empty();
+        ut.expect(expectations_helpers.get_failed_expect_as_anydata()).not_to_be_empty();
     end;
 
 
@@ -223,7 +223,7 @@ is
         --Act
         execute immediate expectations_helpers.unary_expectation_block('to_be_not_null', 'timestamp with local time zone', 'null');
         --Assert
-        ut.expect(anydata.convertCollection(ut3.ut_expectation_processor.get_failed_expectations())).not_to_be_empty();
+        ut.expect(expectations_helpers.get_failed_expect_as_anydata()).not_to_be_empty();
     end;
 
 
@@ -233,7 +233,7 @@ is
         --Act
         execute immediate expectations_helpers.unary_expectation_block('to_be_not_null', 'timestamp with time zone', 'null');
         --Assert
-        ut.expect(anydata.convertCollection(ut3.ut_expectation_processor.get_failed_expectations())).not_to_be_empty();
+        ut.expect(expectations_helpers.get_failed_expect_as_anydata()).not_to_be_empty();
     end;
 
 
@@ -243,7 +243,7 @@ is
         --Act
         execute immediate expectations_helpers.unary_expectation_block('to_be_not_null', 'varchar2(4000)', 'null');
         --Assert
-        ut.expect(anydata.convertCollection(ut3.ut_expectation_processor.get_failed_expectations())).not_to_be_empty();
+        ut.expect(expectations_helpers.get_failed_expect_as_anydata()).not_to_be_empty();
     end;
 
     procedure null_anydata
@@ -252,7 +252,7 @@ is
         --Act
         execute immediate expectations_helpers.unary_expectation_block('to_be_not_null', 'anydata', 'null');
         --Assert
-        ut.expect(anydata.convertCollection(ut3.ut_expectation_processor.get_failed_expectations())).not_to_be_empty();
+        ut.expect(expectations_helpers.get_failed_expect_as_anydata()).not_to_be_empty();
     end;
 
     procedure uninit_object_in_anydata
@@ -262,7 +262,7 @@ is
         execute immediate expectations_helpers.unary_expectation_object_block('to_be_not_null', gc_object_name,
                                                                                 'null', 'object');
         --Assert
-        ut.expect(anydata.convertCollection(ut3.ut_expectation_processor.get_failed_expectations())).not_to_be_empty();
+        ut.expect(expectations_helpers.get_failed_expect_as_anydata()).not_to_be_empty();
     end;
 
     procedure uninit_nested_table_in_anydata
@@ -272,7 +272,7 @@ is
         execute immediate expectations_helpers.unary_expectation_object_block('to_be_not_null', gc_nested_table_name,
                                                                                 'null', 'collection');
         --Assert
-        ut.expect(anydata.convertCollection(ut3.ut_expectation_processor.get_failed_expectations())).not_to_be_empty();
+        ut.expect(expectations_helpers.get_failed_expect_as_anydata()).not_to_be_empty();
     end;
 
     procedure uninit_varray_in_anydata
@@ -282,7 +282,7 @@ is
         execute immediate expectations_helpers.unary_expectation_object_block('to_be_not_null', gc_varray_name,
                                                                                 'null', 'collection');
         --Assert
-        ut.expect(anydata.convertCollection(ut3.ut_expectation_processor.get_failed_expectations())).not_to_be_empty();
+        ut.expect(expectations_helpers.get_failed_expect_as_anydata()).not_to_be_empty();
     end;
 end test_expect_to_be_not_null;
 /

--- a/test/core/expectations/test_expect_to_be_null.pkb
+++ b/test/core/expectations/test_expect_to_be_null.pkb
@@ -34,7 +34,7 @@ is
         --Act
         execute immediate expectations_helpers.unary_expectation_block('to_be_null', 'blob', 'null');
         --Assert
-        ut.expect(anydata.convertCollection(ut3.ut_expectation_processor.get_failed_expectations())).to_be_empty();
+        ut.expect(expectations_helpers.get_failed_expect_as_anydata()).to_be_empty();
     end;
 
     procedure null_boolean
@@ -43,7 +43,7 @@ is
         --Act
         execute immediate expectations_helpers.unary_expectation_block('to_be_null', 'boolean', 'null');
         --Assert
-        ut.expect(anydata.convertCollection(ut3.ut_expectation_processor.get_failed_expectations())).to_be_empty();
+        ut.expect(expectations_helpers.get_failed_expect_as_anydata()).to_be_empty();
     end;
 
 
@@ -53,7 +53,7 @@ is
         --Act
         execute immediate expectations_helpers.unary_expectation_block('to_be_null', 'clob', 'null');
         --Assert
-        ut.expect(anydata.convertCollection(ut3.ut_expectation_processor.get_failed_expectations())).to_be_empty();
+        ut.expect(expectations_helpers.get_failed_expect_as_anydata()).to_be_empty();
     end;
 
 
@@ -63,7 +63,7 @@ is
         --Act
         execute immediate expectations_helpers.unary_expectation_block('to_be_null', 'date', 'null');
         --Assert
-        ut.expect(anydata.convertCollection(ut3.ut_expectation_processor.get_failed_expectations())).to_be_empty();
+        ut.expect(expectations_helpers.get_failed_expect_as_anydata()).to_be_empty();
     end;
 
 
@@ -73,7 +73,7 @@ is
         --Act
         execute immediate expectations_helpers.unary_expectation_block('to_be_null', 'number', 'null');
         --Assert
-        ut.expect(anydata.convertCollection(ut3.ut_expectation_processor.get_failed_expectations())).to_be_empty();
+        ut.expect(expectations_helpers.get_failed_expect_as_anydata()).to_be_empty();
     end;
 
 
@@ -83,7 +83,7 @@ is
         --Act
         execute immediate expectations_helpers.unary_expectation_block('to_be_null', 'timestamp', 'null');
         --Assert
-        ut.expect(anydata.convertCollection(ut3.ut_expectation_processor.get_failed_expectations())).to_be_empty();
+        ut.expect(expectations_helpers.get_failed_expect_as_anydata()).to_be_empty();
     end;
 
 
@@ -93,7 +93,7 @@ is
         --Act
         execute immediate expectations_helpers.unary_expectation_block('to_be_null', 'timestamp with local time zone', 'null');
         --Assert
-        ut.expect(anydata.convertCollection(ut3.ut_expectation_processor.get_failed_expectations())).to_be_empty();
+        ut.expect(expectations_helpers.get_failed_expect_as_anydata()).to_be_empty();
     end;
 
 
@@ -103,7 +103,7 @@ is
         --Act
         execute immediate expectations_helpers.unary_expectation_block('to_be_null', 'timestamp with time zone', 'null');
         --Assert
-        ut.expect(anydata.convertCollection(ut3.ut_expectation_processor.get_failed_expectations())).to_be_empty();
+        ut.expect(expectations_helpers.get_failed_expect_as_anydata()).to_be_empty();
     end;
 
 
@@ -113,7 +113,7 @@ is
         --Act
         execute immediate expectations_helpers.unary_expectation_block('to_be_null', 'varchar2(4000)', 'null');
         --Assert
-        ut.expect(anydata.convertCollection(ut3.ut_expectation_processor.get_failed_expectations())).to_be_empty();
+        ut.expect(expectations_helpers.get_failed_expect_as_anydata()).to_be_empty();
     end;
 
     procedure null_anydata
@@ -122,7 +122,7 @@ is
         --Act
         execute immediate expectations_helpers.unary_expectation_block('to_be_null', 'anydata', 'null');
         --Assert
-        ut.expect(anydata.convertCollection(ut3.ut_expectation_processor.get_failed_expectations())).to_be_empty();
+        ut.expect(expectations_helpers.get_failed_expect_as_anydata()).to_be_empty();
     end;
 
     procedure uninit_object_in_anydata
@@ -132,7 +132,7 @@ is
         execute immediate expectations_helpers.unary_expectation_object_block('to_be_null', gc_object_name,
                                                                                 'null', 'object');
         --Assert
-        ut.expect(anydata.convertCollection(ut3.ut_expectation_processor.get_failed_expectations())).to_be_empty();
+        ut.expect(expectations_helpers.get_failed_expect_as_anydata()).to_be_empty();
     end;
 
     procedure uninit_nested_table_in_anydata
@@ -142,7 +142,7 @@ is
         execute immediate expectations_helpers.unary_expectation_object_block('to_be_null', gc_nested_table_name,
                                                                                 'null', 'collection');
         --Assert
-        ut.expect(anydata.convertCollection(ut3.ut_expectation_processor.get_failed_expectations())).to_be_empty();
+        ut.expect(expectations_helpers.get_failed_expect_as_anydata()).to_be_empty();
     end;
 
     procedure uninit_varray_in_anydata
@@ -152,7 +152,7 @@ is
         execute immediate expectations_helpers.unary_expectation_object_block('to_be_null', gc_varray_name,
                                                                                 'null', 'collection');
         --Assert
-        ut.expect(anydata.convertCollection(ut3.ut_expectation_processor.get_failed_expectations())).to_be_empty();
+        ut.expect(expectations_helpers.get_failed_expect_as_anydata()).to_be_empty();
     end;
 
     procedure blob_not_null
@@ -161,7 +161,7 @@ is
         --Act
         execute immediate expectations_helpers.unary_expectation_block('to_be_null', 'blob', 'to_blob(''abc'')');
         --Assert
-        ut.expect(anydata.convertCollection(ut3.ut_expectation_processor.get_failed_expectations())).not_to_be_empty();
+        ut.expect(expectations_helpers.get_failed_expect_as_anydata()).not_to_be_empty();
     end;
 
     procedure blob_0_length
@@ -170,7 +170,7 @@ is
         --Act
         execute immediate expectations_helpers.unary_expectation_block('to_be_null', 'blob', 'empty_blob()');
         --Assert
-        ut.expect(anydata.convertCollection(ut3.ut_expectation_processor.get_failed_expectations())).not_to_be_empty();
+        ut.expect(expectations_helpers.get_failed_expect_as_anydata()).not_to_be_empty();
     end;
 
     procedure boolean_not_null
@@ -179,7 +179,7 @@ is
         --Act
         execute immediate expectations_helpers.unary_expectation_block('to_be_null', 'boolean', 'true');
         --Assert
-        ut.expect(anydata.convertCollection(ut3.ut_expectation_processor.get_failed_expectations())).not_to_be_empty();
+        ut.expect(expectations_helpers.get_failed_expect_as_anydata()).not_to_be_empty();
     end;
 
     procedure clob_not_null
@@ -188,7 +188,7 @@ is
         --Act
         execute immediate expectations_helpers.unary_expectation_block('to_be_null', 'clob', 'to_clob(''abc'')');
         --Assert
-        ut.expect(anydata.convertCollection(ut3.ut_expectation_processor.get_failed_expectations())).not_to_be_empty();
+        ut.expect(expectations_helpers.get_failed_expect_as_anydata()).not_to_be_empty();
     end;
 
 
@@ -198,7 +198,7 @@ is
         --Act
         execute immediate expectations_helpers.unary_expectation_block('to_be_null', 'clob', 'empty_clob()');
         --Assert
-        ut.expect(anydata.convertCollection(ut3.ut_expectation_processor.get_failed_expectations())).not_to_be_empty();
+        ut.expect(expectations_helpers.get_failed_expect_as_anydata()).not_to_be_empty();
     end;
 
     procedure date_not_null
@@ -207,7 +207,7 @@ is
         --Act
         execute immediate expectations_helpers.unary_expectation_block('to_be_null', 'date', 'sysdate');
         --Assert
-        ut.expect(anydata.convertCollection(ut3.ut_expectation_processor.get_failed_expectations())).not_to_be_empty();
+        ut.expect(expectations_helpers.get_failed_expect_as_anydata()).not_to_be_empty();
     end;
 
     procedure number_not_null
@@ -216,7 +216,7 @@ is
         --Act
         execute immediate expectations_helpers.unary_expectation_block('to_be_null', 'number', '1234');
         --Assert
-        ut.expect(anydata.convertCollection(ut3.ut_expectation_processor.get_failed_expectations())).not_to_be_empty();
+        ut.expect(expectations_helpers.get_failed_expect_as_anydata()).not_to_be_empty();
     end;
 
     procedure timestamp_not_null
@@ -225,7 +225,7 @@ is
         --Act
         execute immediate expectations_helpers.unary_expectation_block('to_be_null', 'timestamp', 'systimestamp');
         --Assert
-        ut.expect(anydata.convertCollection(ut3.ut_expectation_processor.get_failed_expectations())).not_to_be_empty();
+        ut.expect(expectations_helpers.get_failed_expect_as_anydata()).not_to_be_empty();
     end;
 
     procedure timestamp_with_ltz_not_null
@@ -234,7 +234,7 @@ is
         --Act
         execute immediate expectations_helpers.unary_expectation_block('to_be_null', 'timestamp with local time zone', 'systimestamp');
         --Assert
-        ut.expect(anydata.convertCollection(ut3.ut_expectation_processor.get_failed_expectations())).not_to_be_empty();
+        ut.expect(expectations_helpers.get_failed_expect_as_anydata()).not_to_be_empty();
     end;
 
     procedure timestamp_with_tz_not_null
@@ -243,7 +243,7 @@ is
         --Act
         execute immediate expectations_helpers.unary_expectation_block('to_be_null', 'timestamp with time zone', 'systimestamp');
         --Assert
-        ut.expect(anydata.convertCollection(ut3.ut_expectation_processor.get_failed_expectations())).not_to_be_empty();
+        ut.expect(expectations_helpers.get_failed_expect_as_anydata()).not_to_be_empty();
     end;
 
     procedure varchar2_not_null
@@ -252,7 +252,7 @@ is
         --Act
         execute immediate expectations_helpers.unary_expectation_block('to_be_null', 'varchar2(4000)', '''abc''');
         --Assert
-        ut.expect(anydata.convertCollection(ut3.ut_expectation_processor.get_failed_expectations())).not_to_be_empty();
+        ut.expect(expectations_helpers.get_failed_expect_as_anydata()).not_to_be_empty();
     end;
 
     procedure initialized_object
@@ -262,7 +262,7 @@ is
         execute immediate expectations_helpers.unary_expectation_object_block('to_be_null', gc_object_name,
                                                                                 gc_object_name||'(1)', 'object');
         --Assert
-        ut.expect(anydata.convertCollection(ut3.ut_expectation_processor.get_failed_expectations())).not_to_be_empty();
+        ut.expect(expectations_helpers.get_failed_expect_as_anydata()).not_to_be_empty();
     end;
 
     procedure initialized_nested_table
@@ -272,7 +272,7 @@ is
         execute immediate expectations_helpers.unary_expectation_object_block('to_be_null', gc_nested_table_name,
                                                                                 gc_nested_table_name||'()', 'collection');
         --Assert
-        ut.expect(anydata.convertCollection(ut3.ut_expectation_processor.get_failed_expectations())).not_to_be_empty();
+        ut.expect(expectations_helpers.get_failed_expect_as_anydata()).not_to_be_empty();
     end;
 
     procedure initialized_varray
@@ -282,7 +282,7 @@ is
         execute immediate expectations_helpers.unary_expectation_object_block('to_be_null', gc_varray_name,
                                                                                 gc_varray_name||'()', 'collection');
         --Assert
-        ut.expect(anydata.convertCollection(ut3.ut_expectation_processor.get_failed_expectations())).not_to_be_empty();
+        ut.expect(expectations_helpers.get_failed_expect_as_anydata()).not_to_be_empty();
     end;
 
 end test_expect_to_be_null;

--- a/test/helpers/expectations_helpers.pkb
+++ b/test/helpers/expectations_helpers.pkb
@@ -50,5 +50,12 @@ is
 
         return l_execute;
     end;
+
+    function get_failed_expect_as_anydata
+        return anydata
+    is
+    begin
+        return anydata.convertCollection(ut3.ut_expectation_processor.get_failed_expectations());
+    end;
 end expectations_helpers;
 /

--- a/test/helpers/expectations_helpers.pks
+++ b/test/helpers/expectations_helpers.pks
@@ -17,5 +17,8 @@ is
                                         a_data_type_2 in varchar2,
                                         a_data_value_2 in varchar2)
         return varchar2;
+
+    function get_failed_expect_as_anydata
+        return anydata;
 end expectations_helpers;
 /


### PR DESCRIPTION
Aligned ut_documentation_reporter with disabled annotation

Call to this line: anydata.convertCollection(ut3.ut_expectation_processor.get_failed_expectations()) refactored to this: expectations_helpers.get_failed_expect_as_anydata()