### PR TITLE
Fixed misleading naming in documentation

### DIFF
--- a/docs/userguide/annotations.md
+++ b/docs/userguide/annotations.md
@@ -108,19 +108,19 @@ end test_pkg;
 
 | Annotation |Level| Description |
 | --- | --- | --- |
-| `%suite(<description>)` | Package | Mandatory. Marks package as a test suite. Optional suite description can be provided (see `displayname`). |
-| `%suitepath(<path>)` | Package | Similar to java package. The annotation allows logical grouping of suites into hierarchies. |
-| `%displayname(<description>)` | Package/procedure | Human-readable and meaningful description of a suite/test. `%displayname(Name of the suite/test)`. The annotation is provided for flexibility and convenience only. It has exactly the same meaning as `<description>` in `test` and `suite` annotations. If description is provided using both `suite`/`test` and `displayname`, then the one defined as last takes precedence. |
-| `%test(<description>)` | Procedure | Denotes that the annotated procedure is a unit test procedure.  Optional test description can by provided (see `displayname`). |
-| `%throws(<exception_number>[,<exception_number>[,...]])`| Procedure | Denotes that the annotated procedure must throw one of the exception numbers provided. If no valid numbers were provided as annotation parameters the annotation is ignored. Applicable to test procedures only. |
-| `%beforeall` | Procedure | Denotes that the annotated procedure should be executed once before all elements of the suite. |
-| `%afterall` | Procedure | Denotes that the annotated procedure should be executed once after all elements of the suite. |
-| `%beforeeach` | Procedure | Denotes that the annotated procedure should be executed before each `%test` procedure in the suite. |
-| `%aftereach` | Procedure | Denotes that the annotated procedure should be executed after each `%test` procedure in the suite. |
-| `%beforetest(<procedure_name>)` | Procedure | Denotes that mentioned procedure should be executed before the annotated `%test` procedure. |
-| `%aftertest(<procedure_name>)` | Procedure | Denotes that mentioned procedure should be executed after the annotated `%test` procedure. |
-| `%rollback(<type>)` | Package/procedure | Defines transaction control. Supported values: `auto`(default) - a savepoint is created before invocation of each "before block" is and a rollback to specific savepoint is issued after each "after" block; `manual` - rollback is never issued automatically. Property can be overridden for child element (test in suite) |
-| `%disabled` | Package/procedure | Used to disable a suite or a test. Disabled suites/tests do not get executed, they are however marked and reported as disabled in a test run. |
+| `--%suite(<description>)` | Package | Mandatory. Marks package as a test suite. Optional suite description can be provided (see `displayname`). |
+| `--%suitepath(<path>)` | Package | Similar to java package. The annotation allows logical grouping of suites into hierarchies. |
+| `--%displayname(<description>)` | Package/procedure | Human-readable and meaningful description of a suite/test. `%displayname(Name of the suite/test)`. The annotation is provided for flexibility and convenience only. It has exactly the same meaning as `<description>` in `test` and `suite` annotations. If description is provided using both `suite`/`test` and `displayname`, then the one defined as last takes precedence. |
+| `--%test(<description>)` | Procedure | Denotes that the annotated procedure is a unit test procedure.  Optional test description can by provided (see `displayname`). |
+| `--%throws(<exception_number>[,<exception_number>[,...]])`| Procedure | Denotes that the annotated procedure must throw one of the exception numbers provided. If no valid numbers were provided as annotation parameters the annotation is ignored. Applicable to test procedures only. |
+| `--%beforeall` | Procedure | Denotes that the annotated procedure should be executed once before all elements of the suite. |
+| `--%afterall` | Procedure | Denotes that the annotated procedure should be executed once after all elements of the suite. |
+| `--%beforeeach` | Procedure | Denotes that the annotated procedure should be executed before each `%test` procedure in the suite. |
+| `--%aftereach` | Procedure | Denotes that the annotated procedure should be executed after each `%test` procedure in the suite. |
+| `--%beforetest(<procedure_name>)` | Procedure | Denotes that mentioned procedure should be executed before the annotated `%test` procedure. |
+| `--%aftertest(<procedure_name>)` | Procedure | Denotes that mentioned procedure should be executed after the annotated `%test` procedure. |
+| `--%rollback(<type>)` | Package/procedure | Defines transaction control. Supported values: `auto`(default) - a savepoint is created before invocation of each "before block" is and a rollback to specific savepoint is issued after each "after" block; `manual` - rollback is never issued automatically. Property can be overridden for child element (test in suite) |
+| `--%disabled` | Package/procedure | Used to disable a suite or a test. Disabled suites/tests do not get executed, they are however marked and reported as disabled in a test run. |
 
 # Suitepath concept
 

