### PR TITLE
State invalidation no longer stops utPLSQL from running

### DIFF
--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -33,5 +33,6 @@ set feedback on
 --Needed for testing coverage outside of main UT3 schema.
 grant create any procedure, drop any procedure, execute any procedure, create any type, drop any type, execute any type, under any type, select any table, update any table, insert any table, delete any table, create any table, drop any table, alter any table, select any dictionary to $UT3_TESTER;
 revoke execute on dbms_crypto from $UT3_TESTER;
+grant create job to $UT3_TESTER;
 exit
 SQL

--- a/source/api/ut.pkb
+++ b/source/api/ut.pkb
@@ -94,6 +94,16 @@ create or replace package body ut is
     ut_expectation_processor.report_failure(a_message);
   end;
 
+  procedure raise_if_packages_invalidated is
+    e_package_invalidated exception;
+    pragma exception_init (e_package_invalidated, -04068);
+  begin
+    if ut_expectation_processor.invalidation_exception_found() then
+      ut_expectation_processor.reset_invalidation_exception();
+      raise e_package_invalidated;
+    end if;
+  end;
+
   procedure run_autonomous(
     a_paths ut_varchar2_list, a_reporter ut_reporter_base, a_color_console integer,
     a_coverage_schemes ut_varchar2_list := null, a_source_file_mappings ut_file_mappings, a_test_file_mappings ut_file_mappings,
@@ -149,6 +159,8 @@ create or replace package body ut is
       end loop;
       close l_lines;
     end if;
+    raise_if_packages_invalidated();
+    return;
   end;
 
   function run(
@@ -174,6 +186,8 @@ create or replace package body ut is
       end loop;
       close l_lines;
     end if;
+    raise_if_packages_invalidated();
+    return;
   end;
 
   function run(
@@ -198,6 +212,8 @@ create or replace package body ut is
       end loop;
       close l_lines;
     end if;
+    raise_if_packages_invalidated();
+    return;
   end;
 
   function run(
@@ -222,6 +238,8 @@ create or replace package body ut is
       end loop;
       close l_lines;
     end if;
+    raise_if_packages_invalidated();
+    return;
   end;
 
   function run(
@@ -247,6 +265,8 @@ create or replace package body ut is
       end loop;
       close l_lines;
     end if;
+    raise_if_packages_invalidated();
+    return;
   end;
 
   function run(
@@ -272,6 +292,8 @@ create or replace package body ut is
       end loop;
       close l_lines;
     end if;
+    raise_if_packages_invalidated();
+    return;
   end;
 
   procedure run(
@@ -288,6 +310,7 @@ create or replace package body ut is
     if l_reporter is of (ut_output_reporter_base) then
         treat(l_reporter as ut_output_reporter_base).lines_to_dbms_output();
     end if;
+    raise_if_packages_invalidated();
   end;
 
   procedure run(
@@ -304,6 +327,7 @@ create or replace package body ut is
     if l_reporter is of (ut_output_reporter_base) then
       treat(l_reporter as ut_output_reporter_base).lines_to_dbms_output();
     end if;
+    raise_if_packages_invalidated();
   end;
 
   procedure run(

--- a/source/api/ut_runner.pkb
+++ b/source/api/ut_runner.pkb
@@ -73,6 +73,7 @@ create or replace package body ut_runner is
     l_listener     ut_event_listener;
   begin
     begin
+      ut_expectation_processor.reset_invalidation_exception();
       ut_utils.save_dbms_output_to_cache();
 
       ut_console_reporter_base.set_color_enabled(a_color_console);

--- a/source/core/types/ut_executable.tpb
+++ b/source/core/types/ut_executable.tpb
@@ -114,9 +114,6 @@ create or replace type body ut_executable is
       '      l_error_stack := dbms_utility.format_error_stack;' || chr(10) ||
       '      l_error_backtrace := dbms_utility.format_error_backtrace;' || chr(10) ||
       '      --raise on ORA-04068, ORA-04061: existing state of packages has been discarded to avoid unrecoverable session exception' || chr(10) ||
-      '      if l_error_stack like ''%ORA-04068%'' or l_error_stack like ''%ORA-04061%'' then' || chr(10) ||
-      '        raise;' || chr(10) ||
-      '      end if;' || chr(10) ||
       '  end;' || chr(10) ||
       '  :a_error_stack := l_error_stack;' || chr(10) ||
       '  :a_error_backtrace := l_error_backtrace;' || chr(10) ||
@@ -137,7 +134,9 @@ create or replace type body ut_executable is
       save_dbms_output;
 
       l_completed_without_errors := (self.error_stack||self.error_backtrace) is null;
-
+      if self.error_stack like '%ORA-04068%' or self.error_stack like '%ORA-04061%' then
+        ut_expectation_processor.set_invalidation_exception();
+      end if;
       --listener - after call to executable
       a_listener.fire_after_event(self.associated_event_name, a_item);
 

--- a/source/core/ut_expectation_processor.pkb
+++ b/source/core/ut_expectation_processor.pkb
@@ -26,6 +26,8 @@ create or replace package body ut_expectation_processor as
 
   g_nulls_are_equal boolean_not_null := gc_default_nulls_are_equal;
 
+  g_package_invalidated boolean := false;
+
   function nulls_are_equal return boolean is
   begin
     return g_nulls_are_equal;
@@ -169,6 +171,21 @@ create or replace package body ut_expectation_processor as
   function get_warnings return ut_varchar2_list is
   begin
     return g_warnings;
+  end;
+
+  function invalidation_exception_found return boolean is
+  begin
+    return g_package_invalidated;
+  end;
+
+  procedure set_invalidation_exception is
+  begin
+    g_package_invalidated := true;
+  end;
+
+  procedure reset_invalidation_exception is
+  begin
+    g_package_invalidated := false;
   end;
 
 end;

--- a/source/core/ut_expectation_processor.pks
+++ b/source/core/ut_expectation_processor.pks
@@ -52,5 +52,9 @@ create or replace package ut_expectation_processor authid current_user as
 
   function get_warnings return ut_varchar2_list;
 
+  function invalidation_exception_found return boolean;
+  procedure set_invalidation_exception;
+  procedure reset_invalidation_exception;
+
 end;
 /

--- a/test/api/test_ut_run.pkb
+++ b/test/api/test_ut_run.pkb
@@ -1,0 +1,117 @@
+create or replace package body test_ut_run is
+
+  procedure create_test_suite is
+    pragma autonomous_transaction;
+  begin
+    execute immediate q'[
+      create or replace package stateful_package as
+        g_state varchar2(1) := 'A';
+      end;
+    ]';
+    execute immediate q'[
+      create or replace package test_stateful as
+        --%suite
+        --%suitepath(test_state)
+
+        --%test
+        procedure stateful_success;
+
+        --%test
+        --%beforetest(recompile_in_background)
+        procedure failing_stateful_test;
+
+        procedure recompile_in_background;
+
+        --%test
+        procedure dummy_success;
+
+      end;
+    ]';
+    execute immediate q'{
+    create or replace package body test_stateful as
+
+      procedure stateful_success is
+      begin
+        ut3.ut.expect(stateful_package.g_state).to_equal('A');
+      end;
+
+      procedure failing_stateful_test is
+      begin
+        ut3.ut.expect(stateful_package.g_state).to_equal('abc');
+      end;
+
+      procedure dummy_success is
+      begin
+        ut3.ut.expect(1).to_equal(1);
+      end;
+
+      procedure recompile_in_background is
+        l_job_name varchar2(30) := 'recreate_stateful_package';
+        l_cnt      integer      := 1;
+        pragma autonomous_transaction;
+      begin
+        dbms_scheduler.create_job(
+          job_name      =>  l_job_name,
+          job_type      =>  'PLSQL_BLOCK',
+          job_action    =>  q'/
+            begin
+              execute immediate q'[
+                create or replace package stateful_package as
+                  g_state varchar2(3) := 'abc';
+                end;]';
+            end;/',
+          start_date    =>  sysdate,
+          enabled       =>  TRUE,
+          auto_drop     =>  TRUE,
+          comments      =>  'one-time job'
+        );
+        dbms_lock.sleep(0.2);
+        while l_cnt > 0 loop
+          select count(1) into l_cnt
+            from dba_scheduler_running_jobs srj
+           where srj.job_name = l_job_name;
+        end loop;
+      end;
+    end;
+    }';
+
+  end;
+
+  procedure raise_in_invalid_state is
+    l_results   ut3.ut_varchar2_list;
+    l_expected  varchar2(32767);
+  begin
+    --Arrange
+    l_expected := 'test_state
+  test_stateful
+    stateful_success [% sec]
+    failing_stateful_test [% sec] (FAILED - 1)
+    dummy_success [% sec]%
+Failures:%
+  1) failing_stateful_test
+      ORA-04061: existing state of package "UT3_TESTER.STATEFUL_PACKAGE" has been invalidated
+      ORA-04065: not executed, altered or dropped package "UT3_TESTER.STATEFUL_PACKAGE"
+      ORA-06508: PL/SQL: could not find program unit being called: "UT3_TESTER.STATEFUL_PACKAGE"
+      ORA-06512: at "UT3_TESTER.TEST_STATEFUL", line 10%
+      ORA-06512: at line 6%
+3 tests, 0 failed, 1 errored, 0 disabled, 0 warning(s)%';
+
+    --Act
+    select * bulk collect into l_results from table(ut3.ut.run('test_stateful'));
+    --Assert
+    ut.fail('Expected exception but nothing was raised');
+  exception
+    when others then
+      ut.expect( ut3.ut_utils.table_to_clob(l_results) ).to_be_like( l_expected );
+      ut.expect(sqlcode).to_equal(-4068);
+  end;
+
+  procedure drop_test_suite is
+    pragma autonomous_transaction;
+  begin
+    execute immediate 'drop package stateful_package';
+    execute immediate 'drop package test_stateful';
+  end;
+
+end;
+/

--- a/test/api/test_ut_run.pks
+++ b/test/api/test_ut_run.pks
@@ -1,0 +1,12 @@
+create or replace package test_ut_run is
+  --%suite(ut_run)
+
+  procedure create_test_suite;
+  procedure drop_test_suite;
+
+  --%test(ut.run - raises after completing all tests if a test fails with ORA-04068 or ORA-04061)
+  --%beforetest(create_test_suite)
+  --%aftertest(drop_test_suite)
+  procedure raise_in_invalid_state;
+end;
+/

--- a/test/install_tests.sql
+++ b/test/install_tests.sql
@@ -16,6 +16,7 @@ whenever oserror exit failure rollback
 --Install tests
 @@core.pks
 @@api/test_ut_runner.pks
+@@api/test_ut_run.pks
 @@core/test_ut_utils.pks
 @@core/test_ut_suite.pks
 @@core/test_ut_test.pks
@@ -47,6 +48,7 @@ whenever oserror exit failure rollback
 
 @@core.pkb
 @@api/test_ut_runner.pkb
+@@api/test_ut_run.pkb
 @@core/test_ut_utils.pkb
 @@core/test_ut_suite.pkb
 @@core/test_ut_test.pkb


### PR DESCRIPTION
All tests will now get executed even if some of them fail due to package invalidation.
Resolves #504