### PR TITLE
Fixed installation order to eliminate compilation error warning

### DIFF
--- a/source/expectations/data_values/ut_compound_data_value.tpb
+++ b/source/expectations/data_values/ut_compound_data_value.tpb
@@ -132,6 +132,7 @@ create or replace type body ut_compound_data_value as
     l_result          integer;
     --the XML stylesheet is applied on XML representation of data to exclude column names from comparison
     --column names and data-types are compared separately
+    --user CHR(38) instead of ampersand to eliminate define request when installing through some IDEs
     l_xml_data_fmt    constant xmltype := xmltype(
         q'[<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
           <xsl:strip-space elements="*" />
@@ -139,7 +140,7 @@ create or replace type body ut_compound_data_value as
               <xsl:for-each select="child::node()">
                   <xsl:choose>
                       <xsl:when test="*[*]"><xsl:copy-of select="node()"/></xsl:when>
-                      <xsl:when test="position()=last()"><xsl:value-of select="normalize-space(.)"/><xsl:text>&#xD;</xsl:text></xsl:when>
+                      <xsl:when test="position()=last()"><xsl:value-of select="normalize-space(.)"/><xsl:text>'||CHR(38)||'#xD;</xsl:text></xsl:when>
                       <xsl:otherwise><xsl:value-of select="normalize-space(.)"/>,</xsl:otherwise>
                   </xsl:choose>
               </xsl:for-each>

--- a/source/install.sql
+++ b/source/install.sql
@@ -29,6 +29,7 @@ whenever oserror exit failure rollback
 prompt Switching current schema to &&ut3_owner
 prompt &&line_separator
 alter session set current_schema = &&ut3_owner;
+alter session set PLSQL_WARNINGS='ENABLE:ALL';
 --set define off
 
 --dbms_output buffer cache table
@@ -166,7 +167,6 @@ prompt Installing DBMSPLSQL Tables objects into &&ut3_owner schema
 @@install_component.sql 'expectations/data_values/ut_compound_data_diff_tmp.sql'
 @@install_component.sql 'expectations/data_values/ut_data_value.tps'
 @@install_component.sql 'expectations/data_values/ut_compound_data_value.tps'
-@@install_component.sql 'expectations/data_values/ut_compound_data_helper.pks'
 @@install_component.sql 'expectations/data_values/ut_data_value_anydata.tps'
 @@install_component.sql 'expectations/data_values/ut_data_value_collection.tps'
 @@install_component.sql 'expectations/data_values/ut_data_value_object.tps'
@@ -182,6 +182,7 @@ prompt Installing DBMSPLSQL Tables objects into &&ut3_owner schema
 @@install_component.sql 'expectations/data_values/ut_data_value_timestamp_ltz.tps'
 @@install_component.sql 'expectations/data_values/ut_data_value_varchar2.tps'
 @@install_component.sql 'expectations/data_values/ut_data_value_yminterval.tps'
+@@install_component.sql 'expectations/data_values/ut_compound_data_helper.pks'
 @@install_component.sql 'expectations/matchers/ut_matcher.tps'
 @@install_component.sql 'expectations/matchers/ut_comparison_matcher.tps'
 @@install_component.sql 'expectations/matchers/ut_be_false.tps'

--- a/source/install.sql
+++ b/source/install.sql
@@ -29,7 +29,6 @@ whenever oserror exit failure rollback
 prompt Switching current schema to &&ut3_owner
 prompt &&line_separator
 alter session set current_schema = &&ut3_owner;
-alter session set PLSQL_WARNINGS='ENABLE:ALL';
 --set define off
 
 --dbms_output buffer cache table

--- a/source/uninstall.sql
+++ b/source/uninstall.sql
@@ -258,8 +258,6 @@ drop type ut_expectation_result force;
 
 drop package ut_event_manager;
 
-drop type ut_event_listener force;
-
 drop type ut_event_item force;
 
 drop type ut_key_value_pairs force;


### PR DESCRIPTION
Fixed installation order to eliminate compilation error warning
Removed ampersand symbol as some IDEs (PLSQL Developer) recognize it as a parameter to be defined
Removed unnecessary drop as ut_event_listener is already several lines before
Fixes #657