--- a/docs/userguide/expectations.md
+++ b/docs/userguide/expectations.md
@@ -598,7 +598,7 @@ begin
 end;
 /
 create or replace package demo_dept as 
-  -- %suite(demo)
+  --%suite(demo)
 
   --%test(demo of object to object comparison)
   procedure test_department; 
@@ -635,7 +635,7 @@ begin
 end;
 /
 create or replace package demo_depts as 
-  -- %suite(demo)
+  --%suite(demo)
 
   --%test(demo of collection comparison)
   procedure test_departments; 

--- a/docs/userguide/expectations.md
+++ b/docs/userguide/expectations.md
@@ -165,7 +165,7 @@ end;
 ## be_empty
 Unary matcher that validates if the provided dataset is empty.
 
-Can be used with `refcursor` or `table type`
+Can be used with `refcursor` or `nested table`/`varray` passed as `ANYDATA`
 
 Usage:
 ```sql
@@ -179,7 +179,16 @@ begin
 end;
 ```
 
-When used with anydata, it is only valid for collection data types.
+```sql
+procedure test_if_cursor_is_empty is
+  l_data ut_varchar2_list;
+begin
+  l_data := ut_varchar2_list();
+  ut.expect( anydata.convertCollection( l_data ) ).to_be_empty();
+  --or
+  ut.expect( anydata.convertCollection( l_data ) ).to_( be_empty() );
+end;
+```
 
 ## be_false
 Unary matcher that validates if the provided value is false.
@@ -420,7 +429,7 @@ The `a_nulls_are_equal` parameter controls the behavior of a `null = null` compa
 To change the behavior of `NULL = NULL` comparison pass the `a_nulls_are_equal => false` to the `equal` matcher.  
 
 
-## Comparing objects, cursors, collections of data 
+## Comparing cursors, object types, nested tables and varrays 
 
 utPLSQL is capable of comparing compound data-types including:
 - ref cursors 
