### PR TITLE
Update issue with xml special chars in failure.

### DIFF
--- a/source/reporters/ut_junit_reporter.tpb
+++ b/source/reporters/ut_junit_reporter.tpb
@@ -53,7 +53,6 @@ create or replace type body ut_junit_reporter is
         self.print_text('</error>');
       elsif a_test.result > ut_utils.gc_success then
         self.print_text('<failure>');
-        self.print_text(c_cddata_tag_start);
         for i in 1 .. a_test.failed_expectations.count loop
           
           l_lines := a_test.failed_expectations(i).get_result_lines();
@@ -61,9 +60,8 @@ create or replace type body ut_junit_reporter is
           for j in 1 .. l_lines.count loop
             self.print_text(dbms_xmlgen.convert(l_lines(j)));
           end loop;
-          self.print_text(a_test.failed_expectations(i).caller_info);
+          self.print_text(dbms_xmlgen.convert(a_test.failed_expectations(i).caller_info));
         end loop;
-        self.print_text(c_cddata_tag_end);
         self.print_text('</failure>');
       end if;
       -- TODO - decide if we need/want to use the <system-err/> tag too

--- a/source/reporters/ut_sonar_test_reporter.tpb
+++ b/source/reporters/ut_sonar_test_reporter.tpb
@@ -56,14 +56,12 @@ create or replace type body ut_sonar_test_reporter is
         self.print_text('</error>');
       elsif a_test.result > ut_utils.gc_success then
         self.print_text('<failure message="some expectations have failed">');
-        self.print_text('<![CDATA[');
         for i in 1 .. a_test.failed_expectations.count loop
           l_lines := a_test.failed_expectations(i).get_result_lines();
           for i in 1 .. l_lines.count loop
             self.print_text(dbms_xmlgen.convert(l_lines(i)));
           end loop;
         end loop;
-        self.print_text(']]>');
         self.print_text('</failure>');
       end if;
       self.print_text('</testCase>');

--- a/source/reporters/ut_tfs_junit_reporter.tpb
+++ b/source/reporters/ut_tfs_junit_reporter.tpb
@@ -76,15 +76,13 @@ create or replace type body ut_tfs_junit_reporter is
      -- Do not count error as failure
       elsif a_test.result = ut_utils.gc_failure then
         self.print_text('<failure type="failure" message="Test '||a_test.name||' failed">');
-        self.print_text('<![CDATA[');
         for i in 1 .. a_test.failed_expectations.count loop
           l_lines := a_test.failed_expectations(i).get_result_lines();
           for j in 1 .. l_lines.count loop
             self.print_text(dbms_xmlgen.convert(l_lines(j)));
           end loop;
-          self.print_text(a_test.failed_expectations(i).caller_info);
+          self.print_text(dbms_xmlgen.convert(a_test.failed_expectations(i).caller_info));
         end loop;
-        self.print_text(']]>');
         self.print_text('</failure>');
       end if;
 

--- a/test/core/reporters/test_junit_reporter.pkb
+++ b/test/core/reporters/test_junit_reporter.pkb
@@ -146,7 +146,7 @@ create or replace package body test_junit_reporter as
       from table(ut3.ut.run('check_junit_reporting',ut3.ut_junit_reporter()));
     l_actual := ut3.ut_utils.table_to_clob(l_results);
     --Assert
-    ut.expect(l_actual).to_be_like('%at "%.CHECK_JUNIT_REPORTING%", line %');
+    ut.expect(l_actual).to_be_like('%at &quot;%.CHECK_JUNIT_REPORTING%&quot;, line %');
   end;
 
   procedure check_classname_suite is
@@ -305,9 +305,7 @@ create or replace package body test_junit_reporter as
       from table(ut3.ut.run('check_fail_escape',ut3.ut_junit_reporter()));
     l_actual := ut3.ut_utils.table_to_clob(l_results);
     --Assert
-    ut.expect(l_actual).to_be_like('%<![CDATA[%
-Actual: &apos;test&apos; (varchar2) was expected to equal: &apos;&lt;![CDATA[some stuff]]&gt;&apos; (varchar2)%
-]]>%');
+    ut.expect(l_actual).to_be_like('%Actual: &apos;test&apos; (varchar2) was expected to equal: &apos;&lt;![CDATA[some stuff]]&gt;&apos; (varchar2)%');
   end;
   
   procedure check_classname_is_populated is

--- a/test/core/reporters/test_tfs_junit_reporter.pkb
+++ b/test/core/reporters/test_tfs_junit_reporter.pkb
@@ -108,7 +108,7 @@ create or replace package body test_tfs_junit_reporter as
       from table(ut3.ut.run('check_junit_reporting',ut3.ut_tfs_junit_reporter()));
     l_actual := ut3.ut_utils.table_to_clob(l_results);
     --Assert
-    ut.expect(l_actual).to_be_like('%at "%.CHECK_JUNIT_REPORTING%", line %');
+    ut.expect(l_actual).to_be_like('%at &quot;%.CHECK_JUNIT_REPORTING%&quot;, line %');
   end;
 
   procedure check_classname_suite is
@@ -173,9 +173,7 @@ create or replace package body test_tfs_junit_reporter as
       from table(ut3.ut.run('check_fail_escape',ut3.ut_tfs_junit_reporter()));
     l_actual := ut3.ut_utils.table_to_clob(l_results);
     --Assert
-    ut.expect(l_actual).to_be_like('%<![CDATA[%
-Actual: &apos;test&apos; (varchar2) was expected to equal: &apos;&lt;![CDATA[some stuff]]&gt;&apos; (varchar2)%
-]]>%');
+    ut.expect(l_actual).to_be_like('%Actual: &apos;test&apos; (varchar2) was expected to equal: &apos;&lt;![CDATA[some stuff]]&gt;&apos; (varchar2)%');
   end;
 
   procedure check_classname_suitepath is


### PR DESCRIPTION
Remove CDDATA and replace with xml convert
Text inside a CDDATA was not treated as xml so converting all characters was causing a poor display e.g.
```xml
Actual: &apos;test&apos; (varchar2) was expected to equal: &apos;&lt;![CDATA[some stuff]]&gt;&apos; (varchar2)
"at &quot;UT3.CHECK_FAIL_ESCAPE.FAIL_MISERABLY&quot;, line 4 ut3.ut.expect(&apos;test&apos;).to_equal(&apos;&lt;![CDATA[some stuff]]&gt;&apos;);
```
Converted all text using XML CONVERT and removing CDDATA allowed to generate proper result and escape CDDATA tags that caused failure of xml message.

```xml
Actual: 'test' (varchar2) was expected to equal: '<![CDATA[some stuff]]>' (varchar2)
"at "UT3.CHECK_FAIL_ESCAPE.FAIL_MISERABLY", line 4 ut3.ut.expect('test').to_equal('some stuff');"
```

XML content attached along with the screen from jenkins for that xml.
[junit.txt](https://github.com/utPLSQL/utPLSQL/files/1997677/junit.txt)



![test_evidence](https://user-images.githubusercontent.com/7831112/39958255-645ab454-55f8-11e8-845e-dfd7c61613aa.png)
