### PR TITLE
 Allow before/after annotations to accept list of [[owner.]package.]procedure

### DIFF
--- a/source/core/ut_suite_builder.pkb
+++ b/source/core/ut_suite_builder.pkb
@@ -62,7 +62,7 @@ create or replace package body ut_suite_builder is
   );
 
   --holds a list of package and procedure level annotations indexed (order) by position.
-  --procedure level annotations are grouped under procedure name 
+  --procedure level annotations are grouped under procedure name
   type tt_package_annotations is table of t_package_annotation index by t_annotation_position;
 
   --holds all annotations for object
@@ -237,14 +237,39 @@ create or replace package body ut_suite_builder is
     a_annotation_texts tt_annotation_texts,
     a_event_name       ut_utils.t_event_name
   ) is
+    l_string_buffer varchar2(32767);
     l_annotation_pos   binary_integer;
-    begin
-      l_annotation_pos := a_annotation_texts.first;
-      while l_annotation_pos is not null loop
-        add_to_list(a_executables, a_owner, a_package_name, a_annotation_texts(l_annotation_pos), a_event_name );
-        l_annotation_pos := a_annotation_texts.next( l_annotation_pos);
-      end loop;
-    end;
+    l_procedures_list ut_varchar2_list;
+    l_procedures_pos binary_integer;
+    l_components_list ut_varchar2_list;
+  begin
+    l_annotation_pos := a_annotation_texts.first;
+    while l_annotation_pos is not null loop
+      l_string_buffer := l_string_buffer||','||a_annotation_texts(l_annotation_pos);
+      l_annotation_pos := a_annotation_texts.next(l_annotation_pos);
+    end loop;
+    
+    l_procedures_list := ut_utils.trim_list_elements(ut_utils.string_to_table(l_string_buffer, ','));
+    l_procedures_list := ut_utils.filter_list(l_procedures_list, '[[:alpha:]]+');
+    
+    l_procedures_pos := l_procedures_list.first;
+    while l_procedures_pos is not null loop
+      l_components_list := ut_utils.string_to_table(l_procedures_list(l_procedures_pos), '.');
+      
+      case(l_components_list.count())
+        when 1 then 
+          add_to_list(a_executables, a_owner, a_package_name, l_components_list(1), a_event_name );
+        when 2 then 
+          add_to_list(a_executables, a_owner, l_components_list(1), l_components_list(2), a_event_name );
+        when 3 then 
+          add_to_list(a_executables, l_components_list(1), l_components_list(2), l_components_list(3), a_event_name );
+      else
+        null;
+      end case;
+      
+      l_procedures_pos := l_procedures_list.next(l_procedures_pos);
+    end loop;
+  end;
 
   procedure warning_on_duplicate_annot(
     a_suite          in out nocopy ut_suite_item,
@@ -399,7 +424,7 @@ create or replace package body ut_suite_builder is
     warning_on_duplicate_annot(a_suite, a_procedure_name, a_proc_annotations, gc_beforeeach);
     warning_on_duplicate_annot(a_suite, a_procedure_name, a_proc_annotations, gc_afterall);
     warning_on_duplicate_annot(a_suite, a_procedure_name, a_proc_annotations, gc_aftereach);
-    
+
     if a_proc_annotations.exists(gc_test) then
       add_test( a_suite, a_procedure_name, a_proc_annotations);
 

--- a/test/core/annotations/test_before_after_test_annotation.pkb
+++ b/test/core/annotations/test_before_after_test_annotation.pkb
@@ -1,0 +1,138 @@
+create or replace package body test_before_after_annotations is
+  g_tests_results clob;
+
+  procedure create_tests_results is
+    pragma autonomous_transaction;
+
+    l_test_package_spec  varchar2(32737);
+    l_test_package_body  varchar2(32737);
+    l_dummy_utility_pkg_spec varchar2(32737);
+    l_dummy_utility_pkg_body varchar2(32737);
+    l_test_results  ut3.ut_varchar2_list;
+    
+    procedure drop_package(a_package_name varchar2)
+    is
+    begin
+      execute immediate 'drop package '||a_package_name;
+    end;
+  begin
+    l_test_package_spec := '
+        create or replace package dummy_before_after_test is
+            --%suite(Package to test annotations beforetest and aftertest)
+            
+            l_dummy_1 integer;
+            l_dummy_2 integer;
+            l_dummy_3 integer;
+            
+            --%beforeeach
+            procedure clean_global_variables;
+
+            --%test(Beforetest with call to procedure external to the test package)
+            --%beforetest(dummy_utility_pkg_1.test1)
+            procedure beforetest_one_ext_procedure;
+            
+            
+            --%test(Beforetest with call to multi procedures external and interal to the test package)
+            --%beforetest(dummy_utility_pkg_1.test1, test2, ut3_tester.dummy_utility_pkg_1.test3)
+            procedure beforetest_multi_ext_procedure;  
+            
+            --%test(Beforetest with call to multi procedures where one does not exist)
+            --%beforetest(dummy_utility_pkg_1.test1, non_existent_procedure, ut3_tester.dummy_utility_pkg_1.test3)
+            procedure beforetest_one_err_procedure;
+            
+            procedure test2;
+        end;
+    ';
+
+    l_test_package_body := '
+        create or replace package body dummy_before_after_test is
+            procedure clean_global_variables is
+            begin
+              l_dummy_1 := null;
+              l_dummy_2 := null;
+              l_dummy_3 := null;  
+            end;
+        
+            procedure beforetest_one_ext_procedure is
+            begin
+              ut3.ut.expect(l_dummy_1).to_equal(1);
+            end;
+            
+            procedure beforetest_multi_ext_procedure
+            is
+            begin
+              ut3.ut.expect(l_dummy_1).to_equal(1);  
+              ut3.ut.expect(l_dummy_2).to_equal(2);
+              ut3.ut.expect(l_dummy_3).to_equal(3);
+            end;
+            
+            procedure beforetest_one_err_procedure
+            is
+            begin
+              null;
+            end;
+            
+            procedure test2 is
+            begin
+              l_dummy_2 := 2;  
+            end;
+        end;
+    ';
+    
+    l_dummy_utility_pkg_spec := '
+      create or replace package dummy_utility_pkg_1 is
+        procedure test1;
+        
+        procedure test3;
+      end;
+    ';
+    
+    l_dummy_utility_pkg_body := '
+      create or replace package body dummy_utility_pkg_1 is
+        procedure test1 is
+        begin
+          dummy_before_after_test.l_dummy_1 := 1;
+        end;
+        
+        procedure test3 is
+        begin
+          dummy_before_after_test.l_dummy_3 := 3;
+        end;
+      end;      
+    ';
+    
+    execute immediate l_test_package_spec;
+    execute immediate l_test_package_body;
+    execute immediate l_dummy_utility_pkg_spec;
+    execute immediate l_dummy_utility_pkg_body;
+
+    --Execute the tests and recolect the results
+    select * bulk collect into l_test_results from table(ut3.ut.run(('dummy_before_after_test')));
+    
+    drop_package('dummy_utility_pkg_1');
+    drop_package('dummy_before_after_test');
+
+    g_tests_results := ut3.ut_utils.table_to_clob(l_test_results);
+  end;
+  
+  procedure beforetest_one_ext_procedure
+  is
+  begin
+    ut.expect(g_tests_results).to_match('^\s*Beforetest with call to procedure external to the test package \[[\.0-9]+ sec\]\s*$','m');
+    ut.expect(g_tests_results).not_to_match('beforetest_one_ext_procedure');
+  end;
+  
+  procedure beforetest_multi_ext_procedure
+  is
+  begin
+    ut.expect(g_tests_results).to_match('^\s*Beforetest with call to multi procedures external and interal to the test package \[[\.0-9]+ sec\]\s*$','m');
+    ut.expect(g_tests_results).not_to_match('beforetest_multi_ext_procedure');
+  end;
+  
+  procedure beforetest_one_err_procedure
+  is
+  begin
+    ut.expect(g_tests_results).not_to_match('^\s*Beforetest with call to multi procedures where one does not exist \[[\.0-9]+ sec\]\s*$','m');
+    ut.expect(g_tests_results).to_match('beforetest_one_err_procedure');
+  end;
+end;

--- a/test/core/annotations/test_before_after_test_annotation.pks
+++ b/test/core/annotations/test_before_after_test_annotation.pks
@@ -1,0 +1,18 @@
+create or replace package test_before_after_annotations is
+
+  --%suite(annotations - beforetest and aftertest)
+  --%suitepath(utplsql.core.annotations)
+
+  --%beforeall
+  procedure create_tests_results;
+
+
+  --%test(Beforetest with call to procedure external to the test package)
+  procedure beforetest_one_ext_procedure;
+  
+  --%test(Beforetest with call to multi procedures external and interal to the test package)
+  procedure beforetest_multi_ext_procedure; 
+  
+  --%test(Beforetest with call to multi procedure where one does not exist)
+  procedure beforetest_one_err_procedure;
+end;

--- a/test/install_tests.sql
+++ b/test/install_tests.sql
@@ -22,6 +22,8 @@ whenever oserror exit failure rollback
 @@core/test_ut_test.pks
 @@core/annotations/test_annotation_parser.pks
 @@core/annotations/test_annotation_manager.pks
+@@core/annotations/test_before_after_test_annotation.pks
+@@core/annotations/test_before_after_test_annotation.pkb
 @@core/expectations/test_matchers.pks
 @@core/test_output_buffer.pks
 @@core/test_file_mapper.pks


### PR DESCRIPTION
ut_suit_builder modified to accept a list of procedures external o internal to the test package.

Resolve #649 