@@ -434,7 +443,7 @@ utPLSQL is capable of comparing compound data-types including:
 - Comparison of cursor columns containing `DATE` will only compare date part **and ignore time** by default. See [Comparing cursor data containing DATE fields](#comparing-cursor-data-containing-date-fields) to check how to enable date-time comparison in cursors.
 - To compare nested table/varray type you need to convert it to `anydata` by using `anydata.convertCollection()`  
 - To compare object type you need to convert it to `anydata` by using `anydata.convertObject()`  
-- It is possible to compare PL/SQL records and nested tables/varrays/associative arrays of PL/SQL records. To compare this types of data, use cursor comparison feature of utPLSQL and TABLE operator in SQL query
+- It is possible to compare PL/SQL records, collections, varrays and associative arrays. To compare this types of data, use cursor comparison feature of utPLSQL and TABLE operator in SQL query
     - On Oracle 11g Release 2 - pipelined table functions are needed (see section [Implicit (Shadow) Types in this artcile](https://oracle-base.com/articles/misc/pipelined-table-functions))
     - On Oracle 12c and above - use [TABLE function on nested tables/varrays/associative arrays of PL/SQL records](https://oracle-base.com/articles/12c/using-the-table-operator-with-locally-defined-types-in-plsql-12cr1) 
    
@@ -568,16 +577,16 @@ When comparing rows utPLSQL:
 - reports whole missing (expected) row from expected when expected has extra rows 
 
 
-### Object and collection data-type comparison examples
+### Object and nested table data-type comparison examples
 
-When comparing object type to object type or collection to collection, utPLSQL will check:
+When comparing object type / nested table / varray, utPLSQL will check:
 - if data-types match
-- if data in the compared objects/collections are the same.
+- if data in the compared elements is the same.
 
-The diff functionality for objects and collections is similar to diff on cursors.
-When diffing objects/collections however, utPLSQL will not check attribute names and data-types.
+The diff functionality for objects / nested tables / varrays is similar to diff on cursors.
+When diffing, utPLSQL will not check name and data-type of individual attribute as the type itself defines the underlying structure.  
 
-Below examples demonstrate how to compare object and collection data-types. 
+Below examples demonstrate how to compare object and nested table data-types. 
 
 Object type comparison.
 ```sql
@@ -773,19 +782,21 @@ The matrix below illustrates the data types supported by different matchers.
 
 |                               | be_between | be_empty | be_false | be_greater_than | be_greater_or_equal | be_less_or_equal | be_less_than | be_like | be_not_null | be_null | be_true | equal | have_count | match |
 |:------------------------------|:----------:|:--------:|:--------:|:---------------:|:-------------------:|:----------------:|:------------:|:-------:|:-----------:|:-------:|:-------:|:-----:|:----------:|:-----:|
-| anydata( collection, object ) |            |    X     |          |                 |                     |                  |              |         |     X       |   X     |         |   X   |      X     |       |
 | blob                          |            |          |          |                 |                     |                  |              |         |     X       |   X     |         |   X   |            |       |
 | boolean                       |            |          |    X     |                 |                     |                  |              |         |     X       |   X     |    X    |   X   |            |       |
 | clob                          |            |          |          |                 |                     |                  |              |   X     |     X       |   X     |         |   X   |            |   X   |
 | date                          |    X       |          |          |       X         |         X           |      X           |     X        |         |     X       |   X     |         |   X   |            |       |
 | number                        |    X       |          |          |       X         |         X           |      X           |     X        |         |     X       |   X     |         |   X   |            |       |
-| refcursor                     |            |    X     |          |                 |                     |                  |              |         |     X       |   X     |         |   X   |      X     |       |
 | timestamp                     |    X       |          |          |       X         |         X           |      X           |     X        |         |     X       |   X     |         |   X   |            |       |
 | timestamp with timezone       |    X       |          |          |       X         |         X           |      X           |     X        |         |     X       |   X     |         |   X   |            |       |
 | timestamp with local timezone |    X       |          |          |       X         |         X           |      X           |     X        |         |     X       |   X     |         |   X   |            |       |
 | varchar2                      |    X       |          |          |                 |                     |                  |              |   X     |     X       |   X     |         |   X   |            |   X   |
 | interval year to month        |    X       |          |          |       X         |         X           |      X           |     X        |         |     X       |   X     |         |   X   |            |       |
 | interval day to second        |    X       |          |          |       X         |         X           |      X           |     X        |         |     X       |   X     |         |   X   |            |       |
+| refcursor                     |            |    X     |          |                 |                     |                  |              |         |     X       |   X     |         |   X   |      X     |       |
+| nested table (as anydata)     |            |    X     |          |                 |                     |                  |              |         |     X       |   X     |         |   X   |      X     |       |
+| varray (as anydata)           |            |    X     |          |                 |                     |                  |              |         |     X       |   X     |         |   X   |      X     |       |
+| object (as anydata)           |            |          |          |                 |                     |                  |              |         |     X       |   X     |         |   X   |            |       |
 
 
 

--- a/docs/userguide/getting-started.md
+++ b/docs/userguide/getting-started.md
@@ -25,7 +25,7 @@ This way, we assure we don't jump ahead too much and produce code that is untest
 ```sql
 create or replace package test_betwnstr as
 
-  -- %suite(Between string function)
+  --%suite(Between string function)
 
 end;
 /
@@ -46,9 +46,9 @@ Finished in .451423 seconds
 ```sql
 create or replace package test_betwnstr as
 
-  -- %suite(Between string function)
+  --%suite(Between string function)
 
-  -- %test(Returns substring from start position to end position)
+  --%test(Returns substring from start position to end position)
   procedure basic_usage;
 
 end;
@@ -201,12 +201,12 @@ A new requirement was added:
 ```sql
 create or replace package test_betwnstr as
 
-  -- %suite(Between string function)
+  --%suite(Between string function)
 
-  -- %test(Returns substring from start position to end position)
+  --%test(Returns substring from start position to end position)
   procedure basic_usage;
 
-  -- %test(Returns substring when start position is zero)
+  --%test(Returns substring when start position is zero)
   procedure zero_start_position;
 
 end;


### PR DESCRIPTION
Reworded `collection` to `nested table/varray` for schema level table-types