### PR TITLE
Deprecation warnings are now showing in `ut_documentation_reporter` output.

### DIFF
--- a/source/core/types/ut_results_counter.tpb
+++ b/source/core/types/ut_results_counter.tpb
@@ -42,9 +42,9 @@ create or replace type body ut_results_counter as
     self.warnings_count := self.warnings_count + a_item.warnings_count;
   end;
 
-  member procedure increase_warning_count(self in out nocopy ut_results_counter) is
+  member procedure increase_warning_count(self in out nocopy ut_results_counter, a_count integer := 1) is
   begin
-    self.warnings_count := self.warnings_count + 1;
+    self.warnings_count := self.warnings_count + nvl(a_count,0);
   end;
 
   member function total_count return integer is

--- a/source/core/types/ut_results_counter.tps
+++ b/source/core/types/ut_results_counter.tps
@@ -23,7 +23,7 @@ create or replace type ut_results_counter as object(
   constructor function ut_results_counter(self in out nocopy ut_results_counter) return self as result,
   member procedure set_counter_values(self in out nocopy ut_results_counter, a_status integer),
   member procedure sum_counter_values(self in out nocopy ut_results_counter, a_item ut_results_counter),
-  member procedure increase_warning_count(self in out nocopy ut_results_counter),
+  member procedure increase_warning_count(self in out nocopy ut_results_counter, a_count integer := 1),
   member function total_count return integer,
   member function result_status return integer
 )

--- a/source/core/ut_expectation_processor.pkb
+++ b/source/core/ut_expectation_processor.pkb
@@ -168,6 +168,14 @@ create or replace package body ut_expectation_processor as
     g_warnings(g_warnings.last) := a_messsage;
   end;
 
+  procedure add_depreciation_warning(a_deprecated_syntax varchar2, a_new_syntax varchar2) is
+  begin
+    add_warning(
+      ut_utils.build_depreciation_warning( a_deprecated_syntax, a_new_syntax ) || chr(10)
+      || ut_expectation_processor.who_called_expectation(dbms_utility.format_call_stack())
+    );
+  end;
+
   function get_warnings return ut_varchar2_list is
   begin
     return g_warnings;

--- a/source/core/ut_expectation_processor.pks
+++ b/source/core/ut_expectation_processor.pks
@@ -50,6 +50,8 @@ create or replace package ut_expectation_processor authid current_user as
 
   procedure add_warning(a_messsage varchar2);
 
+  procedure add_depreciation_warning(a_deprecated_syntax varchar2, a_new_syntax varchar2);
+
   function get_warnings return ut_varchar2_list;
 
   function invalidation_exception_found return boolean;

