### PR TITLE
Feature/cursor implicit

### DIFF
--- a/source/core/ut_utils.pkb
+++ b/source/core/ut_utils.pkb
@@ -544,5 +544,19 @@ procedure append_to_clob(a_src_clob in out nocopy clob, a_clob_table t_clob_tab,
     return l_filtered_list;
   end;
 
+  function xmlgen_escaped_string(a_string in varchar2) return varchar2 is
+    l_result varchar2(4000);
+    l_sql varchar2(32767) := q'!select q'[!'||a_string||q'!]' as "!'||a_string||'" from dual';
+  begin
+    if a_string is not null then
+      select extract(dbms_xmlgen.getxmltype(l_sql),'/*/*/*').getRootElement() 
+      into l_result
+      from dual;
+    else
+    l_result := a_string;
+    end if;
+    return l_result;
+  end;
+
 end ut_utils;
 /

--- a/source/core/ut_utils.pks
+++ b/source/core/ut_utils.pks
@@ -302,5 +302,8 @@ create or replace package ut_utils authid definer is
   /*It takes a collection of type ut_varchar2_list and it only returns the elements which meets the regular expression*/
   function filter_list(a_list IN ut_varchar2_list, a_regexp_filter in varchar2) return ut_varchar2_list;
 
+  -- Generates XMLGEN escaped string
+  function xmlgen_escaped_string(a_string in varchar2) return varchar2;
+
 end ut_utils;
 /

--- a/source/expectations/data_values/ut_data_value_refcursor.tpb
+++ b/source/expectations/data_values/ut_data_value_refcursor.tpb
@@ -140,7 +140,7 @@ create or replace type body ut_data_value_refcursor as
       for i in 1 .. a_column_diffs.count loop
         if a_column_diffs(i).diff_type in ('-','+') then
           l_incomparable_cols.extend;
-          l_incomparable_cols(l_incomparable_cols.last) := coalesce(a_column_diffs(i).expected_name,a_column_diffs(i).actual_name);
+          l_incomparable_cols(l_incomparable_cols.last) := ut_utils.xmlgen_escaped_string(coalesce(a_column_diffs(i).expected_name,a_column_diffs(i).actual_name));
         end if;
       end loop;
       l_result := ut_utils.to_xpath(l_incomparable_cols);

--- a/test/core/expectations/compound_data/test_expectations_cursor.pkb
+++ b/test/core/expectations/compound_data/test_expectations_cursor.pkb
@@ -963,7 +963,7 @@ Rows: [ 4 differences ]
     ut.expect(ut3.ut_expectation_processor.get_warnings()(1)).to_be_like('The syntax: "%" is deprecated.%');
   end;
 
-  procedure column_diff_on_col_name_implicit is
+  procedure col_diff_on_col_name_implicit is
     l_actual   SYS_REFCURSOR;
     l_expected SYS_REFCURSOR;
     l_actual_message   varchar2(32767);
@@ -989,7 +989,7 @@ Rows: [ 2 differences ]%
     ut.expect(l_actual_message).to_be_like(l_expected_message);
   end;
 
-  procedure column_match_on_col_name_implicit is
+  procedure col_mtch_on_col_name_implicit is
     l_actual   SYS_REFCURSOR;
     l_expected SYS_REFCURSOR;
     l_actual_message   varchar2(32767);

--- a/test/core/expectations/compound_data/test_expectations_cursor.pkb
+++ b/test/core/expectations/compound_data/test_expectations_cursor.pkb
@@ -980,8 +980,8 @@ Diff:%
 Columns:%
   Column <ROWNUM> [data-type: NUMBER] is missing. Expected column position: 1.%
   Column <EXPECTED_COLUMN_NAME> [data-type: NUMBER] is missing. Expected column position: 2.%
-  Column <'1'> [position: 1, data-type: CHAR] is not expected in results.%
-  Column <'2'> [position: 2, data-type: CHAR] is not expected in results.%
+  Column <%1%> [position: 1, data-type: CHAR] is not expected in results.%
+  Column <%2%> [position: 2, data-type: CHAR] is not expected in results.%
 Rows: [ 2 differences ]%
   All rows are different as the columns are not matching.%]';
     l_actual_message := ut3.ut_expectation_processor.get_failed_expectations()(1).message;

