### PR TITLE
Feature/parameters for before after annotations

### DIFF
--- a/source/core/ut_suite_builder.pkb
+++ b/source/core/ut_suite_builder.pkb
@@ -23,15 +23,15 @@ create or replace package body ut_suite_builder is
 
   gc_suite                       constant t_annotation_name := 'suite';
   gc_suitepath                   constant t_annotation_name := 'suitepath';
-  gc_test                        constant t_annotation_name := 'test';
+  gc_test                        constant t_annotation_name := ut_utils.gc_test_execute;
   gc_disabled                    constant t_annotation_name := 'disabled';
   gc_displayname                 constant t_annotation_name := 'displayname';
-  gc_beforeall                   constant t_annotation_name := 'beforeall';
-  gc_beforeeach                  constant t_annotation_name := 'beforeeach';
-  gc_beforetest                  constant t_annotation_name := 'beforetest';
-  gc_afterall                    constant t_annotation_name := 'afterall';
-  gc_aftereach                   constant t_annotation_name := 'aftereach';
-  gc_aftertest                   constant t_annotation_name := 'aftertest';
+  gc_beforeall                   constant t_annotation_name := ut_utils.gc_before_all;
+  gc_beforeeach                  constant t_annotation_name := ut_utils.gc_before_each;
+  gc_beforetest                  constant t_annotation_name := ut_utils.gc_before_test;
+  gc_afterall                    constant t_annotation_name := ut_utils.gc_after_all;
+  gc_aftereach                   constant t_annotation_name := ut_utils.gc_after_each;
+  gc_aftertest                   constant t_annotation_name := ut_utils.gc_after_test;
   gc_throws                      constant t_annotation_name := 'throws';
   gc_rollback                    constant t_annotation_name := 'rollback';
   gc_context                     constant t_annotation_name := 'context';
@@ -42,6 +42,19 @@ create or replace package body ut_suite_builder is
   gc_integer_exception           constant varchar2(1) := 'I';
   gc_named_exception             constant varchar2(1) := 'N';
 
+  type tt_executables is table of ut_executables index by t_annotation_position;
+
+  type tt_tests is table of ut_test index by t_annotation_position;
+
+
+  type t_annotation is record(
+    name                  t_annotation_name,
+    text                  t_annotation_text,
+    procedure_name        t_object_name
+  );
+  
+  type tt_annotations_by_line is table of t_annotation index by t_annotation_position;
+
   --list of annotation texts for a given annotation indexed by annotation position:
   --This would hold: ('some', 'other') for a single annotation name recurring in a single procedure example
   --  --%beforetest(some)
@@ -50,109 +63,40 @@ create or replace package body ut_suite_builder is
   --  procedure some_test ...
   -- when you'd like to have two beforetest procedures executed in a single test
   type tt_annotation_texts is table of t_annotation_text index by t_annotation_position;
+  
+  type tt_annotations_by_name is table of tt_annotation_texts index by t_annotation_name;
 
-  type tt_procedure_annotations is table of tt_annotation_texts index by t_annotation_name;
+  type tt_annotations_by_proc is table of tt_annotations_by_name index by t_object_name;
 
