### PR TITLE
Fix To Pk Join

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ env:
     - DOCKHER_HUB_REPO="${DOCKER_BASE_TAG:-$UT3_DOCKER_REPO}"
     #utPLSQL released version directory
     - UTPLSQL_DIR="utPLSQL_latest_release"
-    - SELFTESTING_BRANCH="develop"
+    - SELFTESTING_BRANCH=${TRAVIS_BRANCH}
     - UTPLSQL_CLI_VERSION="3.1.0"
     # Maven
     - MAVEN_HOME=/usr/local/maven

--- a/source/expectations/data_values/ut_curr_usr_compound_helper.pks
+++ b/source/expectations/data_values/ut_curr_usr_compound_helper.pks
@@ -1,8 +1,12 @@
 create or replace package ut_curr_usr_compound_helper authid current_user is
    
-    function get_columns_info(a_cursor in out nocopy sys_refcursor,a_desc_user_types boolean := false) return xmltype;
+  procedure get_columns_info(a_cursor in out nocopy sys_refcursor,a_columns_info out xmltype,
+      a_join_by_info out xmltype, a_contains_collection out number);
 
-    function get_user_defined_type(a_owner varchar2,a_type_name varchar2) return xmltype;
+  function get_columns_info(a_cursor in out nocopy sys_refcursor,
+     a_desc_user_types boolean := false) return xmltype;
+
+  function get_user_defined_type(a_owner varchar2,a_type_name varchar2) return xmltype;
 
 end;
 /

--- a/source/expectations/data_values/ut_data_value_refcursor.tps
+++ b/source/expectations/data_values/ut_data_value_refcursor.tps
@@ -24,7 +24,12 @@ create or replace type ut_data_value_refcursor under ut_compound_data_value(
    * Determines if the cursor is null
    */
   is_cursor_null  integer,
-
+  
+  /**
+  * hold information if the cursor contains collection object
+  */
+  contain_collection number(1,0),
+  
   /**
   * Holds information about column names and column data-types
   */

--- a/test/core/expectations/compound_data/test_expectations_cursor.pkb
+++ b/test/core/expectations/compound_data/test_expectations_cursor.pkb
@@ -1727,10 +1727,10 @@ Diff:%
  l_expected_message := q'[%Actual: refcursor [ count = 2 ] was expected to equal: refcursor [ count = 2 ]%
 %Diff:%
 %Rows: [ 2 differences ]%
-%PK <NESTED_TABLE>%<UT_KEY_VALUE_PAIR>%<KEY>1</KEY>%<VALUE>Something 1</VALUE>%</UT_KEY_VALUE_PAIR>%<UT_KEY_VALUE_PAIR>%<KEY>2</KEY>%<VALUE>Something 2</VALUE>%</UT_KEY_VALUE_PAIR></NESTED_TABLE> - Extra%<RN>1</RN>%
-%PK <NESTED_TABLE>%<UT_KEY_VALUE_PAIR>%<KEY>1</KEY>%<VALUE>Something 1</VALUE>%</UT_KEY_VALUE_PAIR>%<UT_KEY_VALUE_PAIR>%<KEY>2</KEY>%<VALUE>Something 2</VALUE>%</UT_KEY_VALUE_PAIR></NESTED_TABLE> - Extra%<RN>2</RN>%
-%PK <NESTED_TABLE>%<UT_KEY_VALUE_PAIR>%<KEY>1</KEY>%<VALUE>Somethings 1</VALUE>%</UT_KEY_VALUE_PAIR>%<UT_KEY_VALUE_PAIR>%<KEY>2</KEY>%<VALUE>Somethings 2</VALUE>%</UT_KEY_VALUE_PAIR></NESTED_TABLE> - Missing%<RN>2</RN>%
-%PK <NESTED_TABLE>%<UT_KEY_VALUE_PAIR>%<KEY>1</KEY>%<VALUE>Somethings 1</VALUE>%</UT_KEY_VALUE_PAIR>%<UT_KEY_VALUE_PAIR>%<KEY>2</KEY>%<VALUE>Somethings 2</VALUE>%</UT_KEY_VALUE_PAIR></NESTED_TABLE> - Missing%<RN>1</RN>%]';
+%PK <NESTED_TABLE>%<UT_KEY_VALUE_PAIR>%<KEY>%</KEY>%<VALUE>%</VALUE>%</UT_KEY_VALUE_PAIR>%<UT_KEY_VALUE_PAIR>%<KEY>%</KEY>%<VALUE>%</VALUE>%</UT_KEY_VALUE_PAIR></NESTED_TABLE>%Extra%<RN>%</RN>%
+%PK <NESTED_TABLE>%<UT_KEY_VALUE_PAIR>%<KEY>%</KEY>%<VALUE>%</VALUE>%</UT_KEY_VALUE_PAIR>%<UT_KEY_VALUE_PAIR>%<KEY>%</KEY>%<VALUE>%</VALUE>%</UT_KEY_VALUE_PAIR></NESTED_TABLE>%Extra%<RN>%</RN>%
+%PK <NESTED_TABLE>%<UT_KEY_VALUE_PAIR>%<KEY>%</KEY>%<VALUE>%</VALUE>%</UT_KEY_VALUE_PAIR>%<UT_KEY_VALUE_PAIR>%<KEY>%</KEY>%<VALUE>%</VALUE>%</UT_KEY_VALUE_PAIR></NESTED_TABLE>%Missing%<RN>%</RN>%
+%PK <NESTED_TABLE>%<UT_KEY_VALUE_PAIR>%<KEY>%</KEY>%<VALUE>%</VALUE>%</UT_KEY_VALUE_PAIR>%<UT_KEY_VALUE_PAIR>%<KEY>%</KEY>%<VALUE>%</VALUE>%</UT_KEY_VALUE_PAIR></NESTED_TABLE>%Missing%<RN>%</RN>%]';
     l_actual_message := ut3.ut_expectation_processor.get_failed_expectations()(1).message;
     --Assert
     ut.expect(l_actual_message).to_be_like(l_expected_message);

