### PR TITLE
Build  speedup

### DIFF
--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -13,8 +13,8 @@ alter session set plsql_optimize_level=0;
 @install_headless.sql $UT3_OWNER $UT3_OWNER_PASSWORD
 SQL
 
-#Run this step only on first job slave (11.2 - at it's fastest)
-if [[ "${TRAVIS_JOB_NUMBER}" =~ \.1$ ]]; then
+#Run this step only on second child job (12.1 - at it's fastest)
+if [[ "${TRAVIS_JOB_NUMBER}" =~ \.2$ ]]; then
 
     #check code-style for errors
     time "$SQLCLI" $UT3_OWNER/$UT3_OWNER_PASSWORD@//$CONNECTION_STR @../development/utplsql_style_check.sql

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -8,7 +8,7 @@ time "$SQLCLI" sys/$ORACLE_PWD@//$CONNECTION_STR AS SYSDBA <<-SQL
 set feedback off
 set verify off
 
-alter session set plsql_warnings = 'ENABLE:ALL', 'DISABLE:(5004,5018,6000,6001,6003,6009,6010,7206)';
+--alter session set plsql_warnings = 'ENABLE:ALL', 'DISABLE:(5004,5018,6000,6001,6003,6009,6010,7206)';
 alter session set plsql_optimize_level=0;
 @install_headless.sql $UT3_OWNER $UT3_OWNER_PASSWORD
 SQL


### PR DESCRIPTION
Moved uninstall testing to 12.1 - as it's now the fastest build.
Removed compiler warnings, as it's causing 60 sec delay, when installing on 11g.