### PR TITLE
Feature/documentation throws annotation

### DIFF
--- a/docs/userguide/annotations.md
+++ b/docs/userguide/annotations.md
@@ -4,64 +4,101 @@ Annotations are used to configure tests and suites in a declarative way similar 
 No configuration files or tables are needed. The annotation names are based on popular testing frameworks such as jUnit.
 The framework runner searches for all the suitable annotated packages, automatically configures suites, forms the suite hierarchy, executes it and reports results in specified formats.
 
-Annotations are interpreted only in the package specification and are case-insensitive. It is recommended however, to use  lower-case annotations as described in this documentation.
+Annotations are interpreted only in the package specification and are case-insensitive. We strongly recommend using lower-case annotations as described in this documentation.
 
-There are two places where annotations may appear:
+There are two locations where annotations can be placed:
+- Package level annotations can be placed at the very top of the package specification (`--%suite`, `--%suitepath` etc.)
+- Procedure level annotations can be placed right before a procedure (`--%test`, `--%beforeall`, `--%beforeeach` etc.)
 
-- at the beginning of the package specification (`%suite`, `%suitepath` etc.)
-- right before a procedure (`%test`, `%beforeall`, `%beforeeach` etc.)
+If procedure level annotation is not placed right before procedure, it is not considered an annotation for procedure.
+
+Example of invalid procedure level annotations 
+```sql
+create or replace package test_pkg is
+
+  --%suite(Name of suite)
+
+  --%test
+  -- this single-line comment makes the TEST annotation no longer associated with the procedure  
+  procedure first_test;
+
+  --%test
+  --procedure some_test; /* This TEST annotation is not associated with any procedure*/
+
+  --%test(Name of another test)
+  procedure another_test;
+
+  --%test
+  /**
+  * this multi-line comment makes the TEST annotation no longer associated with the procedure  
+  */
+  procedure yet_another_test;
+end test_pkg;
+```
+Procedure annotations are defined right before the procedure they reference, no empty lines are allowed, no comment lines can exist between annotation and the procedure.
+
 
 Package level annotations need to be separated by at least one empty line from the underlying procedure annotations.
 
-Procedure annotations are defined right before the procedure they reference, no empty lines are allowed.
+Example of invalid package level annotation. 
+```sql
+create or replace package test_pkg is
+  --%suite(Name of suite)
+  --%test
+  procedure first_test;
+end test_pkg;
+```
 
-If a package specification contains the `%suite` annotation, it is treated as a test package and is processed by the framework.
+If a package specification contains the `--%suite` annotation, it is treated as a test package and is processed by the framework.
 