--- a/test/core/expectations/compound_data/test_expectations_cursor.pks
+++ b/test/core/expectations/compound_data/test_expectations_cursor.pks
@@ -292,8 +292,29 @@ create or replace package test_expectations_cursor is
   --%test(Compare table type join by multiple columns- Failure)  
   procedure compare_nest_tab_cols_jb_fail;
   
-  --%test(Compare table type as column join by multiple columns - PLS Failure)  
-  procedure comparet_tabtype_as_cols_jb;
+  --%test(Compare table type as column join by multiple columns - Cannot find match)  
+  procedure compare_tabtype_as_cols_jb;
+
+  --%test(Compare table type as column normal compare )  
+  procedure compare_tabtype_as_cols;
+  
+  --%test(Compare table type as column join on collection element )  
+  procedure compare_tabtype_as_cols_coll; 
+  
+  --%test(Compare same content on record with collections join on record) 
+  procedure compare_rec_colltype_as_cols;
+ 
+  --%test(Compare same content record with collection join on record attribute)  
+  procedure compare_rec_colltype_as_attr;
+
+  --%test(Compare same content record with collection join on whole collection)   
+  procedure compare_collection_in_rec;
+    
+  --%test(Compare diffrent content record with collection join on record attribute) 
+  procedure compare_rec_coll_as_cols_fl;
+
+  --%test(Trying to join on collection element inside record )   
+  procedure compare_rec_coll_as_join;
   
 end;
 /


### PR DESCRIPTION
Fix to pk join where the key info was being collected on the collection by using convert any data object.
This was causing unwanted failure when doing normal compare.
changes been introduced to check whether the object is collection or not before invoking convert to anydata.
Because we will not drill into collections we just add information about type to  xml.
We have also added a new attribute that holds information if the cursor has a collection object type we detected. that is used to add a custom error when we are unable to match on PK. 
Unfortunately we cannot tell exactly which column refereed in join is collection  therefore to not give a false information in certain scenarios the message is very generic but is displayed after information what keys are missing.

The bug is causign a build to fail with one error which is expected behavior. This is being fixed by that PR.
It was tested locally against itself