--- a/test/core/expectations/compound_data/test_expectations_cursor.pkb
+++ b/test/core/expectations/compound_data/test_expectations_cursor.pkb
@@ -963,5 +963,46 @@ Rows: [ 4 differences ]
     ut.expect(ut3.ut_expectation_processor.get_warnings()(1)).to_be_like('The syntax: "%" is deprecated.%');
   end;
 
+  procedure column_diff_on_col_name_implicit is
+    l_actual   SYS_REFCURSOR;
+    l_expected SYS_REFCURSOR;
+    l_actual_message   varchar2(32767);
+    l_expected_message varchar2(32767);
+  begin
+    --Arrange
+    open l_actual   for select '1' , '2'      from dual connect by level <=2;
+    open l_expected for select rownum , rownum expected_column_name from dual connect by level <=2;
+    --Act
+    ut3.ut.expect(l_actual).to_equal(l_expected);
+
+    l_expected_message := q'[Actual: refcursor [ count = 2 ] was expected to equal: refcursor [ count = 2 ]%
+Diff:%
+Columns:%
+  Column <ROWNUM> [data-type: NUMBER] is missing. Expected column position: 1.%
+  Column <EXPECTED_COLUMN_NAME> [data-type: NUMBER] is missing. Expected column position: 2.%
+  Column <'1'> [position: 1, data-type: CHAR] is not expected in results.%
+  Column <'2'> [position: 2, data-type: CHAR] is not expected in results.%
+Rows: [ 2 differences ]%
+  All rows are different as the columns are not matching.%]';
+    l_actual_message := ut3.ut_expectation_processor.get_failed_expectations()(1).message;
+    --Assert
+    ut.expect(l_actual_message).to_be_like(l_expected_message);
+  end;
+
+  procedure column_match_on_col_name_implicit is
+    l_actual   SYS_REFCURSOR;
+    l_expected SYS_REFCURSOR;
+    l_actual_message   varchar2(32767);
+    l_expected_message varchar2(32767);
+  begin
+    --Arrange
+    open l_actual   for select '1' , rownum  from dual connect by level <=2;
+    open l_expected for select '1' , rownum  from dual connect by level <=2;
+    --Act
+    ut3.ut.expect(l_actual).to_equal(l_expected);
+    --Assert
+    ut.expect(expectations.failed_expectations_data()).to_be_empty();
+  end;
+    
 end;
 /

--- a/test/core/expectations/compound_data/test_expectations_cursor.pks
+++ b/test/core/expectations/compound_data/test_expectations_cursor.pks
@@ -188,10 +188,10 @@ create or replace package test_expectations_cursor is
   procedure deprec_equal_excl_list;
 
   --%test(Reports column diff on cursor with column name implicit )
-  procedure column_diff_on_col_name_implicit;
+  procedure col_diff_on_col_name_implicit;
 
   --%test(Reports column match on cursor with column name implicit )
-  procedure column_match_on_col_name_implicit;
+  procedure col_mtch_on_col_name_implicit;
    
 end;
 /

--- a/test/core/expectations/compound_data/test_expectations_cursor.pks
+++ b/test/core/expectations/compound_data/test_expectations_cursor.pks
@@ -187,7 +187,11 @@ create or replace package test_expectations_cursor is
   --%test(Adds a warning when using depreciated syntax to_( equal( a_expected sys_refcursor, a_exclude ut_varchar2_list )) )
   procedure deprec_equal_excl_list;
 
-  --%test(Reports column name differences if found)
+  --%test(Reports column diff on cursor with column name implicit )
+  procedure column_diff_on_col_name_implicit;
 
+  --%test(Reports column match on cursor with column name implicit )
+  procedure column_match_on_col_name_implicit;
+   
 end;
 /


### PR DESCRIPTION
Implement fix for xml parsing when cursor column missing alias. Fixes #632 
This will not include changes to include and exclude options as this will require syntax checking with xpath and possible rework way options are passed 