-Some annotations accept parameters like `%suite`, `%test` and `%displayname`. The parameters for annotations need to be placed in brackets. Values for parameters should be provided without any quotation marks.
+Some annotations accept parameters like `--%suite`, `--%test` and `--%displayname`. The parameters for annotations need to be placed in brackets.
+Values for parameters should be provided without any quotation marks.
+If the parameters are placed without brackets or with incomplete brackets, they will be ignored.
+Example: `--%suite(The name of suite without closing bracket`
 
 # <a name="example"></a>Example of an annotated test package
 
 ```sql
 create or replace package test_pkg is
 
-  -- %suite(Name of suite)
-  -- %suitepath(all.globaltests)
+  --%suite(Name of suite)
+  --%suitepath(all.globaltests)
 
-  -- %beforeall
+  --%beforeall
   procedure global_setup;
 
-  -- %afterall
+  --%afterall
   procedure global_cleanup;
 
   /* Such comments are allowed */
 
-  -- %test
-  -- %displayname(Name of a test)
-  -- %throws(-20145,-20146,-20189,-20563)
+  --%test
+  --%displayname(Name of a test)
+  --%throws(-20145,-20146,-20189,-20563)
   procedure some_test;
 
-  -- %test(Name of another test)
-  -- %beforetest(setup_another_test)
-  -- %aftertest(cleanup_another_test)
+  --%test(Name of another test)
+  --%beforetest(setup_another_test)
+  --%aftertest(cleanup_another_test)
   procedure another_test;
 
-  -- %test
-  -- %displayname(Name of test)
-  -- %disabled
+  --%test
+  --%displayname(Name of test)
+  --%disabled
   procedure disabled_test;
 
-  -- %test(Name of test)
-  -- %rollback(manual)
+  --%test(Name of test)
+  --%rollback(manual)
   procedure no_transaction_control_test;
 
   procedure setup_another_test;
 
   procedure cleanup_another_test;
 
-  -- %beforeeach
+  --%beforeeach
   procedure test_setup;
 
-  -- %aftereach
+  --%aftereach
   procedure test_cleanup;
 
 end test_pkg;
@@ -75,7 +112,7 @@ end test_pkg;
 | `%suitepath(<path>)` | Package | Similar to java package. The annotation allows logical grouping of suites into hierarchies. |
 | `%displayname(<description>)` | Package/procedure | Human-readable and meaningful description of a suite/test. `%displayname(Name of the suite/test)`. The annotation is provided for flexibility and convenience only. It has exactly the same meaning as `<description>` in `test` and `suite` annotations. If description is provided using both `suite`/`test` and `displayname`, then the one defined as last takes precedence. |
 | `%test(<description>)` | Procedure | Denotes that the annotated procedure is a unit test procedure.  Optional test description can by provided (see `displayname`). |
-| `%throws(<exception_number>)`| Test Procedure | Denotes that the annotated test procedure must throws one of the exception numbers written. If there are no valid number the annotation is ignored. Only applies to test procedures. |
+| `%throws(<exception_number>[,<exception_number>[,...]])`| Procedure | Denotes that the annotated procedure must throw one of the exception numbers provided. If no valid numbers were provided as annotation parameters the annotation is ignored. Applicable to test procedures only. |
 | `%beforeall` | Procedure | Denotes that the annotated procedure should be executed once before all elements of the suite. |
 | `%afterall` | Procedure | Denotes that the annotated procedure should be executed once after all elements of the suite. |
 | `%beforeeach` | Procedure | Denotes that the annotated procedure should be executed before each `%test` procedure in the suite. |
@@ -105,17 +142,17 @@ The `%suitepath` annotation is used for such grouping. Even though test packages
 ```sql
 create or replace package test_payment_recognition as
 
-  -- %suite(Payment recognition tests)
-  -- %suitepath(payments)
+  --%suite(Payment recognition tests)
+  --%suitepath(payments)
 
-  -- %test(Recognize payment by policy number)
+  --%test(Recognize payment by policy number)
   procedure test_recognize_by_num;
 
-  -- %test
-  -- %displayname(Recognize payment by payment purpose)
+  --%test
+  --%displayname(Recognize payment by payment purpose)
   procedure test_recognize_by_purpose;
 
-  -- %test(Recognize payment by customer)
+  --%test(Recognize payment by customer)
   procedure test_recognize_by_customer;
 
 end test_payment_recognition;
@@ -125,14 +162,14 @@ And payments set off test package:
 ```sql
 create or replace package test_payment_set_off as
 
-  -- %suite(Payment set off tests)
-  -- %suitepath(payments)
+  --%suite(Payment set off tests)
+  --%suitepath(payments)
 
-  -- %test(Set off creation test)
+  --%test(Set off creation test)
   procedure test_create_set_off;
 
-  -- %test
-  -- %displayname(Set off annulation test)
+  --%test
+  --%displayname(Set off annulation test)
   procedure test_annulate_set_off;
 
 end test_payment_set_off;
@@ -145,12 +182,12 @@ An additional advantage of such grouping is the fact that every element level of
 ```sql
 create or replace package payments as
 
-  -- %suite(Payments)
+  --%suite(Payments)
 
-  -- %beforeall
+  --%beforeall
   procedure set_common_payments_data;
 
-  -- %afterall
+  --%afterall
   procedure reset_common_paymnets_data;
 
 end payments;
@@ -169,7 +206,7 @@ In general, your unit tests should not use transaction control as long as the co
 Keeping the transactions uncommitted allows your changes to be isolated and the execution of tests does not impact others who might be using a shared development database.
 
 If you are in a situation where the code you are testing uses transaction control (common case with ETL code), then your tests probably should not use the default automatic transaction control.