--- a/source/core/ut_utils.pkb
+++ b/source/core/ut_utils.pkb
@@ -496,9 +496,9 @@ procedure append_to_clob(a_src_clob in out nocopy clob, a_clob_table t_clob_tab,
 
   function build_depreciation_warning(a_old_syntax varchar2, a_new_syntax varchar2) return varchar2 is
   begin
-    return 'The syntax: "'||a_old_syntax||'" is depreciated.' ||chr(10)||
+    return 'The syntax: "'||a_old_syntax||'" is deprecated.' ||chr(10)||
            'Please use the new syntax: "'||a_new_syntax||'".' ||chr(10)||
-           'The depreciated syntax will not be supported in future releases.';
+           'The deprecated syntax will not be supported in future releases.';
   end;
 
   function to_xml_number_format(a_value number) return varchar2 is

--- a/source/expectations/matchers/ut_equal.tpb
+++ b/source/expectations/matchers/ut_equal.tpb
@@ -38,13 +38,11 @@ create or replace type body ut_equal as
   end;
 
   constructor function ut_equal(self in out nocopy ut_equal, a_expected anydata, a_exclude varchar2, a_nulls_are_equal boolean := null) return self as result is
-    l_depreciated integer;
+    l_deprecated integer;
   begin
-    ut_expectation_processor.add_warning(
-      ut_utils.build_depreciation_warning(
-        'equal( a_expected anydata, a_exclude varchar2 )',
-        'equal( a_expected anydata ).exclude( a_exclude varchar2 )'
-      )
+    ut_expectation_processor.add_depreciation_warning(
+      'equal( a_expected anydata, a_exclude varchar2 )',
+      'equal( a_expected anydata ).exclude( a_exclude varchar2 )'
     );
     init(ut_data_value_anydata.get_instance(a_expected), a_nulls_are_equal);
     exclude_list := ut_varchar2_list(a_exclude);
@@ -53,11 +51,9 @@ create or replace type body ut_equal as
 
   constructor function ut_equal(self in out nocopy ut_equal, a_expected anydata, a_exclude ut_varchar2_list, a_nulls_are_equal boolean := null) return self as result is
   begin
-    ut_expectation_processor.add_warning(
-        ut_utils.build_depreciation_warning(
-            'equal( a_expected anydata, a_exclude ut_varchar2_list )',
-            'equal( a_expected anydata ).exclude( a_exclude ut_varchar2_list )'
-        )
+    ut_expectation_processor.add_depreciation_warning(
+      'equal( a_expected anydata, a_exclude ut_varchar2_list )',
+      'equal( a_expected anydata ).exclude( a_exclude ut_varchar2_list )'
     );
     init(ut_data_value_anydata.get_instance(a_expected), a_nulls_are_equal);
     exclude_list := coalesce(a_exclude, ut_varchar2_list());
@@ -102,11 +98,9 @@ create or replace type body ut_equal as
 
   constructor function ut_equal(self in out nocopy ut_equal, a_expected sys_refcursor, a_exclude varchar2, a_nulls_are_equal boolean := null) return self as result is
   begin
-    ut_expectation_processor.add_warning(
-        ut_utils.build_depreciation_warning(
-            'equal( a_expected sys_refcursor, a_exclude varchar2 )',
-            'equal( a_expected sys_refcursor ).exclude( a_exclude varchar2 )'
-        )
+    ut_expectation_processor.add_depreciation_warning(
+      'equal( a_expected sys_refcursor, a_exclude varchar2 )',
+      'equal( a_expected sys_refcursor ).exclude( a_exclude varchar2 )'
     );
     init(ut_data_value_refcursor(a_expected), a_nulls_are_equal);
     exclude_list := ut_varchar2_list(a_exclude);
@@ -115,11 +109,9 @@ create or replace type body ut_equal as
 
   constructor function ut_equal(self in out nocopy ut_equal, a_expected sys_refcursor, a_exclude ut_varchar2_list, a_nulls_are_equal boolean := null) return self as result is
   begin
-    ut_expectation_processor.add_warning(
-        ut_utils.build_depreciation_warning(
-            'equal( a_expected sys_refcursor, a_exclude ut_varchar2_list )',
-            'equal( a_expected sys_refcursor ).exclude( a_exclude ut_varchar2_list )'
-        )
+    ut_expectation_processor.add_depreciation_warning(
+      'equal( a_expected sys_refcursor, a_exclude ut_varchar2_list )',
+      'equal( a_expected sys_refcursor ).exclude( a_exclude ut_varchar2_list )'
     );
     init(ut_data_value_refcursor(a_expected), a_nulls_are_equal);
     exclude_list := coalesce(a_exclude, ut_varchar2_list());

--- a/source/expectations/ut_expectation.tpb
+++ b/source/expectations/ut_expectation.tpb
@@ -138,22 +138,18 @@ create or replace type body ut_expectation as
 
   member procedure to_equal(self in ut_expectation, a_expected sys_refcursor, a_exclude varchar2, a_nulls_are_equal boolean := null) is
   begin
-    ut_expectation_processor.add_warning(
-        ut_utils.build_depreciation_warning(
-            'to_equal( a_expected sys_refcursor, a_exclude varchar2 )',
-            'to_equal( a_expected sys_refcursor ).exclude( a_exclude varchar2 )'
-        )
+    ut_expectation_processor.add_depreciation_warning(
+      'to_equal( a_expected sys_refcursor, a_exclude varchar2 )',
+      'to_equal( a_expected sys_refcursor ).exclude( a_exclude varchar2 )'
     );
     self.to_( ut_equal(a_expected, a_nulls_are_equal).exclude(a_exclude) );
   end;
 
   member procedure to_equal(self in ut_expectation, a_expected sys_refcursor, a_exclude ut_varchar2_list, a_nulls_are_equal boolean := null) is
   begin
-    ut_expectation_processor.add_warning(
-        ut_utils.build_depreciation_warning(
-            'to_equal( a_expected sys_refcursor, a_exclude ut_varchar2_list )',
-            'to_equal( a_expected sys_refcursor ).exclude( a_exclude ut_varchar2_list )'
-        )
+    ut_expectation_processor.add_depreciation_warning(
+      'to_equal( a_expected sys_refcursor, a_exclude ut_varchar2_list )',
+      'to_equal( a_expected sys_refcursor ).exclude( a_exclude ut_varchar2_list )'
     );
     self.to_( ut_equal(a_expected, a_nulls_are_equal).exclude(a_exclude) );
   end;
@@ -196,22 +192,18 @@ create or replace type body ut_expectation as
 
   member procedure not_to_equal(self in ut_expectation, a_expected anydata, a_exclude varchar2, a_nulls_are_equal boolean := null) is
   begin
-    ut_expectation_processor.add_warning(
-        ut_utils.build_depreciation_warning(
-            'not_to_equal( a_expected anydata, a_exclude varchar2 )',
-            'not_to_equal( a_expected anydata ).exclude( a_exclude varchar2 )'
-        )
+    ut_expectation_processor.add_depreciation_warning(
+      'not_to_equal( a_expected anydata, a_exclude varchar2 )',
+      'not_to_equal( a_expected anydata ).exclude( a_exclude varchar2 )'
     );
     self.not_to( ut_equal(a_expected, a_nulls_are_equal).exclude(a_exclude) );
   end;
 
   member procedure not_to_equal(self in ut_expectation, a_expected anydata, a_exclude ut_varchar2_list, a_nulls_are_equal boolean := null) is
   begin
-    ut_expectation_processor.add_warning(
-        ut_utils.build_depreciation_warning(
-            'not_to_equal( a_expected anydata, a_exclude ut_varchar2_list )',
-            'not_to_equal( a_expected anydata ).exclude( a_exclude ut_varchar2_list )'
-        )
+    ut_expectation_processor.add_depreciation_warning(
+      'not_to_equal( a_expected anydata, a_exclude ut_varchar2_list )',
+      'not_to_equal( a_expected anydata ).exclude( a_exclude ut_varchar2_list )'
     );
     self.not_to( ut_equal(a_expected, a_nulls_are_equal).exclude(a_exclude) );
   end;
@@ -248,22 +240,18 @@ create or replace type body ut_expectation as
 
   member procedure not_to_equal(self in ut_expectation, a_expected sys_refcursor, a_exclude varchar2, a_nulls_are_equal boolean := null) is
   begin
-    ut_expectation_processor.add_warning(
-        ut_utils.build_depreciation_warning(
-            'not_to_equal( a_expected sys_refcursor, a_exclude varchar2 )',
-            'not_to_equal( a_expected sys_refcursor ).exclude( a_exclude varchar2 )'
-        )
+    ut_expectation_processor.add_depreciation_warning(
+      'not_to_equal( a_expected sys_refcursor, a_exclude varchar2 )',
+      'not_to_equal( a_expected sys_refcursor ).exclude( a_exclude varchar2 )'
     );
     self.not_to( ut_equal(a_expected, a_nulls_are_equal).exclude(a_exclude) );
   end;
 
   member procedure not_to_equal(self in ut_expectation, a_expected sys_refcursor, a_exclude ut_varchar2_list, a_nulls_are_equal boolean := null) is
   begin
-    ut_expectation_processor.add_warning(
-        ut_utils.build_depreciation_warning(
-            'not_to_equal( a_expected sys_refcursor, a_exclude ut_varchar2_list )',
-            'not_to_equal( a_expected sys_refcursor ).exclude( a_exclude ut_varchar2_list )'
-        )
+    ut_expectation_processor.add_depreciation_warning(
+      'not_to_equal( a_expected sys_refcursor, a_exclude ut_varchar2_list )',
+      'not_to_equal( a_expected sys_refcursor ).exclude( a_exclude ut_varchar2_list )'
     );
     self.not_to( ut_equal(a_expected, a_nulls_are_equal).exclude(a_exclude) );
   end;

--- a/source/reporters/ut_documentation_reporter.tpb
+++ b/source/reporters/ut_documentation_reporter.tpb
@@ -148,9 +148,7 @@ create or replace type body ut_documentation_reporter is
       if a_item is of (ut_logical_suite) then
         l_items := treat(a_item as ut_logical_suite).items;
         for i in 1 .. l_items.count loop
-          if l_items(i) is of(ut_suite_item) then
-            print_item_warnings(l_items(i));
-          end if;
+          print_item_warnings(l_items(i));
         end loop;
       end if;
 

--- a/test/core/expectations/compound_data/test_expectation_anydata.pkb
+++ b/test/core/expectations/compound_data/test_expectation_anydata.pkb
@@ -401,7 +401,7 @@ Rows: [ 1 differences ]
     ut3.ut.expect(get_anydata()).to_equal(get_anydata(), a_exclude => 'A_COLUMN,Some_Col');
     --Assert
     ut.expect(cardinality(ut3.ut_expectation_processor.get_warnings())).to_equal(1);
-    ut.expect(ut3.ut_expectation_processor.get_warnings()(1)).to_be_like('The syntax: "%" is depreciated.%');
+    ut.expect(ut3.ut_expectation_processor.get_warnings()(1)).to_be_like('The syntax: "%" is deprecated.%');
   end;
 
   procedure deprec_to_equal_excl_list is
@@ -410,7 +410,7 @@ Rows: [ 1 differences ]
     ut3.ut.expect(get_anydata()).to_equal(get_anydata(), a_exclude => ut3.ut_varchar2_list('A_COLUMN','Some_Col'));
     --Assert
     ut.expect(cardinality(ut3.ut_expectation_processor.get_warnings())).to_equal(1);
-    ut.expect(ut3.ut_expectation_processor.get_warnings()(1)).to_be_like('The syntax: "%" is depreciated.%');
+    ut.expect(ut3.ut_expectation_processor.get_warnings()(1)).to_be_like('The syntax: "%" is deprecated.%');
   end;
 
   procedure deprec_not_to_equal_excl_varch is
@@ -419,7 +419,7 @@ Rows: [ 1 differences ]
     ut3.ut.expect(get_anydata()).not_to_equal(get_anydata(), a_exclude => 'A_COLUMN,Some_Col');
     --Assert
     ut.expect(cardinality(ut3.ut_expectation_processor.get_warnings())).to_equal(1);
-    ut.expect(ut3.ut_expectation_processor.get_warnings()(1)).to_be_like('The syntax: "%" is depreciated.%');
+    ut.expect(ut3.ut_expectation_processor.get_warnings()(1)).to_be_like('The syntax: "%" is deprecated.%');
   end;
 
   procedure deprec_not_to_equal_excl_list is
@@ -428,7 +428,7 @@ Rows: [ 1 differences ]
     ut3.ut.expect(get_anydata()).not_to_equal(get_anydata(), a_exclude => ut3.ut_varchar2_list('A_COLUMN','Some_Col'));
     --Assert
     ut.expect(cardinality(ut3.ut_expectation_processor.get_warnings())).to_equal(1);
-    ut.expect(ut3.ut_expectation_processor.get_warnings()(1)).to_be_like('The syntax: "%" is depreciated.%');
+    ut.expect(ut3.ut_expectation_processor.get_warnings()(1)).to_be_like('The syntax: "%" is deprecated.%');
   end;
 
   procedure deprec_equal_excl_varch is
@@ -437,7 +437,7 @@ Rows: [ 1 differences ]
     ut3.ut.expect(get_anydata()).to_(ut3.equal(get_anydata(), a_exclude => 'A_COLUMN,Some_Col'));
     --Assert
     ut.expect(cardinality(ut3.ut_expectation_processor.get_warnings())).to_equal(1);
-    ut.expect(ut3.ut_expectation_processor.get_warnings()(1)).to_be_like('The syntax: "%" is depreciated.%');
+    ut.expect(ut3.ut_expectation_processor.get_warnings()(1)).to_be_like('The syntax: "%" is deprecated.%');
   end;
 
   procedure deprec_equal_excl_list is
@@ -446,7 +446,7 @@ Rows: [ 1 differences ]
     ut3.ut.expect(get_anydata()).to_(ut3.equal(get_anydata(), a_exclude => ut3.ut_varchar2_list('A_COLUMN','Some_Col')));
     --Assert
     ut.expect(cardinality(ut3.ut_expectation_processor.get_warnings())).to_equal(1);
-    ut.expect(ut3.ut_expectation_processor.get_warnings()(1)).to_be_like('The syntax: "%" is depreciated.%');
+    ut.expect(ut3.ut_expectation_processor.get_warnings()(1)).to_be_like('The syntax: "%" is deprecated.%');
   end;
 
   --%test(Reports only mismatched columns on column data mismatch)

--- a/test/core/expectations/compound_data/test_expectations_cursor.pkb
+++ b/test/core/expectations/compound_data/test_expectations_cursor.pkb
@@ -915,7 +915,7 @@ Rows: [ 4 differences ]
     ut3.ut.expect(get_cursor()).to_equal(get_cursor(), a_exclude => 'A_COLUMN,Some_Col');
     --Assert
     ut.expect(cardinality(ut3.ut_expectation_processor.get_warnings())).to_equal(1);
-    ut.expect(ut3.ut_expectation_processor.get_warnings()(1)).to_be_like('The syntax: "%" is depreciated.%');
+    ut.expect(ut3.ut_expectation_processor.get_warnings()(1)).to_be_like('The syntax: "%" is deprecated.%');
   end;
 
   procedure deprec_to_equal_excl_list is
@@ -924,7 +924,7 @@ Rows: [ 4 differences ]
     ut3.ut.expect(get_cursor()).to_equal(get_cursor(), a_exclude => ut3.ut_varchar2_list('A_COLUMN','Some_Col'));
     --Assert
     ut.expect(cardinality(ut3.ut_expectation_processor.get_warnings())).to_equal(1);
-    ut.expect(ut3.ut_expectation_processor.get_warnings()(1)).to_be_like('The syntax: "%" is depreciated.%');
+    ut.expect(ut3.ut_expectation_processor.get_warnings()(1)).to_be_like('The syntax: "%" is deprecated.%');
   end;
 
   procedure deprec_not_to_equal_excl_varch is
@@ -933,7 +933,7 @@ Rows: [ 4 differences ]
     ut3.ut.expect(get_cursor()).not_to_equal(get_cursor(), a_exclude => 'A_COLUMN,Some_Col');
     --Assert
     ut.expect(cardinality(ut3.ut_expectation_processor.get_warnings())).to_equal(1);
-    ut.expect(ut3.ut_expectation_processor.get_warnings()(1)).to_be_like('The syntax: "%" is depreciated.%');
+    ut.expect(ut3.ut_expectation_processor.get_warnings()(1)).to_be_like('The syntax: "%" is deprecated.%');
   end;
 
   procedure deprec_not_to_equal_excl_list is
@@ -942,7 +942,7 @@ Rows: [ 4 differences ]
     ut3.ut.expect(get_cursor()).not_to_equal(get_cursor(), a_exclude => ut3.ut_varchar2_list('A_COLUMN','Some_Col'));
     --Assert
     ut.expect(cardinality(ut3.ut_expectation_processor.get_warnings())).to_equal(1);
-    ut.expect(ut3.ut_expectation_processor.get_warnings()(1)).to_be_like('The syntax: "%" is depreciated.%');
+    ut.expect(ut3.ut_expectation_processor.get_warnings()(1)).to_be_like('The syntax: "%" is deprecated.%');
   end;
 
   procedure deprec_equal_excl_varch is
@@ -951,7 +951,7 @@ Rows: [ 4 differences ]
     ut3.ut.expect(get_cursor()).to_(ut3.equal(get_cursor(), a_exclude => 'A_COLUMN,Some_Col'));
     --Assert
     ut.expect(cardinality(ut3.ut_expectation_processor.get_warnings())).to_equal(1);
-    ut.expect(ut3.ut_expectation_processor.get_warnings()(1)).to_be_like('The syntax: "%" is depreciated.%');
+    ut.expect(ut3.ut_expectation_processor.get_warnings()(1)).to_be_like('The syntax: "%" is deprecated.%');
   end;
 
   procedure deprec_equal_excl_list is
@@ -960,7 +960,7 @@ Rows: [ 4 differences ]
     ut3.ut.expect(get_cursor()).to_(ut3.equal(get_cursor(), a_exclude => ut3.ut_varchar2_list('A_COLUMN','Some_Col')));
     --Assert
     ut.expect(cardinality(ut3.ut_expectation_processor.get_warnings())).to_equal(1);
-    ut.expect(ut3.ut_expectation_processor.get_warnings()(1)).to_be_like('The syntax: "%" is depreciated.%');
+    ut.expect(ut3.ut_expectation_processor.get_warnings()(1)).to_be_like('The syntax: "%" is deprecated.%');
   end;
 
 end;


### PR DESCRIPTION
Fixed - warnings counters were not updated.
Fixed - typo in deprecation warnings
Added line number and line text to the deprecation warning.