### PR TITLE
Fixes classname not appearing when procedure name showing as mixed case, regression bug

### DIFF
--- a/source/core/ut_suite_builder.pkb
+++ b/source/core/ut_suite_builder.pkb
@@ -105,7 +105,7 @@ create or replace package body ut_suite_builder is
     l_annotation_pos binary_integer;
   begin
     l_result.owner := a_object.object_owner;
-    l_result.name  := a_object.object_name;
+    l_result.name  := lower(trim(a_object.object_name));
     l_annotation_no := a_object.annotations.first;
     while l_annotation_no is not null loop
       l_annotation_pos := a_object.annotations(l_annotation_no).position;
@@ -113,7 +113,7 @@ create or replace package body ut_suite_builder is
         l_result.annotations(l_annotation_pos).name := a_object.annotations(l_annotation_no).name;
         l_result.annotations(l_annotation_pos).text := a_object.annotations(l_annotation_no).text;
       else
-        l_result.annotations(l_annotation_pos).procedure_name        := a_object.annotations(l_annotation_no).subobject_name;
+        l_result.annotations(l_annotation_pos).procedure_name        := lower(trim(a_object.annotations(l_annotation_no).subobject_name));
         l_result.annotations(l_annotation_pos).procedure_annotations := get_procedure_annotations(a_object.annotations, l_annotation_no);
       end if;
       l_annotation_no := a_object.annotations.next(l_annotation_no);

--- a/test/core/reporters/test_junit_reporter.pkb
+++ b/test/core/reporters/test_junit_reporter.pkb
@@ -307,6 +307,7 @@ create or replace package body test_junit_reporter as
     execute immediate 'drop package check_junit_rep_suitepath';
     execute immediate 'drop package tst_package_junit_nodesc';
     execute immediate 'drop package tst_package_junit_nosuite';
+    execute immediate 'drop package Tst_Fix_Case_Sensitive';
     reporters.reporters_cleanup;
   end;
 end;

--- a/test/core/reporters/test_junit_reporter.pkb
+++ b/test/core/reporters/test_junit_reporter.pkb
@@ -62,6 +62,18 @@ create or replace package body test_junit_reporter as
     procedure test1 is begin ut.expect(1).to_equal(1); end;
   end;]';
 
+  
+   execute immediate q'[create or replace package Tst_Fix_Case_Sensitive as
+      --%suite
+
+      --%test(bugfix)
+      procedure bUgFiX;
+   end;]';
+
+   execute immediate q'[create or replace package body Tst_Fix_Case_Sensitive as
+    procedure bUgFiX is begin ut.expect(1).to_equal(1); end;
+  end;]';  
+  
   reporters.reporters_setup;
   
   end;
@@ -263,6 +275,27 @@ create or replace package body test_junit_reporter as
     select *
       bulk collect into l_results
     from table(ut3.ut.run('test_reporters',ut3.ut_junit_reporter()));
+    l_actual := ut3.ut_utils.table_to_clob(l_results);
+    ut.expect(l_actual).to_be_like(l_expected);  
+  end;
+  
+  procedure check_classname_is_populated is
+    l_results   ut3.ut_varchar2_list;
+    l_actual    clob;
+    l_expected  varchar2(32767):= q'[<testsuites tests="1" disabled="0" errors="0" failures="0" name="" time="%" >
+<testsuite tests="1" id="1" package="tst_fix_case_sensitive"  disabled="0" errors="0" failures="0" name="tst_fix_case_sensitive" time="%" >
+<testcase classname="tst_fix_case_sensitive" assertions="0" name="bugfix" time="%" >
+<system-out/>
+<system-err/>
+</testcase>
+<system-out/>
+<system-err/>
+</testsuite>
+</testsuites>]';
+  begin
+    select *
+      bulk collect into l_results
+    from table(ut3.ut.run('Tst_Fix_Case_Sensitive',ut3.ut_junit_reporter()));
     l_actual := ut3.ut_utils.table_to_clob(l_results);
     ut.expect(l_actual).to_be_like(l_expected);  
   end;

--- a/test/core/reporters/test_junit_reporter.pks
+++ b/test/core/reporters/test_junit_reporter.pks
@@ -27,14 +27,17 @@ create or replace package test_junit_reporter as
   --%test(Reports duration according to XML specification for numbers)
   procedure check_nls_number_formatting;
   
-    --%test(Report on test without description)
+  --%test(Report on test without description)
   procedure report_test_without_desc;
   
-    --%test(Report on suite without description)
+  --%test(Report on suite without description)
   procedure report_suite_without_desc;
   
-    --%test(Report produces expected output)
+  --%test(Report produces expected output)
   procedure reporort_produces_expected_out;
+  
+  --%test( Test for bug #659)
+  procedure check_classname_is_populated;
 
   --%afterall
   procedure remove_test_package;

--- a/test/core/reporters/test_junit_reporter.pks
+++ b/test/core/reporters/test_junit_reporter.pks
@@ -36,7 +36,7 @@ create or replace package test_junit_reporter as
   --%test(Report produces expected output)
   procedure reporort_produces_expected_out;
   
-  --%test( Test for bug #659)
+  --%test( Check classname is populated when procedure is mixed cased - bug #659)
   procedure check_classname_is_populated;
 
   --%afterall


### PR DESCRIPTION
Fixes to bug introduced in revision
Revision: c787e4793de0d89ff9770320e2e863ce25142be4
* Added support for multiple occurrences of before and after blocks.

that removed a path from ut_suite_item.tpb and move to suite_builder missing a lower case transformation for object name and procedure name.
Fixes #659 