-In that case use the annotation `-- %rollback(manual)` on the suite level to disable automatic transaction control for the entire suite.
+In that case use the annotation `--%rollback(manual)` on the suite level to disable automatic transaction control for the entire suite.
 If you are using nested suites, you need to make sure that the entire suite all the way to the root is using manual transaction control.
 
 It is possible with utPLSQL to change the transaction control on individual suites or tests that are part of complex suite.
@@ -240,70 +277,88 @@ exec ut_runner.purge_cache('HR', 'PACKAGE');
 
 # Throws annotation
 
-utPLSQL uses the `%throws` annotation to allow the user to delimit which exception numbers a test must throws.
+The `--%throws` annotation allows you to specify a list of exception numbers that can be expected from a test.
 
-If `%throws` is specified for one test and nothing is raise or a different exception than the annotated one is thrown, the test is marked as failed.
+If `--%throws(-20001,-20002)` is specified and no exception is raised or the exception raised is not on the list of provided exception numbers, the test is marked as failed.
 
-The framework discards the bad arguments, `--%throws(7894562, operaqk, -=1, -20496, pow74d, posdfk3)` it converts that to this `--%throws(-20496)`.
-If the arguments is empty `--%throws()`,`--%throws`, or only no valid arguments are provided `--%throws(abe, 723pf)` the annotation is ignored.
+The framework ignores bad arguments. `--%throws(7894562, operaqk, -=1, -20496, pow74d, posdfk3)` will be interpreted as `--%throws(-20496)`.
+The annotation is ignored, when no valid arguments are provided `--%throws()`,`--%throws`, `--%throws(abe, 723pf)`.
 
-Example how to use the annotation:
-
-```
+Example:
+```sql
 create or replace package example_pgk as
 
-  -- %suite(Example Throws Annotation)
+  --%suite(Example Throws Annotation)
 
-  -%test(Throws one of the listed exceptions)
+  --%test(Throws one of the listed exceptions)
   --%throws(-20145,-20146, -20189 ,-20563)
   procedure raised_one_listed_exception;
 
-  --%test(Throws diff exception)
+  --%test(Throws different exception than expected)
   --%throws(-20144)
-  procedure raised_diff_exception;
+  procedure raised_different_exception;
 
-  --%test(Givess failure when a exception is expected and nothing is thrown)
+  --%test(Throws different exception than listed)
+  --%throws(-20144,-00001,-20145)
+  procedure raised_unlisted_exception;
+
+  --%test(Gives failure when an exception is expected and nothing is thrown)
   --%throws(-20459, -20136, -20145)
   procedure nothing_thrown;
 
 end;  
-```
-
-```
-create package body annotated_package_with_throws is
+/
+create or replace package body example_pgk is
   procedure raised_one_listed_exception is
   begin
       raise_application_error(-20189, 'Test error');
   end;
 
-  procedure raised_diff_exception is
+  procedure raised_different_exception is
+  begin
+      raise_application_error(-20143, 'Test error');
+  end;
+
+  procedure raised_unlisted_exception is
   begin
       raise_application_error(-20143, 'Test error');
   end;
 
   procedure nothing_thrown is
   begin
-      null;
+      ut.expect(1).to_equal(1);
   end;
 end;
+/
+        
+exec ut.run('example_pgk');
 ```
 
-The test results are:
-
+Running the test will give report:
 ```
 Example Throws Annotation
-  Throws one of the listed exceptions [.011 sec]
-  Throws diff exception [.011 sec] (FAILED - 1)
-  Givess failure when a exception is expected and nothing is thrown [.014 sec] (FAILED - 2)
-
+  Throws one of the listed exceptions [.018 sec]
+  Throws different exception than expected [.008 sec] (FAILED - 1)
+  Throws different exception than listed [.007 sec] (FAILED - 2)
+  Gives failure when an exception is expected and nothing is thrown [.002 sec] (FAILED - 3)
+ 
 Failures:
-
-  1) raised_diff_exception
-      UT3.annotated_package_with_throws.raised_diff_exception Actual: -20143 was expected to be one of (-20144)
-
-  2) nothing_thrown
-      UT3.annotated_package_with_throws.nothing_thrown Expected one of exceptions (-20459,-20136,-20145) but nothing was raised.
-
-Finished in .040591 seconds
-3 tests, 2 failed, 0 errored, 0 disabled, 0 warning(s)
+ 
+  1) raised_different_exception
+      Actual: -20143 was expected to equal: -20144
+      ORA-20143: Test error
+      ORA-06512: at "UT3.EXAMPLE_PGK", line 9
+      ORA-06512: at line 6
+       
+  2) raised_unlisted_exception
+      Actual: -20143 was expected to be one of: (-20144, -1, -20145)
+      ORA-20143: Test error
+      ORA-06512: at "UT3.EXAMPLE_PGK", line 14
+      ORA-06512: at line 6
+       
+  3) nothing_thrown
+      Expected one of exceptions (-20459, -20136, -20145) but nothing was raised.
+       
+Finished in .038692 seconds
+4 tests, 3 failed, 0 errored, 0 disabled, 0 warning(s)
 ```

--- a/docs/userguide/exception-reporting.md
+++ b/docs/userguide/exception-reporting.md
@@ -2,19 +2,19 @@
 
 The utPLSQL is responsible for handling exceptions wherever they occur in the test run. utPLSQL is trapping most of the exceptions so that the test execution is not affected by individual tests or test packages throwing an exception.
 The framework provides a full stacktrace for every exception that was thrown. The stacktrace is clean and does not include any utPLSQL library calls in it.
-To achieve rerunability, the ORA-04068, ORA-04061 exceptions are not handled and test execution will be interrupted if such exception is encountered. This is because of how Oracle behaves on those exceptions.
+To achieve rerunability, the package state invalidation exceptions (ORA-04068, ORA-04061) are not handled and test execution will be interrupted if such exceptions are encountered. This is because of how Oracle behaves on those exceptions.
 
 Test execution can fail for different reasons. The failures on different exceptions are handled as follows:
-* A test package without body - each `%test` is reported as failed with exception, nothing is executed
-* A test package with _invalid body_ - each `%test` is reported as failed with exception, nothing is executed
+* A test package without body - each `--%test` is reported as failed with exception, nothing is executed
+* A test package with _invalid body_ - each `--%test` is reported as failed with exception, nothing is executed
 * A test package with _invalid spec_ - package is not considered a valid unit test package and is excluded from execution. When trying to run a test package with invalid spec explicitly, exception is raised. Only valid specifications are parsed for annotations 
-* A test package that is raising an exception in `%beforeall` - each `%test` is reported as failed with exception, `%test`, `%beforeeach`, `%beforetest`, `%aftertest` and `%aftereach` are not executed. `%afterall` is executed to allow cleanup of whatever was done in `%beforeall`
-* A test package that is raising an exception in `%beforeeach` - each `%test` is reported as failed with exception, `%test`, `%beforetest` and `%aftertest` is not executed. The `%aftereach` and `%afterall` blocks are getting executed to allow cleanup of whatever was done in `%before...` blocks
-* A test package that is raising an exception in `%beforetest` - the `%test` is reported as failed  with exception, `%test` is not executed. The `%aftertest`, `%aftereach` and `%afterall` blocks are getting executed to allow cleanup of whatever was done in `%before...` blocks
-* A test package that is raising an exception in `%test` - the `%test` is reported as failed with exception. The execution of other blocks continues normally
-* A test package that is raising an exception in `%aftertest` - the `%test` is reported as failed with exception. The execution of other blocks continues normally
-* A test package that is raising an exception in `%aftereach` - each `%test` is reported as failed with exception.
-* A test package that is raising an exception in `%afterall` - all blocks of  the package are executed, as the `%afterall` is the last step of package execution. Exception in `%afterall` is not affecting test results. A warning with exception stacktrace is displayed in the summary
+* A test package that is raising an exception in `--%beforeall` - each `--%test` is reported as failed with exception, `--%test`, `--%beforeeach`, `--%beforetest`, `--%aftertest` and `--%aftereach` are not executed. `--%afterall` is executed to allow cleanup of whatever was done in `--%beforeall`
+* A test package that is raising an exception in `--%beforeeach` - each `--%test` is reported as failed with exception, `--%test`, `--%beforetest` and `--%aftertest` is not executed. The `--%aftereach` and `--%afterall` blocks are getting executed to allow cleanup of whatever was done in `--%before...` blocks
+* A test package that is raising an exception in `--%beforetest` - the `--%test` is reported as failed  with exception, `--%test` is not executed. The `--%aftertest`, `--%aftereach` and `--%afterall` blocks are getting executed to allow cleanup of whatever was done in `--%before...` blocks
+* A test package that is raising an exception in `--%test` - the `--%test` is reported as failed with exception. The execution of other blocks continues normally
+* A test package that is raising an exception in `--%aftertest` - the `--%test` is reported as failed with exception. The execution of other blocks continues normally
+* A test package that is raising an exception in `--%aftereach` - each `--%test` is reported as failed with exception.
+* A test package that is raising an exception in `--%afterall` - all blocks of  the package are executed, as the `--%afterall` is the last step of package execution. Exception in `--%afterall` is not affecting test results. A warning with exception stacktrace is displayed in the summary
 
 
 Example of reporting with exception thrown in `%beforetest`:

--- a/old_tests/ut_utils/ut_utils.table_to_clob.sql
+++ b/old_tests/ut_utils/ut_utils.table_to_clob.sql
@@ -1,4 +1,4 @@
-@@lib/RunTest.sql "ut_utils/common/ut_utils.table_to_clob.sql null                                   ''',''' ''''''"
+@@lib/RunTest.sql "ut_utils/common/ut_utils.table_to_clob.sql "cast(null as ut_varchar2_list)"       ''',''' ''''''"
 @@lib/RunTest.sql "ut_utils/common/ut_utils.table_to_clob.sql ut_varchar2_list()                     ''',''' ''''''"
 @@lib/RunTest.sql "ut_utils/common/ut_utils.table_to_clob.sql ut_varchar2_list('a','b','c','d')      ''',''' '''a,b,c,d''' "
 @@lib/RunTest.sql "ut_utils/common/ut_utils.table_to_clob.sql ut_varchar2_list('1,b,','c,d')         ''',''' '''1,b,,c,d'''"

--- a/source/core/types/ut_executable_test.tpb
+++ b/source/core/types/ut_executable_test.tpb
@@ -13,7 +13,7 @@ create or replace type body ut_executable_test as
 
   member procedure do_execute(
     self in out nocopy ut_executable_test, a_item in out nocopy ut_suite_item, 
-    a_listener in out nocopy ut_event_listener_base, a_expected_error_codes in ut_varchar2_list := null
+    a_listener in out nocopy ut_event_listener_base, a_expected_error_codes in ut_integer_list
   ) is
     l_completed_without_errors  boolean;
   begin
@@ -22,29 +22,30 @@ create or replace type body ut_executable_test as
 
   member function do_execute(
     self in out nocopy ut_executable_test, a_item in out nocopy ut_suite_item, 
-    a_listener in out nocopy ut_event_listener_base, a_expected_error_codes in ut_varchar2_list := null
+    a_listener in out nocopy ut_event_listener_base, a_expected_error_codes in ut_integer_list
   ) return boolean is
-    l_ut_executable ut_executable;
     l_expected_except_message  varchar2(4000);
 
-    function failed_expec_errnum_message(a_error_stack in varchar2, a_expected_error_codes in ut_varchar2_list) return varchar is
-      l_actual_error_no integer;
+    function failed_expec_errnum_message(a_expected_error_codes in ut_integer_list) return varchar is
+      l_actual_error_no      integer;
       l_expected_error_codes varchar2(4000);
-      l_list_expect_error_codes ut_varchar2_list;
-      l_fail_message varchar2(4000);
+      l_fail_message         varchar2(4000);
     begin
       --Convert the ut_varchar2_list to string to can construct the message
-      l_expected_error_codes := ut_utils.table_to_clob(a_expected_error_codes, ',');
+      l_expected_error_codes := ut_utils.table_to_clob(a_expected_error_codes, ', ');
 
-      if a_error_stack is null then
+      if self.error_stack is null then
         l_fail_message := 'Expected one of exceptions ('||l_expected_error_codes||') but nothing was raised.';
       else
-        l_actual_error_no := regexp_substr(a_error_stack, '^ORA(-[0-9]+)', subexpression=>1);
-
-        if l_actual_error_no member of a_expected_error_codes then
-          l_fail_message := null;
-        else
-          l_fail_message := 'Actual: '||l_actual_error_no||' was expected to be one of ('||l_expected_error_codes||')';
+        l_actual_error_no := regexp_substr(self.error_stack, '^[a-zA-Z]{3}(-[0-9]+)', subexpression=>1);
+        if not l_actual_error_no member of a_expected_error_codes then
+          l_fail_message := 'Actual: '||l_actual_error_no||' was expected to ';
+          if cardinality(a_expected_error_codes) > 1 then
+            l_fail_message := l_fail_message || 'be one of: ('||l_expected_error_codes||')';
+          else
+            l_fail_message := l_fail_message || 'equal: '||l_expected_error_codes;
+          end if;
+          l_fail_message := substr( l_fail_message||chr(10)||self.error_stack||chr(10)||self.error_backtrace, 1, 4000 );
         end if;
       end if;
 
@@ -52,21 +53,18 @@ create or replace type body ut_executable_test as
     end;
   begin
     --Create a ut_executable object and call do_execute after that get the data to know the test's execution result
-    l_ut_executable := treat(self as ut_executable);
-    l_ut_executable.do_execute(a_item, a_listener);
-    self.serveroutput := l_ut_executable.serveroutput;
+    self.do_execute(a_item, a_listener);
 
     if a_expected_error_codes is not null and a_expected_error_codes is not empty then
-      l_expected_except_message := failed_expec_errnum_message(l_ut_executable.error_stack, a_expected_error_codes);
+      l_expected_except_message := failed_expec_errnum_message(a_expected_error_codes);
 
       if l_expected_except_message is not null then
         ut_expectation_processor.add_expectation_result(
-          ut_expectation_result(ut_utils.tr_failure, null, self.owner_name||'.'||self.object_name||'.'||self.procedure_name||' '||l_expected_except_message, false)
+          ut_expectation_result(ut_utils.tr_failure, null, l_expected_except_message, false)
         );
       end if;
-    else
-      self.error_stack := l_ut_executable.error_stack;
-      self.error_backtrace := l_ut_executable.error_backtrace;
+      self.error_stack := null;
+      self.error_backtrace := null;
     end if;
 
     return (self.error_stack||self.error_backtrace) is null;

--- a/source/core/types/ut_executable_test.tps
+++ b/source/core/types/ut_executable_test.tps
@@ -22,12 +22,12 @@ create or replace type ut_executable_test authid current_user under ut_executabl
   
   member procedure do_execute(
     self in out nocopy ut_executable_test, a_item in out nocopy ut_suite_item, 
-    a_listener in out nocopy ut_event_listener_base, a_expected_error_codes in ut_varchar2_list := null
+    a_listener in out nocopy ut_event_listener_base, a_expected_error_codes in ut_integer_list
   ),
   
   member function do_execute(
     self in out nocopy ut_executable_test, a_item in out nocopy ut_suite_item, 
-    a_listener in out nocopy ut_event_listener_base, a_expected_error_codes in ut_varchar2_list := null
+    a_listener in out nocopy ut_event_listener_base, a_expected_error_codes in ut_integer_list
   ) return boolean
   
 ) final;

--- a/source/core/types/ut_integer_list.tps
+++ b/source/core/types/ut_integer_list.tps
@@ -1,0 +1,19 @@
+create or replace type ut_integer_list as
+  /*
+  utPLSQL - Version 3
+  Copyright 2016 - 2017 utPLSQL Project
+
+  Licensed under the Apache License, Version 2.0 (the "License"):
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  */
+  table of integer
+/

--- a/source/core/types/ut_test.tpb
+++ b/source/core/types/ut_test.tpb
@@ -21,7 +21,7 @@ create or replace type body ut_test as
     a_path varchar2 := null, a_rollback_type integer := null, a_disabled_flag boolean := false,
     a_before_each_proc_name varchar2 := null, a_before_test_proc_name varchar2 := null,
     a_after_test_proc_name varchar2 := null, a_after_each_proc_name varchar2 := null,
-    a_expected_error_codes ut_varchar2_list := null
+    a_expected_error_codes ut_integer_list := null
   ) return self as result is
   begin
     self.self_type := $$plsql_unit;

--- a/source/core/types/ut_test.tps
+++ b/source/core/types/ut_test.tps
@@ -58,13 +58,13 @@ create or replace type ut_test under ut_suite_item (
   /**
   *Holds the expected error codes list when the user use the annotation throws
   */
-  expected_error_codes  ut_varchar2_list,
+  expected_error_codes  ut_integer_list,
   constructor function ut_test(
     self in out nocopy ut_test, a_object_owner varchar2 := null, a_object_name varchar2, a_name varchar2, a_description varchar2 := null,
     a_path varchar2 := null, a_rollback_type integer := null, a_disabled_flag boolean := false,
     a_before_each_proc_name varchar2 := null, a_before_test_proc_name varchar2 := null,
     a_after_test_proc_name varchar2 := null, a_after_each_proc_name varchar2 := null,
-    a_expected_error_codes ut_varchar2_list := null
+    a_expected_error_codes ut_integer_list := null
   ) return self as result,
   member function is_valid(self in out nocopy ut_test) return boolean,
   member procedure set_beforeeach(self in out nocopy ut_test, a_before_each_proc_name varchar2),

--- a/source/core/ut_utils.pkb
+++ b/source/core/ut_utils.pkb
@@ -255,14 +255,28 @@ create or replace package body ut_utils is
   end;
 
   function table_to_clob(a_text_table ut_varchar2_list, a_delimiter varchar2:= chr(10)) return clob is
-    l_result          clob;
-    l_text_table_rows integer := coalesce(cardinality(a_text_table),0);
+    l_result     clob;
+    l_table_rows integer := coalesce(cardinality(a_text_table),0);
   begin
-    for i in 1 .. l_text_table_rows loop
-      if i < l_text_table_rows then
+    for i in 1 .. l_table_rows loop
+      if i < l_table_rows then
         append_to_clob(l_result, a_text_table(i)||a_delimiter);
       else
         append_to_clob(l_result, a_text_table(i));
+      end if;
+    end loop;
+    return l_result;
+  end;
+
+  function table_to_clob(a_integer_table ut_integer_list, a_delimiter varchar2:= chr(10)) return clob is
+    l_result     clob;
+    l_table_rows integer := coalesce(cardinality(a_integer_table),0);
+  begin
+    for i in 1 .. l_table_rows loop
+      if i < l_table_rows then
+        append_to_clob(l_result, a_integer_table(i)||a_delimiter);
+      else
+        append_to_clob(l_result, a_integer_table(i));
       end if;
     end loop;
     return l_result;

--- a/source/core/ut_utils.pks
+++ b/source/core/ut_utils.pks
@@ -198,6 +198,8 @@ create or replace package ut_utils authid definer is
 
   function table_to_clob(a_text_table ut_varchar2_list, a_delimiter varchar2:= chr(10)) return clob;
 
+  function table_to_clob(a_integer_table ut_integer_list, a_delimiter varchar2:= chr(10)) return clob;
+
   /**
    * Returns time difference in seconds (with miliseconds) between given timestamps
    */

--- a/source/create_synonyms_and_grants_for_public.sql
+++ b/source/create_synonyms_and_grants_for_public.sql
@@ -56,6 +56,7 @@ grant execute on &&ut3_owner..ut_coveralls_reporter to public;
 grant execute on &&ut3_owner..ut_reporters to public;
 grant execute on &&ut3_owner..ut_varchar2_list to public;
 grant execute on &&ut3_owner..ut_varchar2_rows to public;
+grant execute on &&ut3_owner..ut_integer_list to public;
 grant execute on &&ut3_owner..ut_reporter_base to public;
 grant execute on &&ut3_owner..ut_coverage to public;
 grant execute on &&ut3_owner..ut_coverage_options to public;
@@ -109,6 +110,7 @@ create public synonym ut_coveralls_reporter for &&ut3_owner..ut_coveralls_report
 create public synonym ut_reporters for &&ut3_owner..ut_reporters;
 create public synonym ut_varchar2_list for &&ut3_owner..ut_varchar2_list;
 create public synonym ut_varchar2_rows for &&ut3_owner..ut_varchar2_rows;
+create public synonym ut_integer_list for &&ut3_owner..ut_integer_list;
 create public synonym ut_reporter_base for &&ut3_owner..ut_reporter_base;
 create public synonym ut_coverage for &&ut3_owner..ut_coverage;
 create public synonym ut_coverage_options for &&ut3_owner..ut_coverage_options;

--- a/source/create_synonyms_and_grants_for_user.sql
+++ b/source/create_synonyms_and_grants_for_user.sql
@@ -76,6 +76,7 @@ grant execute on &&ut3_owner..ut_coveralls_reporter to &ut3_user;
 grant execute on &&ut3_owner..ut_reporters to &ut3_user;
 grant execute on &&ut3_owner..ut_varchar2_list to &ut3_user;
 grant execute on &&ut3_owner..ut_varchar2_rows to &ut3_user;
+grant execute on &&ut3_owner..ut_integer_list to &ut3_user;
 grant execute on &&ut3_owner..ut_reporter_base to &ut3_user;
 grant execute on &&ut3_owner..ut_coverage to &ut3_user;
 grant execute on &&ut3_owner..ut_coverage_options to &ut3_user;
@@ -128,6 +129,7 @@ create or replace synonym &ut3_user..ut_coveralls_reporter for &&ut3_owner..ut_c
 create or replace synonym &ut3_user..ut_reporters for &&ut3_owner..ut_reporters;
 create or replace synonym &ut3_user..ut_varchar2_list for &&ut3_owner..ut_varchar2_list;
 create or replace synonym &ut3_user..ut_varchar2_rows for &&ut3_owner..ut_varchar2_rows;
+create or replace synonym &ut3_user..ut_integer_list for &&ut3_owner..ut_integer_list;
 create or replace synonym &ut3_user..ut_reporter_base for &&ut3_owner..ut_reporter_base;
 create or replace synonym &ut3_user..ut_coverage for &&ut3_owner..ut_coverage;
 create or replace synonym &ut3_user..ut_coverage_options for &&ut3_owner..ut_coverage_options;

--- a/source/install.sql
+++ b/source/install.sql
@@ -37,6 +37,7 @@ alter session set current_schema = &&ut3_owner;
 --common utilities
 @@install_component.sql 'core/types/ut_varchar2_list.tps'
 @@install_component.sql 'core/types/ut_varchar2_rows.tps'
+@@install_component.sql 'core/types/ut_integer_list.tps'
 @@install_component.sql 'core/types/ut_object_name.tps'
 @@install_component.sql 'core/types/ut_object_name.tpb'
 @@install_component.sql 'core/types/ut_object_names.tps'

--- a/source/uninstall.sql
+++ b/source/uninstall.sql
@@ -248,6 +248,8 @@ drop type ut_object_names force;
 
 drop type ut_object_name force;
 
+drop type ut_integer_list force;
+
 drop type ut_varchar2_list force;
 
 drop type ut_varchar2_rows force;

--- a/test/core/annotations/test_annot_throws_exception.pks
+++ b/test/core/annotations/test_annot_throws_exception.pks
@@ -1,17 +1,20 @@
 create or replace package test_annot_throws_exception
 is
-  --%suite(annotations- throws)
+  --%suite(annotations - throws)
   --%suitepath(utplsql.core.annotations)
     
   --%beforeall
-  procedure recolect_tests_results;
+  procedure recollect_tests_results;
   
   --%test(Gives success when annotated number exception is thrown)
   procedure throws_same_annotated_except;
-  
-  --%test(Gives succes when one of the annotated number exceptions is thrown)
+
+  --%test(Gives success when one of the annotated number exceptions is thrown)
   procedure throws_one_of_annotated_excpt;
-  
+
+  --%test(Gives success when annotated number exceptions has leading zero)
+  procedure throws_with_leading_zero;
+
   --%test(Gives failure when the raised exception is different that the annotated one)
   procedure throws_diff_annotated_except;
   


### PR DESCRIPTION
Resolves #585
Updated documentation for `--%throws` annotation. 
Updated documentation to assure that annotations are mentioned as `--%annotation` rather than `%annotation`
Fixed bug, where `--%throws(-00001)` would not catch exception `ORA-00001` due to leading zero.
Added full stack trace, when a different than expected exception was thrown.
Added ut_integer_list_type.
Cleanup of `ut_executable_test`
Reworked tests for `--%throws` to check for the test report text content.
