### PR TITLE
Resolves issues with teamcity reporter

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,14 +2,14 @@
 # http://www.mkdocs.org/user-guide/configuration/
 
 site_name: utPLSQL
-site_description: utPLSQL Documenation Powerful Unit Testing Framework for Oracle PL/SQL
+site_description: utPLSQL Ultimate Unit Testing Framework for Oracle PL/SQL
 copyright: Copyright &copy; 2016 - 2018 utPLSQL Team
 repo_url: https://github.com/utPLSQL/utPLSQL
 theme: mkdocs
 use_directory_urls: false
 strict: true
 
-pages:
+nav:
   - Home: index.md
   - User Guide:
        - Installation: userguide/install.md

--- a/source/reporters/ut_teamcity_reporter_helper.pkb
+++ b/source/reporters/ut_teamcity_reporter_helper.pkb
@@ -28,6 +28,7 @@ create or replace package body ut_teamcity_reporter_helper is
     l_message varchar2(32767);
     l_index   t_prop_index;
     l_value   varchar2(32767);
+    l_max_len binary_integer := 2000;
   begin
     l_message := '##teamcity[' || a_command || ' timestamp=''' ||
                  regexp_replace(to_char(systimestamp, 'YYYY-MM-DD"T"HH24:MI:ss.FF3TZHTZM'), '(\.\d{3})\d+(\+)', '\1\2') || '''';
@@ -35,7 +36,10 @@ create or replace package body ut_teamcity_reporter_helper is
     l_index := a_props.first;
     while l_index is not null loop
       if a_props(l_index) is not null then
-        l_value   := substr(escape_value(a_props(l_index)),1,2000);
+        l_value   := escape_value(a_props(l_index));
+        if length(l_value) > l_max_len then
+          l_value   := substr(l_value,1,l_max_len-7)||escape_value('[...]');
+        end if;
         l_message := l_message || ' ' || l_index || '=''' || l_value || '''';
       end if;
       l_index := a_props.next(l_index);

--- a/source/reporters/ut_teamcity_reporter_helper.pkb
+++ b/source/reporters/ut_teamcity_reporter_helper.pkb
@@ -21,7 +21,7 @@ create or replace package body ut_teamcity_reporter_helper is
 
   function escape_value(a_value in varchar2) return varchar2 is
   begin
-    return translate(regexp_replace(a_value, '(''|"|[|]|' || chr(13) || '|' || chr(10) || ')', '|\1'),chr(13)||chr(10),'nr');
+    return translate(regexp_replace(a_value, q'/(\'|\||\[|\]|/' || chr(13) || '|' || chr(10) || ')', '|\1'),chr(13)||chr(10),'rn');
   end;
 
   function message(a_command in varchar2, a_props t_props default cast(null as t_props)) return varchar2 is
@@ -35,7 +35,7 @@ create or replace package body ut_teamcity_reporter_helper is
     l_index := a_props.first;
     while l_index is not null loop
       if a_props(l_index) is not null then
-        l_value   := escape_value(a_props(l_index));
+        l_value   := substr(escape_value(a_props(l_index)),1,2000);
         l_message := l_message || ' ' || l_index || '=''' || l_value || '''';
       end if;
       l_index := a_props.next(l_index);

--- a/test/core/reporters.pkb
+++ b/test/core/reporters.pkb
@@ -76,7 +76,7 @@ as
   is
   begin
     dbms_output.put_line('<!failing test!>');
-    ut3.ut.expect(1,'Fails as values are different').to_equal(2);
+    ut3.ut.expect('number [1] ','Fails as values are different').to_equal('number [2] ');
   end;
 
   procedure erroring_test

--- a/test/core/reporters/test_teamcity_reporter.pkb
+++ b/test/core/reporters/test_teamcity_reporter.pkb
@@ -22,14 +22,14 @@ create or replace package body test_teamcity_reporter as
 <!beforeeach!>
 <!failing test!>
 <!aftereach!>
-%##teamcity[testFailed timestamp='%' message='Fails as values are different' name='ut3_tester.test_reporters.failing_test']
+%##teamcity[testFailed timestamp='%' details='Actual: |'number |[1|] |' (varchar2) was expected to equal: |'number |[2|] |' (varchar2) ' message='Fails as values are different' name='ut3_tester.test_reporters.failing_test']
 %##teamcity[testFinished timestamp='%' duration='%' name='ut3_tester.test_reporters.failing_test']
 %##teamcity[testStarted timestamp='%' captureStandardOutput='true' name='ut3_tester.test_reporters.erroring_test']
 <!beforeeach!>
 <!erroring test!>
 <!aftereach!>
-%##teamcity[testStdErr timestamp='%' name='ut3_tester.test_reporters.erroring_test' out='Test exception:|rORA-06512: at |"UT3_TESTER.TEST_REPORTERS|", line %|rORA-06512: at %|r|r']
-%##teamcity[testFailed timestamp='%' details='Test exception:|rORA-06512: at |"UT3_TESTER.TEST_REPORTERS|", line %|rORA-06512: at %|r|r' message='Error occured' name='ut3_tester.test_reporters.erroring_test']
+%##teamcity[testStdErr timestamp='%' name='ut3_tester.test_reporters.erroring_test' out='Test exception:|nORA-06512: at "UT3_TESTER.TEST_REPORTERS", line %|nORA-06512: at %|n|n']
+%##teamcity[testFailed timestamp='%' details='Test exception:|nORA-06512: at "UT3_TESTER.TEST_REPORTERS", line %|nORA-06512: at %|n|n' message='Error occured' name='ut3_tester.test_reporters.erroring_test']
 %##teamcity[testFinished timestamp='%' duration='%' name='ut3_tester.test_reporters.erroring_test']
 %##teamcity[testStarted timestamp='%' captureStandardOutput='true' name='ut3_tester.test_reporters.disabled_test']
 %##teamcity[testIgnored timestamp='%' name='ut3_tester.test_reporters.disabled_test']

--- a/test/core/reporters/test_teamcity_reporter.pkb
+++ b/test/core/reporters/test_teamcity_reporter.pkb
@@ -1,5 +1,39 @@
 create or replace package body test_teamcity_reporter as
 
+  procedure create_a_test_package is
+    pragma autonomous_transaction;
+    begin
+      execute immediate q'[create or replace package check_escape_special_chars is
+      --%suite(A suite with 'quote')
+
+      --%test(A test with 'quote')
+      procedure test_do_stuff;
+
+    end;]';
+      execute immediate q'[create or replace package body check_escape_special_chars is
+      procedure test_do_stuff is
+      begin
+        ut3.ut.expect(' [ ' || chr(13) || chr(10) || ' ] ' ).to_be_null;
+      end;
+
+    end;]';
+
+      execute immediate q'[create or replace package check_trims_long_output is
+      --%suite
+
+      --%test
+      procedure long_output;
+    end;]';
+      execute immediate q'[create or replace package body check_trims_long_output is
+      procedure long_output is
+      begin
+        ut3.ut.expect(rpad('aVarchar',4000,'a')).to_be_null;
+      end;
+    end;]';
+
+    end;
+
+
   procedure report_produces_expected_out is
     l_output_data       ut3.ut_varchar2_list;
     l_output            clob;
@@ -47,6 +81,51 @@ create or replace package body test_teamcity_reporter as
     --assert
     ut.expect(ut3.ut_utils.table_to_clob(l_output_data)).to_be_like(l_expected);
   end;
+
+  procedure escape_special_chars is
+    l_output_data       ut3.ut_varchar2_list;
+    l_output            clob;
+    l_expected          varchar2(32767);
+  begin
+    l_expected := q'{%##teamcity[testSuiteStarted timestamp='%' name='A suite with |'quote|'']
+%##teamcity[testStarted timestamp='%' captureStandardOutput='true' name='ut3_tester.check_escape_special_chars.test_do_stuff']
+%##teamcity[testFailed timestamp='%' details='Actual: (varchar2)|n    |' |[ |r|n     |] |'|nwas expected to be null' name='ut3_tester.check_escape_special_chars.test_do_stuff']
+%##teamcity[testFinished timestamp='%' duration='%' name='ut3_tester.check_escape_special_chars.test_do_stuff']
+%##teamcity[testSuiteFinished timestamp='%' name='A suite with |'quote|'']}';
+    --act
+    select *
+        bulk collect into l_output_data
+    from table(ut3.ut.run('check_escape_special_chars',ut3.ut_teamcity_reporter()));
+
+    --assert
+    ut.expect(ut3.ut_utils.table_to_clob(l_output_data)).to_be_like(l_expected);
+  end;
+
+  procedure trims_long_output is
+    l_output_data       ut3.ut_varchar2_list;
+    l_output            clob;
+    l_expected          varchar2(32767);
+  begin
+    l_expected := q'{%##teamcity[testSuiteStarted timestamp='%' name='check_trims_long_output']
+%##teamcity[testStarted timestamp='%' captureStandardOutput='true' name='ut3_tester.check_trims_long_output.long_output']
+%##teamcity[testFailed timestamp='%' details='Actual: (varchar2)|n    |'aVarcharaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa|[...|]' name='ut3_tester.check_trims_long_output.long_output']
+%##teamcity[testFinished timestamp='%' duration='%' name='ut3_tester.check_trims_long_output.long_output']
+%##teamcity[testSuiteFinished timestamp='%' name='check_trims_long_output']}';
+    --act
+    select *
+        bulk collect into l_output_data
+    from table(ut3.ut.run('check_trims_long_output',ut3.ut_teamcity_reporter()));
+
+    --assert
+    ut.expect(ut3.ut_utils.table_to_clob(l_output_data)).to_be_like(l_expected);
+  end;
+
+  procedure remove_test_package is
+    pragma autonomous_transaction;
+    begin
+      execute immediate 'drop package check_escape_special_chars';
+      execute immediate 'drop package check_trims_long_output';
+    end;
 
 end;
 /

--- a/test/core/reporters/test_teamcity_reporter.pks
+++ b/test/core/reporters/test_teamcity_reporter.pks
@@ -3,8 +3,20 @@ create or replace package test_teamcity_reporter as
   --%suite(ut_teamcity_reporter)
   --%suitepath(utplsql.core.reporters)
 
+  --%beforeall
+  procedure create_a_test_package;
+
   --%test(Report produces expected output)
   procedure report_produces_expected_out;
+
+  --%test(Escapes special characters)
+  procedure escape_special_chars;
+
+  --%test(Trims output so it fits into 4000 chars)
+  procedure trims_long_output;
+
+  --%afterall
+  procedure remove_test_package;
 
 end;
 /


### PR DESCRIPTION
- the `[` and `]` were not escaped
- the `"` was escaped though not needed
- If total length of message inside the square brackets exceeds 4000 characters it's causing teamcity to report success for a test failed
Resolves #747