-  --holds information about
-  --   package level annotation
-  -- or
-  --   procedure and annotations associated with the procedure
-  type t_package_annotation is record(
-    text                  t_annotation_text,
-    name                  t_annotation_name,
-    procedure_name        t_object_name,
-    procedure_annotations tt_procedure_annotations
+  type t_annotations_info is record (
+    owner   t_object_name,
+    name    t_object_name,
+    by_line tt_annotations_by_line,
+    by_proc tt_annotations_by_proc,
+    by_name tt_annotations_by_name
   );
 
-  --holds a list of package and procedure level annotations indexed (order) by position.
-  --procedure level annotations are grouped under procedure name
-  type tt_package_annotations is table of t_package_annotation index by t_annotation_position;
-
-  --holds all annotations for object
-  type t_package_annotations_info is record(
-    owner         t_object_name,
-    name          t_object_name,
-    annotations   tt_package_annotations
-  );
-
-  --list of all package level annotation positions for a given annotaion name
-  type tt_package_annot_positions is table of boolean index by t_annotation_position;
-  --index used to lookup package level annotations by package-level annotation name
-  type tt_annotations_index   is table of tt_package_annot_positions index by t_annotation_name;
-
-
-  -----------------------------------------------
-  --- Conversion of annotations for processing
-  -----------------------------------------------
-  function get_procedure_annotations(a_annotations ut_annotations, a_index in out nocopy binary_integer) return tt_procedure_annotations is
-    l_result         tt_procedure_annotations;
-    l_index          binary_integer := a_index;
-    l_annotation_pos binary_integer;
-    function is_last_annotation_for_proc(a_annotations ut_annotations, a_index binary_integer) return boolean is
-    begin
-      return a_index = a_annotations.count or a_annotations(a_index).subobject_name != nvl(a_annotations(a_index+1).subobject_name, ' ');
-    end;
-  begin
-    loop
-      l_annotation_pos := a_annotations(a_index).position;
-      l_result(a_annotations(a_index).name)(l_annotation_pos) := a_annotations(a_index).text;
-      exit when is_last_annotation_for_proc(a_annotations, a_index);
-      a_index := a_annotations.next(a_index);
-    end loop;
-    return l_result;
-  end;
-
-  function convert_package_annotations(a_object ut_annotated_object) return t_package_annotations_info is
-    l_result         t_package_annotations_info;
-    l_annotation_no  binary_integer;
-    l_annotation_pos binary_integer;
-  begin
-    l_result.owner := a_object.object_owner;
-    l_result.name  := lower(trim(a_object.object_name));
-    l_annotation_no := a_object.annotations.first;
-    while l_annotation_no is not null loop
-      l_annotation_pos := a_object.annotations(l_annotation_no).position;
-      if a_object.annotations(l_annotation_no).subobject_name is null then
-        l_result.annotations(l_annotation_pos).name := a_object.annotations(l_annotation_no).name;
-        l_result.annotations(l_annotation_pos).text := a_object.annotations(l_annotation_no).text;
-      else
-        l_result.annotations(l_annotation_pos).procedure_name        := lower(trim(a_object.annotations(l_annotation_no).subobject_name));
-        l_result.annotations(l_annotation_pos).procedure_annotations := get_procedure_annotations(a_object.annotations, l_annotation_no);
-      end if;
-      l_annotation_no := a_object.annotations.next(l_annotation_no);
-    end loop;
-    return l_result;
-  end;
-
-  function build_annotation_index(a_annotations tt_package_annotations ) return tt_annotations_index is
-    l_result         tt_annotations_index;
-    l_annotation_pos binary_integer;
-  begin
-    l_annotation_pos := a_annotations.first;
-    while l_annotation_pos is not null loop
-      if a_annotations( l_annotation_pos ).name is not null then
-        l_result(a_annotations( l_annotation_pos ).name)( l_annotation_pos ) := true;
-      end if;
-      l_annotation_pos := a_annotations.next( l_annotation_pos );
-    end loop;
-    return l_result;
-  end;
-
-  procedure delete_from_annotation_index(
-    a_index in out nocopy tt_annotations_index,
-    a_start_pos t_annotation_position,
-    a_end_pos t_annotation_position
+  procedure delete_annotations_range(
+    a_annotations in out nocopy t_annotations_info,
+    a_start_pos   t_annotation_position,
+    a_end_pos     t_annotation_position
   ) is
-    l_idx t_annotation_name;
+    l_pos         t_annotation_position := a_start_pos;
+    l_annotation  t_annotation;
   begin
-    l_idx :=  a_index.first;
-    while l_idx is not null loop
-      a_index( l_idx ).delete( a_start_pos, a_end_pos);
-      if a_index( l_idx ).count = 0 then
-        a_index.delete( l_idx );
+    while l_pos is not null and l_pos <= a_end_pos loop
+      l_annotation := a_annotations.by_line(l_pos);
+      if l_annotation.procedure_name is not null and a_annotations.by_proc.exists(l_annotation.procedure_name) then
+        a_annotations.by_proc.delete(l_annotation.procedure_name);
+      elsif a_annotations.by_name.exists(l_annotation.name) then
+        a_annotations.by_name(l_annotation.name).delete(l_pos);
+        if a_annotations.by_name(l_annotation.name).count = 0 then
+          a_annotations.by_name.delete(l_annotation.name);
+        end if;
       end if;
-      l_idx := a_index.next( l_idx );
+      l_pos := a_annotations.by_line.next( l_pos );
     end loop;
+    a_annotations.by_line.delete(a_start_pos, a_end_pos);
   end;
 
   -----------------------------------------------
@@ -180,7 +124,6 @@ create or replace package body ut_suite_builder is
     a_line_no        binary_integer,
     a_procedure_name t_object_name := null
   ) is
-    l_object_name varchar2(1000);
   begin
     a_suite.put_warning(
         replace(a_message,'%%%','"--%'||a_annotation||'"') || ' Annotation ignored.'
@@ -199,113 +142,6 @@ create or replace package body ut_suite_builder is
      return l_rollback_type;
   end;
 
-  function check_exception_type(a_exception_name in varchar2) return varchar2 is
-      l_exception_type varchar2(50);
-    begin
-      --check if it is a predefined exception
-      begin
-        execute immediate 'begin null; exception when '||a_exception_name||' then null; end;';
-        l_exception_type := gc_named_exception;
-      exception
-        when others then
-          if dbms_utility.format_error_stack() like '%PLS-00485%' then
-            begin
-              execute immediate 'declare x positiven := -('||a_exception_name||'); begin null; end;';
-              l_exception_type := gc_integer_exception;
-            exception
-              when others then
-                --invalid exception number (positive)
-                --TODO add warning for this value
-                null;
-            end;
-          end if;
-      end;
-      return l_exception_type;
-   end;
-
-  function get_exception_number (a_exception_var in varchar2) return integer is
-    l_exc_no   integer;
-    l_exc_type varchar2(50);
-    l_sql      varchar2(32767);
-    function remap_no_data_found (a_number integer) return integer is
-    begin
-      return case a_number when 100 then -1403 else a_number end; 
-    end;
-  begin
-    l_exc_type := check_exception_type(a_exception_var); 
-   
-    if l_exc_type is not null then
-   
-      execute immediate
-        case l_exc_type
-          when gc_integer_exception then
-            'declare
-              l_exception number;
-            begin
-              :l_exception := '||a_exception_var||'; '
-          when gc_named_exception then
-            'begin
-              raise '||a_exception_var||';
-            exception
-              when others then
-                :l_exception := sqlcode; '
-          end ||
-            'end;'
-      using out l_exc_no;
-
-    end if;
-    return remap_no_data_found(l_exc_no);
-  end;  
-
-  function is_valid_qualified_name (a_name varchar2) return boolean is
-   l_name varchar2(500);
-  begin
-    l_name:=dbms_assert.qualified_sql_name(a_name);
-    return true;
-  exception when others then
-    return false;
-  end;
-  
-  function build_exception_numbers_list(
-    a_suite           in out nocopy ut_suite,
-    a_procedure_name  t_object_name,
-    a_line_no         integer,
-    a_annotation_text in varchar2
-  ) return ut_integer_list is
-    l_throws_list             ut_varchar2_list;
-    l_exception_number        integer;
-    l_exception_number_list   ut_integer_list := ut_integer_list();
-    c_regexp_for_exception_no constant varchar2(30) := '^-?[[:digit:]]{1,5}$';
-  begin
-    /*the a_expected_error_codes is converted to a ut_varchar2_list after that is trimmed and filtered to left only valid exception numbers*/
-    l_throws_list := ut_utils.trim_list_elements(ut_utils.string_to_table(a_annotation_text, ',', 'Y'));
-    
-    for i in 1 .. l_throws_list.count
-    loop
-      /** 
-      * Check if its a valid qualified name and if so try to resolve name to an exception number
-      */
-      if is_valid_qualified_name(l_throws_list(i)) then
-        l_exception_number := get_exception_number(l_throws_list(i));
-      elsif regexp_like(l_throws_list(i), c_regexp_for_exception_no) then
-        l_exception_number := l_throws_list(i);
-      end if;
-
-      if l_exception_number is null then
-        a_suite.put_warning(
-            'Invalid parameter value "'||l_throws_list(i)||'" for "--%throws" annotation. Parameter ignored.'
-            || chr( 10 ) || 'at "' || get_qualified_object_name(a_suite, a_procedure_name) || '", line ' || a_line_no
-        );
-      else
-        l_exception_number_list.extend;
-        l_exception_number_list(l_exception_number_list.last) := l_exception_number;
-      end if;
-      l_exception_number := null;
-    end loop;
-    
-    return l_exception_number_list;
-  end;
-
   procedure add_to_throws_numbers_list(
     a_suite           in out nocopy ut_suite,
     a_list            in out nocopy ut_integer_list,
@@ -313,6 +149,114 @@ create or replace package body ut_suite_builder is
     a_throws_ann_text tt_annotation_texts
   ) is
     l_annotation_pos binary_integer;
+
+    function is_valid_qualified_name (a_name varchar2) return boolean is
+      l_name varchar2(500);
+    begin
+      l_name := dbms_assert.qualified_sql_name(a_name);
+      return true;
+      exception when others then
+      return false;
+    end;
+
+    function check_exception_type(a_exception_name in varchar2) return varchar2 is
+      l_exception_type varchar2(50);
+    begin
+      --check if it is a predefined exception
+      begin
+        execute immediate 'begin null; exception when '||a_exception_name||' then null; end;';
+        l_exception_type := gc_named_exception;
+        exception
+        when others then
+        if dbms_utility.format_error_stack() like '%PLS-00485%' then
+          begin
+            execute immediate 'declare x positiven := -('||a_exception_name||'); begin null; end;';
+            l_exception_type := gc_integer_exception;
+            exception
+            when others then
+            --invalid exception number (positive)
+            --TODO add warning for this value
+            null;
+          end;
+        end if;
+      end;
+      return l_exception_type;
+    end;
+
+    function get_exception_number (a_exception_var in varchar2) return integer is
+      l_exc_no   integer;
+      l_exc_type varchar2(50);
+      l_sql      varchar2(32767);
+      function remap_no_data_found (a_number integer) return integer is
+      begin
+        return case a_number when 100 then -1403 else a_number end;
+      end;
+    begin
+      l_exc_type := check_exception_type(a_exception_var);
+
+      if l_exc_type is not null then
+
+        execute immediate
+        case l_exc_type
+        when gc_integer_exception then
+          'declare
+            l_exception number;
+          begin
+            :l_exception := '||a_exception_var||'; '
+        when gc_named_exception then
+          'begin
+            raise '||a_exception_var||';
+          exception
+            when others then
+              :l_exception := sqlcode; '
+        end ||
+        'end;'
+        using out l_exc_no;
+
+      end if;
+      return remap_no_data_found(l_exc_no);
+    end;
+
+    function build_exception_numbers_list(
+      a_suite           in out nocopy ut_suite,
+      a_procedure_name  t_object_name,
+      a_line_no         integer,
+      a_annotation_text in varchar2
+    ) return ut_integer_list is
+      l_throws_list             ut_varchar2_list;
+      l_exception_number        integer;
+      l_exception_number_list   ut_integer_list := ut_integer_list();
+      c_regexp_for_exception_no constant varchar2(30) := '^-?[[:digit:]]{1,5}$';
+    begin
+      /*the a_expected_error_codes is converted to a ut_varchar2_list after that is trimmed and filtered to left only valid exception numbers*/
+      l_throws_list := ut_utils.trim_list_elements(ut_utils.string_to_table(a_annotation_text, ',', 'Y'));
+
+      for i in 1 .. l_throws_list.count
+      loop
+        /**
+        * Check if its a valid qualified name and if so try to resolve name to an exception number
+        */
+        if is_valid_qualified_name(l_throws_list(i)) then
+          l_exception_number := get_exception_number(l_throws_list(i));
+        elsif regexp_like(l_throws_list(i), c_regexp_for_exception_no) then
+          l_exception_number := l_throws_list(i);
+        end if;
+
+        if l_exception_number is null then
+          a_suite.put_warning(
+              'Invalid parameter value "'||l_throws_list(i)||'" for "--%throws" annotation. Parameter ignored.'
+              || chr( 10 ) || 'at "' || get_qualified_object_name(a_suite, a_procedure_name) || '", line ' || a_line_no
+          );
+        else
+          l_exception_number_list.extend;
+          l_exception_number_list(l_exception_number_list.last) := l_exception_number;
+        end if;
+        l_exception_number := null;
+      end loop;
+
+      return l_exception_number_list;
+    end;
+
   begin
     a_list := ut_integer_list();
     l_annotation_pos := a_throws_ann_text.first;
@@ -336,7 +280,34 @@ create or replace package body ut_suite_builder is
     end loop;
   end;
 
-  procedure add_to_list(
+  function convert_list(
+    a_list tt_executables
+  ) return ut_executables is
+    l_result ut_executables := ut_executables();
+    l_pos   t_annotation_position := a_list.first;
+    begin
+      while l_pos is not null loop
+        l_result := l_result multiset union all a_list(l_pos);
+        l_pos := a_list.next(l_pos);
+      end loop;
+      return l_result;
+    end;
+
+  function convert_list(
+    a_list tt_tests
+  ) return ut_suite_items is
+    l_result ut_suite_items := ut_suite_items();
+    l_pos   t_annotation_position := a_list.first;
+    begin
+      while l_pos is not null loop
+        l_result.extend;
+        l_result(l_result.last) := a_list(l_pos);
+        l_pos := a_list.next(l_pos);
+      end loop;
+      return l_result;
+    end;
+
+  procedure add_executable(
     a_executables     in out nocopy ut_executables,
     a_owner           t_object_name,
     a_package_name    t_object_name,
@@ -351,51 +322,59 @@ create or replace package body ut_suite_builder is
       a_executables(a_executables.last) := ut_executable(a_owner, a_package_name, a_procedure_name, a_executable_type);
   end;
 
-  procedure add_all_to_list(
-    a_executables in out nocopy ut_executables,
+  function add_executables(
     a_owner            t_object_name,
     a_package_name     t_object_name,
     a_annotation_texts tt_annotation_texts,
     a_event_name       ut_utils.t_event_name
-  ) is
-    l_string_buffer varchar2(32767);
-    l_annotation_pos   binary_integer;
+  ) return tt_executables is
+    l_executables     ut_executables;
+    l_result          tt_executables;
+    l_annotation_pos  binary_integer;
     l_procedures_list ut_varchar2_list;
-    l_procedures_pos binary_integer;
+    l_procedures_pos  binary_integer;
     l_components_list ut_varchar2_list;
   begin
     l_annotation_pos := a_annotation_texts.first;
     while l_annotation_pos is not null loop
-      l_string_buffer := l_string_buffer||','||a_annotation_texts(l_annotation_pos);
+      l_procedures_list :=
+        ut_utils.filter_list(
+          ut_utils.trim_list_elements(
+            ut_utils.string_to_table(a_annotation_texts(l_annotation_pos), ',')
+          )
+          , '[[:alpha:]]+'
+        );
+
+      l_procedures_pos := l_procedures_list.first;
+      l_executables := ut_executables();
+      while l_procedures_pos is not null loop
+        l_components_list := ut_utils.string_to_table(l_procedures_list(l_procedures_pos), '.');
+
+        l_executables.extend;
+        l_executables(l_executables.last) :=
+          case(l_components_list.count())
+            when 1 then
+              ut_executable(a_owner, a_package_name, l_components_list(1), a_event_name)
+            when 2 then
+              ut_executable(a_owner,l_components_list(1), l_components_list(2), a_event_name)
+            when 3 then
+              ut_executable(l_components_list(1), l_components_list(2), l_components_list(3), a_event_name)
+            else
+              null
+          end;
+        l_procedures_pos := l_procedures_list.next(l_procedures_pos);
+      end loop;
+      l_result(l_annotation_pos) := l_executables;
       l_annotation_pos := a_annotation_texts.next(l_annotation_pos);
     end loop;
-    
-    l_procedures_list := ut_utils.trim_list_elements(ut_utils.string_to_table(l_string_buffer, ','));
-    l_procedures_list := ut_utils.filter_list(l_procedures_list, '[[:alpha:]]+');
-    
-    l_procedures_pos := l_procedures_list.first;
-    while l_procedures_pos is not null loop
-      l_components_list := ut_utils.string_to_table(l_procedures_list(l_procedures_pos), '.');
-      
-      case(l_components_list.count())
-        when 1 then 
-          add_to_list(a_executables, a_owner, a_package_name, l_components_list(1), a_event_name );
-        when 2 then 
-          add_to_list(a_executables, a_owner, l_components_list(1), l_components_list(2), a_event_name );
-        when 3 then 
-          add_to_list(a_executables, l_components_list(1), l_components_list(2), l_components_list(3), a_event_name );
-      else
-        null;
-      end case;
-      
-      l_procedures_pos := l_procedures_list.next(l_procedures_pos);
-    end loop;
+    return l_result;
   end;
 
   procedure warning_on_duplicate_annot(
     a_suite          in out nocopy ut_suite_item,
-    a_annotations     tt_annotations_index,
-    a_for_annotation varchar2
+    a_annotations    tt_annotations_by_name,
+    a_for_annotation varchar2,
+    a_procedure_name  t_object_name := null
   ) is
     l_annotation_name t_annotation_name;
     l_line_no           binary_integer;
@@ -405,38 +384,17 @@ create or replace package body ut_suite_builder is
         --start from second occurrence of annotation
         l_line_no := a_annotations(a_for_annotation).next( a_annotations(a_for_annotation).first );
         while l_line_no is not null loop
-          add_annotation_ignored_warning( a_suite, a_for_annotation, 'Duplicate annotation %%%.', l_line_no );
+          add_annotation_ignored_warning( a_suite, a_for_annotation, 'Duplicate annotation %%%.', l_line_no, a_procedure_name );
           l_line_no := a_annotations(a_for_annotation).next( l_line_no );
         end loop;
       end if;
     end if;
   end;
 
-  procedure warning_on_duplicate_annot(
-    a_suite          in out nocopy ut_suite_item,
-    a_procedure_name  t_object_name,
-    a_annotations     tt_procedure_annotations,
-    a_for_annotation  varchar2
-  ) is
-    l_annotation_name t_annotation_name;
-    l_line_no           binary_integer;
-    begin
-      if a_annotations.exists(a_for_annotation) then
-        if a_annotations(a_for_annotation).count > 1 then
-          --start from second occurrence of annotation
-          l_line_no := a_annotations(a_for_annotation).next( a_annotations(a_for_annotation).first );
-          while l_line_no is not null loop
-            add_annotation_ignored_warning( a_suite, a_for_annotation, 'Duplicate annotation %%%.', l_line_no, a_procedure_name );
-            l_line_no := a_annotations(a_for_annotation).next( l_line_no );
-          end loop;
-        end if;
-      end if;
-    end;
-
   procedure warning_bad_annot_combination(
     a_suite               in out nocopy ut_suite_item,
     a_procedure_name      t_object_name,
-    a_proc_annotations    tt_procedure_annotations,
+    a_proc_annotations    tt_annotations_by_name,
     a_for_annotation      varchar2,
     a_invalid_annotations ut_varchar2_list
   ) is
@@ -444,45 +402,59 @@ create or replace package body ut_suite_builder is
     l_warning         varchar2(32767);
     l_line_no           binary_integer;
   begin
-    l_annotation_name := a_proc_annotations.first;
-    while l_annotation_name is not null loop
-      if l_annotation_name member of a_invalid_annotations then
-        l_line_no := a_proc_annotations(l_annotation_name).first;
-        while l_line_no is not null loop
-          add_annotation_ignored_warning(
-              a_suite, l_annotation_name, 'Annotation %%% cannot be used with "--%'|| a_for_annotation || '".',
-              l_line_no, a_procedure_name
-          );
-          l_line_no := a_proc_annotations(l_annotation_name).next(l_line_no);
-        end loop;
-      end if;
-      l_annotation_name := a_proc_annotations.next(l_annotation_name);
-    end loop;
+    if a_proc_annotations.exists(a_for_annotation) then
+      l_annotation_name := a_proc_annotations.first;
+      while l_annotation_name is not null loop
+        if l_annotation_name member of a_invalid_annotations then
+          l_line_no := a_proc_annotations(l_annotation_name).first;
+          while l_line_no is not null loop
+            add_annotation_ignored_warning(
+                a_suite, l_annotation_name, 'Annotation %%% cannot be used with "--%'|| a_for_annotation || '".',
+                l_line_no, a_procedure_name
+            );
+            l_line_no := a_proc_annotations(l_annotation_name).next(l_line_no);
+          end loop;
+        end if;
+        l_annotation_name := a_proc_annotations.next(l_annotation_name);
+      end loop;
+    end if;
   end;
 
   procedure add_test(
-    a_suite          in out nocopy ut_suite,
-    a_procedure_name t_object_name,
-    a_annotations    tt_procedure_annotations
+    a_suite            in out nocopy ut_suite,
+    a_tests            in out nocopy tt_tests,
+    a_procedure_name   t_object_name,
+    a_proc_annotations tt_annotations_by_name
   ) is
     l_test             ut_test;
     l_annotation_texts tt_annotation_texts;
     l_annotation_pos   binary_integer;
   begin
+    if not a_proc_annotations.exists(gc_test) then
+      return;
+    end if;
+    warning_on_duplicate_annot(a_suite, a_proc_annotations, gc_test, a_procedure_name);
+    warning_on_duplicate_annot(a_suite, a_proc_annotations, gc_displayname, a_procedure_name);
+    warning_on_duplicate_annot(a_suite, a_proc_annotations, gc_rollback, a_procedure_name);
+    warning_bad_annot_combination(
+        a_suite, a_procedure_name, a_proc_annotations, gc_test,
+        ut_varchar2_list(gc_beforeeach, gc_aftereach, gc_beforeall, gc_afterall)
+    );
+    
     l_test := ut_test(a_suite.object_owner, a_suite.object_name, a_procedure_name);
 
-    if a_annotations.exists(gc_displayname) then
-      l_annotation_texts := a_annotations(gc_displayname);
+    if a_proc_annotations.exists(gc_displayname) then
+      l_annotation_texts := a_proc_annotations(gc_displayname);
       --take the last definition if more than one was provided
       l_test.description := l_annotation_texts(l_annotation_texts.first);
       --TODO if more than one - warning
     else
-      l_test.description := a_annotations(gc_test)(a_annotations(gc_test).first);
+      l_test.description := a_proc_annotations(gc_test)(a_proc_annotations(gc_test).first);
     end if;
     l_test.path := a_suite.path ||'.'||a_procedure_name;
 
-    if a_annotations.exists(gc_rollback) then
-      l_annotation_texts := a_annotations(gc_rollback);
+    if a_proc_annotations.exists(gc_rollback) then
+      l_annotation_texts := a_proc_annotations(gc_rollback);
       l_test.rollback_type := get_rollback_type(l_annotation_texts(l_annotation_texts.first));
       if l_test.rollback_type is null then
         add_annotation_ignored_warning(
@@ -492,24 +464,28 @@ create or replace package body ut_suite_builder is
       end if;
     end if;
 
-    if a_annotations.exists(gc_beforetest) then
-      add_all_to_list( l_test.before_test_list, l_test.object_owner, l_test.object_name, a_annotations(gc_beforetest), ut_utils.gc_before_test );
+    if a_proc_annotations.exists(gc_beforetest) then
+      l_test.before_test_list := convert_list(
+          add_executables( l_test.object_owner, l_test.object_name, a_proc_annotations( gc_beforetest ), gc_beforetest )
+      );
     end if;
-    if a_annotations.exists(gc_aftertest) then
-      add_all_to_list( l_test.after_test_list, l_test.object_owner, l_test.object_name, a_annotations(gc_aftertest), ut_utils.gc_after_test );
+    if a_proc_annotations.exists(gc_aftertest) then
+      l_test.after_test_list := convert_list(
+          add_executables( l_test.object_owner, l_test.object_name, a_proc_annotations( gc_aftertest ), gc_aftertest )
+      );
     end if;
-    if a_annotations.exists(gc_throws) then
-      add_to_throws_numbers_list(a_suite, l_test.expected_error_codes, a_procedure_name, a_annotations(gc_throws));
+    if a_proc_annotations.exists(gc_throws) then
+      add_to_throws_numbers_list(a_suite, l_test.expected_error_codes, a_procedure_name, a_proc_annotations(gc_throws));
     end if;
-    l_test.disabled_flag := ut_utils.boolean_to_int(a_annotations.exists(gc_disabled));
+    l_test.disabled_flag := ut_utils.boolean_to_int(a_proc_annotations.exists(gc_disabled));
 
-    a_suite.add_item(l_test);
+    a_tests(a_proc_annotations(gc_test).first) := l_test;
   end;
 
-  procedure update_before_after_list(
+  procedure update_before_after_each(
     a_suite in out nocopy ut_logical_suite,
-    a_before_each_list ut_executables,
-    a_after_each_list ut_executables
+    a_before_each_list tt_executables,
+    a_after_each_list  tt_executables
   ) is
     l_test      ut_test;
     l_context   ut_logical_suite;
@@ -518,306 +494,297 @@ create or replace package body ut_suite_builder is
       for i in 1 .. a_suite.items.count loop
         if a_suite.items(i) is of (ut_test) then
           l_test := treat( a_suite.items(i) as ut_test);
-          l_test.before_each_list := coalesce(a_before_each_list,ut_executables()) multiset union all l_test.before_each_list;
-          l_test.after_each_list := l_test.after_each_list multiset union all coalesce(a_after_each_list,ut_executables());
+          l_test.before_each_list := coalesce(convert_list(a_before_each_list),ut_executables()) multiset union all l_test.before_each_list;
+          l_test.after_each_list := l_test.after_each_list multiset union all coalesce(convert_list(a_after_each_list),ut_executables());
           a_suite.items(i) := l_test;
         elsif a_suite.items(i) is of (ut_logical_suite) then
           l_context := treat(a_suite.items(i) as ut_logical_suite);
-          update_before_after_list(l_context, a_before_each_list, a_after_each_list);
+          update_before_after_each(l_context, a_before_each_list, a_after_each_list);
           a_suite.items(i) := l_context;
         end if;
       end loop;
     end if;
   end;
 
-  procedure add_annotated_procedure(
+  procedure process_before_after_annot(
+    a_list             in out nocopy tt_executables,
+    a_annotation_name  t_annotation_name,
     a_procedure_name   t_object_name,
-    a_proc_annotations tt_procedure_annotations,
-    a_suite            in out nocopy ut_suite,
-    a_before_each_list in out nocopy ut_executables,
-    a_after_each_list  in out nocopy ut_executables
-  ) is
+    a_proc_annotations tt_annotations_by_name,
+    a_suite            in out nocopy ut_suite
+  ) is 
   begin
-    warning_on_duplicate_annot(a_suite, a_procedure_name, a_proc_annotations, gc_test);
-    warning_on_duplicate_annot(a_suite, a_procedure_name, a_proc_annotations, gc_displayname);
-    warning_on_duplicate_annot(a_suite, a_procedure_name, a_proc_annotations, gc_rollback);
-    warning_on_duplicate_annot(a_suite, a_procedure_name, a_proc_annotations, gc_beforeall);
-    warning_on_duplicate_annot(a_suite, a_procedure_name, a_proc_annotations, gc_beforeeach);
-    warning_on_duplicate_annot(a_suite, a_procedure_name, a_proc_annotations, gc_afterall);
-    warning_on_duplicate_annot(a_suite, a_procedure_name, a_proc_annotations, gc_aftereach);
-
-    if a_proc_annotations.exists(gc_test) then
-      add_test( a_suite, a_procedure_name, a_proc_annotations);
-
-      warning_bad_annot_combination(
-        a_suite, a_procedure_name, a_proc_annotations, gc_test,
-        ut_varchar2_list(gc_beforeeach, gc_aftereach, gc_beforeall, gc_afterall)
-      );
-
-    else
-      if a_proc_annotations.exists(gc_beforeeach) then
-        add_to_list( a_before_each_list, a_suite.object_owner, a_suite.object_name, a_procedure_name, ut_utils.gc_before_each );
-        --TODO add warning if annotation has text - text ignored
-      end if;
-      if a_proc_annotations.exists(gc_aftereach) then
-        add_to_list( a_after_each_list, a_suite.object_owner, a_suite.object_name, a_procedure_name, ut_utils.gc_after_each );
-        --TODO add warning if annotation has text - text ignored
-      end if;
-      if a_proc_annotations.exists(gc_beforeall) then
-        add_to_list( a_suite.before_all_list, a_suite.object_owner, a_suite.object_name, a_procedure_name, ut_utils.gc_before_all );
-        --TODO add warning if annotation has text - text ignored
-      end if;
-      if a_proc_annotations.exists(gc_afterall) then
-        add_to_list( a_suite.after_all_list, a_suite.object_owner, a_suite.object_name, a_procedure_name, ut_utils.gc_after_all );
-        --TODO add warning if annotation has text - text ignored
-      end if;
+    if a_proc_annotations.exists(a_annotation_name) and not a_proc_annotations.exists(gc_test) then
+      a_list( a_proc_annotations(a_annotation_name).first ) := ut_executables(ut_executable(a_suite.object_owner,  a_suite.object_name, a_procedure_name, a_annotation_name));
+      warning_on_duplicate_annot(a_suite, a_proc_annotations, a_annotation_name, a_procedure_name);
+    --TODO add warning if annotation has text - text ignored
     end if;
   end;
 
   procedure add_annotated_procedures(
-    a_annotations tt_package_annotations,
-    a_suite in out nocopy ut_suite,
-    a_before_each_list out nocopy ut_executables,
-    a_after_each_list out nocopy ut_executables
+    a_proc_annotations tt_annotations_by_proc,
+    a_suite            in out nocopy ut_suite,
+    a_before_each_list in out nocopy tt_executables,
+    a_after_each_list  in out nocopy tt_executables,
+    a_before_all_list  in out nocopy tt_executables,
+    a_after_all_list   in out nocopy tt_executables
   ) is
-    l_position t_annotation_position;
+    l_procedure_name   t_object_name;
+    l_tests            tt_tests;
   begin
-    a_before_each_list := ut_executables();
-    a_after_each_list := ut_executables();
-    l_position := a_annotations.first;
-    while l_position is not null loop
-      if a_annotations(l_position).procedure_name is not null then
-        add_annotated_procedure(
-          a_annotations(l_position).procedure_name,
-          a_annotations(l_position).procedure_annotations,
-          a_suite,
-          a_before_each_list,
-          a_after_each_list
-        );
-      end if;
-      l_position := a_annotations.next( l_position);
+    l_procedure_name := a_proc_annotations.first;
+    while l_procedure_name is not null loop
+      add_test( a_suite, l_tests, l_procedure_name, a_proc_annotations(l_procedure_name) );
+      process_before_after_annot(a_before_each_list, gc_beforeeach, l_procedure_name, a_proc_annotations(l_procedure_name), a_suite);
+      process_before_after_annot(a_after_each_list,  gc_aftereach,  l_procedure_name, a_proc_annotations(l_procedure_name), a_suite);
+      process_before_after_annot(a_before_all_list,  gc_beforeall,  l_procedure_name, a_proc_annotations(l_procedure_name), a_suite);
+      process_before_after_annot(a_after_all_list,   gc_afterall,   l_procedure_name, a_proc_annotations(l_procedure_name), a_suite);
+      l_procedure_name := a_proc_annotations.next( l_procedure_name );
     end loop;
+    a_suite.items := a_suite.items multiset union all convert_list(l_tests);
   end;
 
-  procedure populate_suite_contents(
+  procedure build_suitepath(
     a_suite              in out nocopy ut_suite,
-    a_annotations        tt_package_annotations,
-    a_package_ann_index  tt_annotations_index,
-    a_context_name       t_object_name := null
+    a_annotations        t_annotations_info
   ) is
-    l_before_each_list   ut_executables;
-    l_after_each_list    ut_executables;
-    l_rollback_type      ut_utils.t_rollback_type;
-    l_annotation_text    varchar2(32767);
-    l_object_name        t_object_name;
+    l_annotation_text    t_annotation_text;
   begin
-    if a_context_name is not null then
-      l_object_name := a_suite.object_name||'.'||a_context_name;
-    else
-      l_object_name := a_suite.object_name;
-    end if;
-    if a_package_ann_index.exists(gc_suitepath) then
-      l_annotation_text := trim(a_annotations(a_package_ann_index(gc_suitepath).first).text);
+    if a_annotations.by_name.exists(gc_suitepath) then
+      l_annotation_text := trim(a_annotations.by_name(gc_suitepath)(a_annotations.by_name(gc_suitepath).first));
       if l_annotation_text is not null then
         if regexp_like(l_annotation_text,'^((\w|[$#])+\.)*(\w|[$#])+$') then
-          a_suite.path := l_annotation_text||'.'||l_object_name;
+          a_suite.path := l_annotation_text||'.'||a_suite.object_name;
         else
           add_annotation_ignored_warning(
-            a_suite, gc_suitepath||'('||l_annotation_text||')',
-            'Invalid path value in annotation %%%.', a_package_ann_index(gc_suitepath).first
+              a_suite, gc_suitepath||'('||l_annotation_text||')',
+              'Invalid path value in annotation %%%.', a_annotations.by_name(gc_suitepath).first
           );
         end if;
       else
         add_annotation_ignored_warning(
-          a_suite, gc_suitepath, '%%% annotation requires a non-empty parameter value.',
-          a_package_ann_index(gc_suitepath).first
+            a_suite, gc_suitepath, '%%% annotation requires a non-empty parameter value.',
+            a_annotations.by_name(gc_suitepath).first
         );
       end if;
-      warning_on_duplicate_annot(a_suite, a_package_ann_index, gc_suitepath);
+      warning_on_duplicate_annot(a_suite, a_annotations.by_name, gc_suitepath);
     end if;
-    a_suite.path := lower(coalesce(a_suite.path, l_object_name));
+    a_suite.path := lower(coalesce(a_suite.path, a_suite.object_name));
+  end;
 
-    if a_package_ann_index.exists(gc_displayname) then
-      l_annotation_text := trim(a_annotations(a_package_ann_index(gc_displayname).first).text);
+  procedure populate_suite_contents(
+    a_suite              in out nocopy ut_suite,
+    a_annotations        t_annotations_info
+  ) is
+    l_before_each_list   tt_executables;
+    l_after_each_list    tt_executables;
+    l_before_all_list    tt_executables;
+    l_after_all_list     tt_executables;
+    l_executables        ut_executables;
+    l_rollback_type      ut_utils.t_rollback_type;
+    l_annotation_text    t_annotation_text;
+  begin
+    if a_annotations.by_name.exists(gc_displayname) then
+      l_annotation_text := trim(a_annotations.by_name(gc_displayname)(a_annotations.by_name(gc_displayname).first));
       if l_annotation_text is not null then
         a_suite.description := l_annotation_text;
       else
         add_annotation_ignored_warning(
             a_suite, gc_displayname, '%%% annotation requires a non-empty parameter value.',
-            a_package_ann_index(gc_displayname).first
+            a_annotations.by_name(gc_displayname).first
         );
       end if;
-      warning_on_duplicate_annot(a_suite, a_package_ann_index, gc_displayname);
+      warning_on_duplicate_annot(a_suite, a_annotations.by_name, gc_displayname);
     end if;
 
-    if a_package_ann_index.exists(gc_rollback) then
-      l_rollback_type := get_rollback_type(a_annotations(a_package_ann_index(gc_rollback).first).text);
+    if a_annotations.by_name.exists(gc_rollback) then
+      l_rollback_type := get_rollback_type(a_annotations.by_name(gc_rollback)(a_annotations.by_name(gc_rollback).first));
       if l_rollback_type is null then
         add_annotation_ignored_warning(
             a_suite, gc_rollback, '%%% annotation requires one of values as parameter: "auto" or "manual".',
-            a_package_ann_index(gc_rollback).first
+            a_annotations.by_name(gc_rollback).first
         );
       end if;
-      warning_on_duplicate_annot(a_suite, a_package_ann_index, gc_rollback);
+      warning_on_duplicate_annot(a_suite, a_annotations.by_name, gc_rollback);
+    end if;
+    if a_annotations.by_name.exists(gc_beforeall) then
+      l_before_all_list := add_executables( a_suite.object_owner, a_suite.object_name, a_annotations.by_name(gc_beforeall), gc_beforeall );
+    end if;
+    if a_annotations.by_name.exists(gc_afterall) then
+      l_after_all_list := add_executables( a_suite.object_owner, a_suite.object_name, a_annotations.by_name(gc_afterall), gc_afterall );
     end if;
 
-    a_suite.disabled_flag := ut_utils.boolean_to_int(a_package_ann_index.exists(gc_disabled));
+    if a_annotations.by_name.exists(gc_beforeeach) then
+      l_before_each_list := add_executables( a_suite.object_owner, a_suite.object_name, a_annotations.by_name(gc_beforeeach), gc_beforeeach );
+    end if;
+    if a_annotations.by_name.exists(gc_aftereach) then
+      l_after_each_list := add_executables( a_suite.object_owner, a_suite.object_name, a_annotations.by_name(gc_aftereach), gc_aftereach );
+    end if;
+
+    a_suite.disabled_flag := ut_utils.boolean_to_int(a_annotations.by_name.exists(gc_disabled));
 
     --process procedure annotations for suite
-    add_annotated_procedures(a_annotations, a_suite, l_before_each_list, l_after_each_list);
+    add_annotated_procedures(a_annotations.by_proc, a_suite, l_before_each_list, l_after_each_list, l_before_all_list, l_after_all_list);
 
     a_suite.set_rollback_type(l_rollback_type);
-    update_before_after_list(a_suite, l_before_each_list, l_after_each_list);
+    update_before_after_each(a_suite, l_before_each_list, l_after_each_list);
+    a_suite.before_all_list := convert_list(l_before_all_list);
+    a_suite.after_all_list  := convert_list(l_after_all_list);
   end;
 
 
   procedure add_suite_contexts(
     a_suite              in out nocopy ut_suite,
-    a_annotations        in out nocopy tt_package_annotations,
-    a_package_ann_index  in out nocopy tt_annotations_index
+    a_annotations        in out nocopy t_annotations_info
   ) is
     l_context_pos        t_annotation_position;
     l_end_context_pos    t_annotation_position;
-    l_context_ann_index  tt_annotations_index;
     l_context_name       t_object_name;
-    l_annotations        tt_package_annotations;
+    l_ctx_annotations    t_annotations_info;
     l_context            ut_suite_context;
     l_context_no         binary_integer := 1;
 
     function get_endcontext_position(
-      a_context_ann_pos   t_annotation_position,
-      a_package_ann_index in out nocopy tt_annotations_index
+      a_context_ann_pos     t_annotation_position,
+      a_package_annotations in out nocopy tt_annotations_by_name
     ) return t_annotation_position is
       l_result t_annotation_position;
     begin
-      if a_package_ann_index.exists(gc_endcontext) then
-        l_result := a_package_ann_index(gc_endcontext).first;
+      if a_package_annotations.exists(gc_endcontext) then
+        l_result := a_package_annotations(gc_endcontext).first;
         while l_result <= a_context_ann_pos loop
-          --remove invalid endcontext
-          delete_from_annotation_index(a_package_ann_index, l_result, l_result);
-          --remove the bad endcontext from index
-          l_result := a_package_ann_index(gc_endcontext).next(l_result);
+          l_result := a_package_annotations(gc_endcontext).next(l_result);
         end loop;
       end if;
       return l_result;
     end;
 
     function get_annotations_in_context(
-      a_annotations        tt_package_annotations,
+      a_annotations        t_annotations_info,
       a_context_pos        t_annotation_position,
       a_end_context_pos    t_annotation_position
-    ) return tt_package_annotations is
-      l_annotations        tt_package_annotations;
-      l_position           t_annotation_position;
+    ) return t_annotations_info is
+      l_result          t_annotations_info;
+      l_position        t_annotation_position;
+      l_procedure_name  t_object_name;
+      l_annotation_name t_annotation_name;
+      l_annotation_text t_annotation_text;
     begin
       l_position := a_context_pos;
+      l_result.owner := a_annotations.owner;
+      l_result.name := a_annotations.name;
       while l_position is not null and l_position <= a_end_context_pos loop
-        l_annotations(l_position) := a_annotations(l_position);
-        l_position := a_annotations.next(l_position);
+        l_result.by_line(l_position) := a_annotations.by_line(l_position);
+        l_procedure_name  := l_result.by_line(l_position).procedure_name;
+        l_annotation_name := l_result.by_line(l_position).name;
+        l_annotation_text := l_result.by_line(l_position).text;
+        if l_procedure_name is not null then
+          l_result.by_proc(l_procedure_name)(l_annotation_name)(l_position) := l_annotation_text;
+        else
+          l_result.by_name(l_annotation_name)(l_position) := l_annotation_text;
+        end if;
+        l_position := a_annotations.by_line.next(l_position);
       end loop;
-      return l_annotations;
+      return l_result;
     end;
 
   begin
-    if not a_package_ann_index.exists(gc_context) then
+    if not a_annotations.by_name.exists(gc_context) then
       return;
     end if;
-    l_context_pos := a_package_ann_index(gc_context).first;
+
+    l_context_pos := a_annotations.by_name( gc_context).first;
+
     while l_context_pos is not null loop
-      l_end_context_pos := get_endcontext_position(l_context_pos, a_package_ann_index);
+      l_end_context_pos := get_endcontext_position(l_context_pos, a_annotations.by_name );
       if l_end_context_pos is null then
         exit;
       end if;
 
       --create a sub-set of annotations to process as sub-suite (context)
-      l_annotations       := get_annotations_in_context(a_annotations, l_context_pos, l_end_context_pos);
-      l_context_ann_index := build_annotation_index(l_annotations);
+      l_ctx_annotations   := get_annotations_in_context( a_annotations, l_context_pos, l_end_context_pos);
 
       l_context_name := coalesce(
-          l_annotations( l_context_pos ).text
-          , gc_context||'_'||l_context_no
+        l_ctx_annotations.by_line( l_context_pos ).text
+        , gc_context||'_'||l_context_no
       );
+
       l_context := ut_suite_context(a_suite.object_owner, a_suite.object_name, l_context_name );
 
-      l_context.description := l_annotations(l_context_pos).text;
-      warning_on_duplicate_annot( l_context, l_context_ann_index, gc_suite );
+      l_context.path := a_suite.path||'.'||l_context_name;
+      l_context.description := l_ctx_annotations.by_line( l_context_pos ).text;
 
-      populate_suite_contents( l_context, l_annotations, l_context_ann_index, l_context_name );
+      warning_on_duplicate_annot( l_context, l_ctx_annotations.by_name, gc_context );
+
+      populate_suite_contents( l_context, l_ctx_annotations );
 
       a_suite.add_item(l_context);
 
       -- remove annotations within context after processing them
-      a_annotations.delete(l_context_pos, l_end_context_pos);
-      delete_from_annotation_index(a_package_ann_index, l_context_pos, l_end_context_pos);
+      delete_annotations_range(a_annotations, l_context_pos, l_end_context_pos);
 
-      if a_package_ann_index.exists(gc_context) then
-        l_context_pos := a_package_ann_index(gc_context).next(l_context_pos);
-      else
-        l_context_pos := null;
-      end if;
+      exit when not a_annotations.by_name.exists( gc_context);
+
+      l_context_pos := a_annotations.by_name( gc_context).next( l_context_pos);
       l_context_no := l_context_no + 1;
     end loop;
   end;
 
   procedure warning_on_incomplete_context(
     a_suite              in out nocopy ut_suite,
-    a_annotations        tt_package_annotations,
-    a_package_ann_index  tt_annotations_index
+    a_package_ann_index  tt_annotations_by_name
   ) is
     l_annotation_pos  t_annotation_position;
-    begin
-      if a_package_ann_index.exists(gc_context) then
-        l_annotation_pos := a_package_ann_index(gc_context).first;
-        while l_annotation_pos is not null loop
-          add_annotation_ignored_warning(
-              a_suite, gc_context, 'Invalid annotation %%%. Cannot find following "--%endcontext".',
-              l_annotation_pos
-          );
-          l_annotation_pos := a_package_ann_index(gc_context).next(l_annotation_pos);
-        end loop;
-      end if;
-      if a_package_ann_index.exists(gc_endcontext) then
-        l_annotation_pos := a_package_ann_index(gc_endcontext).first;
-        while l_annotation_pos is not null loop
-          add_annotation_ignored_warning(
-              a_suite, gc_endcontext, 'Invalid annotation %%%. Cannot find preceding "--%context".',
-              l_annotation_pos
-          );
-          l_annotation_pos := a_package_ann_index(gc_endcontext).next(l_annotation_pos);
-        end loop;
-      end if;
-    end;
-
-  function create_suite(
-    a_package_annotations t_package_annotations_info
-  ) return ut_logical_suite is
-    l_annotations       tt_package_annotations := a_package_annotations.annotations;
-    l_package_ann_index tt_annotations_index;
-    l_suite              ut_suite;
   begin
-    l_package_ann_index   := build_annotation_index(l_annotations);
-    if l_package_ann_index.exists(gc_suite) then
+    if a_package_ann_index.exists(gc_context) then
+      l_annotation_pos := a_package_ann_index(gc_context).first;
+      while l_annotation_pos is not null loop
+        add_annotation_ignored_warning(
+            a_suite, gc_context, 'Invalid annotation %%%. Cannot find following "--%endcontext".',
+            l_annotation_pos
+        );
+        l_annotation_pos := a_package_ann_index(gc_context).next(l_annotation_pos);
+      end loop;
+    end if;
+    if a_package_ann_index.exists(gc_endcontext) then
+      l_annotation_pos := a_package_ann_index(gc_endcontext).first;
+      while l_annotation_pos is not null loop
+        add_annotation_ignored_warning(
+            a_suite, gc_endcontext, 'Invalid annotation %%%. Cannot find preceding "--%context".',
+            l_annotation_pos
+        );
+        l_annotation_pos := a_package_ann_index(gc_endcontext).next(l_annotation_pos);
+      end loop;
+    end if;
+  end;
+  
+  function create_suite(
+    a_annotations t_annotations_info
+  ) return ut_logical_suite is
+    l_annotations    t_annotations_info := a_annotations;
+    l_annotation_pos t_annotation_position;
+    l_suite          ut_suite;
+  begin
+    if l_annotations.by_name.exists( gc_suite) then
 
       --create an incomplete suite
-      l_suite := ut_suite(a_package_annotations.owner, a_package_annotations.name);
+      l_suite := ut_suite(l_annotations.owner, l_annotations.name);
+      l_annotation_pos := l_annotations.by_name( gc_suite).first;
+      l_suite.description := l_annotations.by_name( gc_suite)( l_annotation_pos);
 
-      l_suite.description := l_annotations(l_package_ann_index(gc_suite).first).text;
-      warning_on_duplicate_annot(l_suite, l_package_ann_index, gc_suite);
+      warning_on_duplicate_annot( l_suite, l_annotations.by_name, gc_suite );
 
-      add_suite_contexts( l_suite, l_annotations, l_package_ann_index );
+      build_suitepath( l_suite, l_annotations );
+
+      add_suite_contexts( l_suite, l_annotations );
       --by this time all contexts were consumed and l_annotations should not have any context/endcontext annotation in it.
-      warning_on_incomplete_context( l_suite, l_annotations, l_package_ann_index );
+      warning_on_incomplete_context( l_suite, l_annotations.by_name );
 
-      populate_suite_contents( l_suite, l_annotations, l_package_ann_index );
+      populate_suite_contents( l_suite, l_annotations );
 
     end if;
     return l_suite;
   end;
-
-  function create_suite(a_object ut_annotated_object) return ut_logical_suite is
-  begin
-    return create_suite( convert_package_annotations(a_object) );
-  end create_suite;
 
   function build_suites_hierarchy(a_suites_by_path tt_schema_suites) return tt_schema_suites is
     l_result            tt_schema_suites;
@@ -867,12 +834,38 @@ create or replace package body ut_suite_builder is
     l_annotated_objects ut_annotated_objects;
     l_all_suites        tt_schema_suites;
     l_result            t_schema_suites_info;
+
+    function convert_package_annotations(a_object ut_annotated_object) return t_annotations_info is
+      l_result          t_annotations_info;
+      l_annotation      t_annotation;
+      l_annotation_no   binary_integer;
+      l_annotation_pos  binary_integer;
+    begin
+      l_result.owner := a_object.object_owner;
+      l_result.name  := lower(trim(a_object.object_name));
+      l_annotation_no := a_object.annotations.first;
+      while l_annotation_no is not null loop
+        l_annotation_pos := a_object.annotations(l_annotation_no).position;
+        l_annotation.name := a_object.annotations(l_annotation_no).name;
+        l_annotation.text := a_object.annotations(l_annotation_no).text;
+        l_annotation.procedure_name := lower(trim(a_object.annotations(l_annotation_no).subobject_name));
+        l_result.by_line( l_annotation_pos) := l_annotation;
+        if l_annotation.procedure_name is null then
+          l_result.by_name( l_annotation.name)( l_annotation_pos) := l_annotation.text;
+        else
+          l_result.by_proc(l_annotation.procedure_name)(l_annotation.name)(l_annotation_pos) := l_annotation.text;
+        end if;
+        l_annotation_no := a_object.annotations.next(l_annotation_no);
+      end loop;
+      return l_result;
+    end;
+
   begin
     fetch a_annotated_objects bulk collect into l_annotated_objects;
     close a_annotated_objects;
 
     for i in 1 .. l_annotated_objects.count loop
-      l_suite := create_suite(l_annotated_objects(i));
+      l_suite := create_suite(convert_package_annotations(l_annotated_objects(i)));
       if l_suite is not null then
         l_all_suites(l_suite.path) := l_suite;
         l_result.suite_paths(l_suite.object_name) := l_suite.path;

--- a/test/core/test_suite_builder.pkb
+++ b/test/core/test_suite_builder.pkb
@@ -523,6 +523,68 @@ create or replace package body test_suite_builder is
     );
   end;
 
+  procedure multiple_mixed_bef_aft is
+    l_actual      clob;
+    l_annotations ut3.ut_annotations;
+  begin
+    --Arrange
+    l_annotations := ut3.ut_annotations(
+        ut3.ut_annotation(1, 'suite','Cool', null),
+        ut3.ut_annotation(2, 'beforeall', null,'first_before_all'),
+        ut3.ut_annotation(3, 'beforeall', 'different_package.another_before_all',null),
+        ut3.ut_annotation(4, 'beforeeach', 'first_before_each',null),
+        ut3.ut_annotation(5, 'beforeeach', 'different_owner.different_package.another_before_each',null),
+        ut3.ut_annotation(6, 'aftereach', null, 'first_after_each'),
+        ut3.ut_annotation(7, 'aftereach', 'another_after_each,different_owner.different_package.one_more_after_each',null),
+        ut3.ut_annotation(8, 'afterall', 'first_after_all',null),
+        ut3.ut_annotation(9, 'afterall', 'another_after_all',null),
+        ut3.ut_annotation(14, 'test','A test', 'some_test'),
+        ut3.ut_annotation(15, 'beforetest','before_test_proc', 'some_test'),
+        ut3.ut_annotation(16, 'beforetest','before_test_proc2', 'some_test'),
+        ut3.ut_annotation(18, 'aftertest','after_test_proc', 'some_test'),
+        ut3.ut_annotation(20, 'aftertest','after_test_proc2', 'some_test'),
+        ut3.ut_annotation(21, 'beforeall', null,'last_before_all'),
+        ut3.ut_annotation(22, 'aftereach', null, 'last_after_each'),
+        ut3.ut_annotation(23, 'afterall', null, 'last_after_all')
+    );
+    --Act
+    l_actual := invoke_builder_for_annotations(l_annotations, 'SOME_PACKAGE');
+    --Assert
+    ut.expect(l_actual).to_be_like(
+        '%<UT_SUITE_ITEM>%<OBJECT_NAME>some_package</OBJECT_NAME>%<NAME>some_test</NAME>' ||
+        '%<BEFORE_EACH_LIST>' ||
+        '%<OBJECT_NAME>some_package</OBJECT_NAME><PROCEDURE_NAME>first_before_each</PROCEDURE_NAME>' ||
+        '%<OWNER_NAME>different_owner</OWNER_NAME><OBJECT_NAME>different_package</OBJECT_NAME><PROCEDURE_NAME>another_before_each</PROCEDURE_NAME>' ||
+        '%</BEFORE_EACH_LIST>' ||
+        '%<BEFORE_TEST_LIST>' ||
+        '%<OBJECT_NAME>some_package</OBJECT_NAME><PROCEDURE_NAME>before_test_proc</PROCEDURE_NAME>' ||
+        '%<OBJECT_NAME>some_package</OBJECT_NAME><PROCEDURE_NAME>before_test_proc2</PROCEDURE_NAME>' ||
+        '%</BEFORE_TEST_LIST>' ||
+        '%<AFTER_TEST_LIST>' ||
+        '%<OBJECT_NAME>some_package</OBJECT_NAME><PROCEDURE_NAME>after_test_proc</PROCEDURE_NAME>' ||
+        '%<OBJECT_NAME>some_package</OBJECT_NAME><PROCEDURE_NAME>after_test_proc2</PROCEDURE_NAME>' ||
+        '%</AFTER_TEST_LIST>' ||
+        '%<AFTER_EACH_LIST>' ||
+        '%<OBJECT_NAME>some_package</OBJECT_NAME><PROCEDURE_NAME>first_after_each</PROCEDURE_NAME>' ||
+        '%<OBJECT_NAME>some_package</OBJECT_NAME><PROCEDURE_NAME>another_after_each</PROCEDURE_NAME>' ||
+        '%<OWNER_NAME>different_owner</OWNER_NAME><OBJECT_NAME>different_package</OBJECT_NAME><PROCEDURE_NAME>one_more_after_each</PROCEDURE_NAME>' ||
+        '%<OBJECT_NAME>some_package</OBJECT_NAME><PROCEDURE_NAME>last_after_each</PROCEDURE_NAME>' ||
+        '%</AFTER_EACH_LIST>' ||
+        '%</UT_SUITE_ITEM>' ||
+        '%<BEFORE_ALL_LIST>' ||
+        '%<OBJECT_NAME>some_package</OBJECT_NAME><PROCEDURE_NAME>first_before_all</PROCEDURE_NAME>' ||
+        '%<OBJECT_NAME>different_package</OBJECT_NAME><PROCEDURE_NAME>another_before_all</PROCEDURE_NAME>' ||
+        '%<OBJECT_NAME>some_package</OBJECT_NAME><PROCEDURE_NAME>last_before_all</PROCEDURE_NAME>' ||
+        '%</BEFORE_ALL_LIST>' ||
+        '%<AFTER_ALL_LIST>' ||
+        '%<OBJECT_NAME>some_package</OBJECT_NAME><PROCEDURE_NAME>first_after_all</PROCEDURE_NAME>' ||
+        '%<OBJECT_NAME>some_package</OBJECT_NAME><PROCEDURE_NAME>another_after_all</PROCEDURE_NAME>' ||
+        '%<OBJECT_NAME>some_package</OBJECT_NAME><PROCEDURE_NAME>last_after_all</PROCEDURE_NAME>' ||
+        '%</AFTER_ALL_LIST>%'
+    );
+  end;
+
+
   procedure before_after_mixed_with_test is
     l_actual      clob;
     l_annotations ut3.ut_annotations;

--- a/test/core/test_suite_builder.pks
+++ b/test/core/test_suite_builder.pks
@@ -2,47 +2,53 @@ create or replace package test_suite_builder is
   --%suite(suite_builder)
   --%suitepath(utplsql.core)
 
+  --%context(suite)
+  --%displayname(--%suite annotation)
+
   --%test(Sets suite name from package name and leaves description empty)
   procedure no_suite_description;
 
   --%test(Sets suite description using first --%suite annotation)
   procedure suite_description_from_suite;
 
-  --%test(Sets suite path using first --%suitepath annotation)
-  procedure suitepath_from_non_empty_path;
+  --%test(Gives warning if more than one --%suite annotation used)
+  procedure suite_annot_duplicated;
+
+  --%endcontext
+
+  --%context(displayname)
+  --%displayname(--%displayname annotation)
 
   --%test(Overrides suite description using first --%displayname annotation)
   procedure suite_descr_from_displayname;
 
-  --%test(Sets rollback type using first --%rollback annotation)
-  procedure rollback_type_valid;
+  --%test(Gives warning if more than one --%displayname annotation used)
+  procedure displayname_annot_duplicated;
 
-  --%test(Gives warning if more than one --%rollback annotation used)
-  procedure rollback_type_duplicated;
+  --%test(Gives warning if --%displayname annotation has no value)
+  procedure displayname_annot_empty;
 
-  --%test(Gives warning if more than one --%suite annotation used)
-  procedure suite_annot_duplicated;
+  --%endcontext
+
+  --%context(test)
+  --%displayname(--%test annotation)
+
+  --%test(Creates a test item for procedure annotated with --%test annotation)
+  procedure test_annotation;
 
   --%test(Gives warning if more than one --%test annotation used)
   procedure test_annot_duplicated;
 
-  --%test(Gives warning if more than one --%beforeall annotation used)
-  procedure beforeall_annot_duplicated;
+  --%endcontext
 
-  --%test(Gives warning if more than one --%beforeeach annotation used)
-  procedure beforeeach_annot_duplicated;
+  --%context(suitepath)
+  --%displayname(--%suitepath annotation)
 
-  --%test(Gives warning if more than one --%afterall annotation used)
-  procedure afterall_annot_duplicated;
-
-  --%test(Gives warning if more than one --%aftereach annotation used)
-  procedure aftereach_annot_duplicated;
+  --%test(Sets suite path using first --%suitepath annotation)
+  procedure suitepath_from_non_empty_path;
 
   --%test(Gives warning if more than one --%suitepath annotation used)
   procedure suitepath_annot_duplicated;
-
-  --%test(Gives warning if more than one --%displayname annotation used)
-  procedure displayname_annot_duplicated;
 
   --%test(Gives warning if --%suitepath annotation has no value)
   procedure suitepath_annot_empty;
@@ -50,8 +56,16 @@ create or replace package test_suite_builder is
   --%test(Gives warning if --%suitepath annotation has invalid value)
   procedure suitepath_annot_invalid_path;
 
-  --%test(Gives warning if --%displayname annotation has no value)
-  procedure displayname_annot_empty;
+  --%endcontext
+
+  --%context(rollback)
+  --%displayname(--%rollback annotation)
+
+  --%test(Sets rollback type using first --%rollback annotation)
+  procedure rollback_type_valid;
+
+  --%test(Gives warning if more than one --%rollback annotation used)
+  procedure rollback_type_duplicated;
 
   --%test(Gives warning if --%rollback annotation has no value)
   procedure rollback_type_empty;
@@ -59,14 +73,39 @@ create or replace package test_suite_builder is
   --%test(Gives warning if --%rollback annotation has invalid value)
   procedure rollback_type_invalid;
 
-  --%test(Supports multiple before/after definitions)
+  --%endcontext
+
+  --%context(before_after_all_each)
+  --%displayname(--%before/after all/each annotations)
+
+  --%test(Supports multiple before/after all/each procedure level definitions)
   procedure multiple_before_after;
 
-  --%test(Supports before/after all/each annotations on single procedure)
+  --%test(Supports multiple before/after all/each standalone level definitions)
+  procedure multiple_standalone_bef_aft;
+
+  --%test(Supports mixing before/after all/each annotations on single procedure)
   procedure before_after_on_single_proc;
+
+  --%test(Gives warning if more than one --%beforeall annotation used on procedure)
+  procedure beforeall_annot_duplicated;
+
+  --%test(Gives warning if more than one --%beforeeach annotation used on procedure)
+  procedure beforeeach_annot_duplicated;
+
+  --%test(Gives warning if more than one --%afterall annotation used on procedure)
+  procedure afterall_annot_duplicated;
+
+  --%test(Gives warning if more than one --%aftereach annotation used on procedure)
+  procedure aftereach_annot_duplicated;
 
   --%test(Gives warning on before/after all/each annotations mixed with test)
   procedure before_after_mixed_with_test;
+
+  --%endcontext
+
+  --%context(context)
+  --%displayname(--%context annotation)
 
   --%test(Creates nested suite for content between context/endcontext annotations)
   procedure suite_from_context;
@@ -83,11 +122,43 @@ create or replace package test_suite_builder is
   --%test(Gives warning if --%endcontext is missing a preceding --%context)
   procedure endcontext_without_context;
 
+  --%endcontext
+
+  --%context(throws)
+  --%displayname(--%throws annotation)
+
   --%test(Gives warning if --%throws annotation has no value)
   procedure throws_value_empty;
 
   --%test(Gives warning if --%throws annotation has invalid value)
   procedure throws_value_invalid;
+
+  --%endcontext
+
+  --%context(beforetest_aftertest)
+  --%displayname(--%beforetest/aftertest annotation)
+
+  --%test(Supports multiple occurrences of beforetest/aftertest for a test)
+  procedure before_aftertest_multi;
+
+  --%test(Supports same procedure defined twice)
+  procedure before_aftertest_twice;
+
+  --%test(Supports beforetest from external package)
+  procedure before_aftertest_pkg_proc;
+
+  --%test(Supports mix of procedure and package.procedure)
+  procedure before_aftertest_mixed_syntax;
+
+  --%endcontext
+
+  --%context(test)
+  --%displayname(--%test annontation)
+
+  --%test(Is added to suite according to annotation order in package spec)
+  procedure test_annotation_ordering;
+
+  --%endcontext
 
 end;
 /

--- a/test/core/test_suite_builder.pks
+++ b/test/core/test_suite_builder.pks
@@ -87,6 +87,9 @@ create or replace package test_suite_builder is
   --%test(Supports mixing before/after all/each annotations on single procedure)
   procedure before_after_on_single_proc;
 
+  --%test(Supports mixed before/after all/each as standalone and procedure level definitions)
+  procedure multiple_mixed_bef_aft;
+
   --%test(Gives warning if more than one --%beforeall annotation used on procedure)
   procedure beforeall_annot_duplicated;
 

--- a/test/install_and_run_tests.sh
+++ b/test/install_and_run_tests.sh
@@ -13,6 +13,7 @@ cd test
 cd ..
 
 utPLSQL-cli/bin/utplsql run ${UT3_TESTER}/${UT3_TESTER_PASSWORD}@${CONNECTION_STR} \
+-p=test_suite_builder \
 -source_path=source -owner=ut3 \
 -test_path=test -c \
 -f=ut_documentation_reporter  -o=test_results.log -s \

--- a/test/install_and_run_tests.sh
+++ b/test/install_and_run_tests.sh
@@ -13,7 +13,6 @@ cd test
 cd ..
 
 utPLSQL-cli/bin/utplsql run ${UT3_TESTER}/${UT3_TESTER_PASSWORD}@${CONNECTION_STR} \
--p=test_suite_builder \
 -source_path=source -owner=ut3 \
 -test_path=test -c \
 -f=ut_documentation_reporter  -o=test_results.log -s \


### PR DESCRIPTION
Resolves #649

New ability to use standalone/floating `--%beforeall`,`--%beforeeach`,`--%afterall`,`--%aftereach`.
Now you can use multiple before/after and use mixed approach of procedure level or standalone annotation, depending on your needs and pattern chosen.

Reworked package-level private data-types in suite_builder to make the code more readable.