### PR TITLE
`ut_output_table_buffer` will now throw an exception on timeout.

### DIFF
--- a/examples/developer_examples/RunExampleTestSuiteWithCompositeReporter.sql
+++ b/examples/developer_examples/RunExampleTestSuiteWithCompositeReporter.sql
@@ -33,7 +33,7 @@ begin
   l_run := ut_run(ut_suite_items(l_suite));
   l_run.do_execute();
 
-  ut_event_manager.trigger_event(ut_utils.gc_finalize, l_run);
+  ut_event_manager.trigger_event(ut_event_manager.gc_finalize, l_run);
   l_doc_reporter.lines_to_dbms_output(0,0);
   l_tc_reporter.lines_to_dbms_output(0,0);
 end;

--- a/examples/developer_examples/RunExampleTestSuiteWithCustomReporter.sql
+++ b/examples/developer_examples/RunExampleTestSuiteWithCustomReporter.sql
@@ -43,7 +43,7 @@ begin
   ut_event_manager.add_listener(l_reporter);
   l_run := ut_run(ut_suite_items(l_suite));
   l_run.do_execute();
-  ut_event_manager.trigger_event(ut_utils.gc_finalize, l_run);
+  ut_event_manager.trigger_event(ut_event_manager.gc_finalize, l_run);
   l_reporter.lines_to_dbms_output(0,0);
 end;
 /

--- a/source/api/ut_runner.pkb
+++ b/source/api/ut_runner.pkb
@@ -45,7 +45,7 @@ create or replace package body ut_runner is
   procedure finish_run(a_run ut_run, a_force_manual_rollback boolean) is
   begin
     ut_utils.cleanup_temp_tables;
-    ut_event_manager.trigger_event(ut_utils.gc_finalize, a_run);
+    ut_event_manager.trigger_event(ut_event_manager.gc_finalize, a_run);
     ut_metadata.reset_source_definition_cache;
     ut_utils.read_cache_to_dbms_output();
     ut_coverage_helper.cleanup_tmp_table();
@@ -141,9 +141,12 @@ create or replace package body ut_runner is
         set(a_test_file_mappings),
         a_client_character_set
       );
+
+      ut_event_manager.trigger_event(ut_event_manager.gc_initialize, l_run);
+      
       ut_suite_manager.configure_execution_by_path(l_paths, l_run.items);
       if a_force_manual_rollback then
-        l_run.set_rollback_type(ut_utils.gc_rollback_manual, a_force=>true);
+        l_run.set_rollback_type( a_rollback_type => ut_utils.gc_rollback_manual, a_force => true );
       end if;
 
       l_run.do_execute();

--- a/source/core/events/ut_event_manager.pkb
+++ b/source/core/events/ut_event_manager.pkb
@@ -60,13 +60,11 @@ create or replace package body ut_event_manager  as
   procedure trigger_event( a_event_name t_event_name, a_event_object ut_event_item ) is
   begin
     if a_event_name is not null and g_event_listeners_index.exists(a_event_name)
-    -- disabled due to compiler warning: PLW-06023: invocation of IS NOT NULL computes trivial value
---        and g_event_listeners_index(a_event_name) is not null
     then
       for listener_number in 1 .. g_event_listeners_index(a_event_name).count loop
         g_listeners(listener_number).on_event(a_event_name, a_event_object);
       end loop;
-      if a_event_name = ut_utils.gc_finalize then
+      if a_event_name = ut_event_manager.gc_finalize then
         dispose_listeners;
       end if;
     end if;

--- a/source/core/events/ut_event_manager.pks
+++ b/source/core/events/ut_event_manager.pks
@@ -15,7 +15,41 @@ create or replace package ut_event_manager authid current_user as
   See the License for the specific language governing permissions and
   limitations under the License.
   */
+  /* Constants: Event names */
   subtype t_event_name           is varchar2(250);
+
+  gc_initialize                  constant t_event_name := 'initialize';
+
+  gc_before_run                  constant t_event_name := 'before_run';
+  gc_before_suite                constant t_event_name := 'before_suite';
+
+  gc_before_before_all           constant t_event_name := 'before_beforeall';
+  gc_after_before_all            constant t_event_name := 'after_beforeall';
+    
+  gc_before_test                 constant t_event_name := 'beforetest';
+
+  gc_before_before_each          constant t_event_name := 'before_beforeeach';
+  gc_after_before_each           constant t_event_name := 'after_beforeeach';
+  gc_before_before_test          constant t_event_name := 'before_beforetest';
+  gc_after_before_test           constant t_event_name := 'after_beforetest';
+
+  gc_before_test_execute         constant t_event_name := 'before_test';
+  gc_after_test_execute          constant t_event_name := 'after_test';
+
+  gc_before_after_test           constant t_event_name := 'before_aftertest';
+  gc_after_after_test            constant t_event_name := 'after_aftertest';
+  gc_before_after_each           constant t_event_name := 'before_aftereach';
+  gc_after_after_each            constant t_event_name := 'after_aftereach';
+
+  gc_after_test                  constant t_event_name := 'aftertest';
+
+  gc_before_after_all            constant t_event_name := 'before_afterall';
+  gc_after_after_all             constant t_event_name := 'after_afterall';
+
+  gc_after_suite                 constant t_event_name := 'after_suite';
+  gc_after_run                   constant t_event_name := 'after_run';
+
+  gc_finalize                    constant t_event_name := 'finalize';
 
   procedure trigger_event( a_event_name t_event_name, a_event_object ut_event_item );
 

--- a/source/core/output_buffers/ut_output_buffer_tmp.sql
+++ b/source/core/output_buffers/ut_output_buffer_tmp.sql
@@ -28,7 +28,9 @@ begin
   item_type      varchar2(1000),
   is_finished    number(1,0) default 0 not null,
   constraint ut_output_buffer_tmp_pk primary key(output_id, message_id),
-  constraint ut_output_buffer_tmp_ck check(is_finished = 0 and text is not null or is_finished = 1 and text is null),
+  constraint ut_output_buffer_tmp_ck check(
+         is_finished = 0 and (text is not null or item_type is not null )
+      or is_finished = 1 and text is null and item_type is null ),
   constraint ut_output_buffer_fk1 foreign key (output_id) references ut_output_buffer_info_tmp$(output_id)
 ) organization index overflow nologging initrans 100 ';
   begin

--- a/source/core/types/ut_logical_suite.tpb
+++ b/source/core/types/ut_logical_suite.tpb
@@ -18,13 +18,13 @@ create or replace type body ut_logical_suite as
 
   overriding member procedure mark_as_skipped(self in out nocopy ut_logical_suite) is
   begin
-    ut_event_manager.trigger_event(ut_utils.gc_before_suite, self);
+    ut_event_manager.trigger_event(ut_event_manager.gc_before_suite, self);
     self.start_time := current_timestamp;
     for i in 1 .. self.items.count loop
       self.items(i).mark_as_skipped();
     end loop;
     self.end_time := self.start_time;
-    ut_event_manager.trigger_event(ut_utils.gc_after_suite, self);
+    ut_event_manager.trigger_event(ut_event_manager.gc_after_suite, self);
     self.calc_execution_result();
   end;
 
@@ -43,7 +43,7 @@ create or replace type body ut_logical_suite as
   begin
     ut_utils.debug_log('ut_logical_suite.execute');
 
-    ut_event_manager.trigger_event(ut_utils.gc_before_suite, self);
+    ut_event_manager.trigger_event(ut_event_manager.gc_before_suite, self);
     self.start_time := current_timestamp;
 
     for i in 1 .. self.items.count loop
@@ -54,7 +54,7 @@ create or replace type body ut_logical_suite as
     self.calc_execution_result();
     self.end_time := current_timestamp;
 
-    ut_event_manager.trigger_event(ut_utils.gc_after_suite, self);
+    ut_event_manager.trigger_event(ut_event_manager.gc_after_suite, self);
 
     return l_completed_without_errors;
   end;
@@ -78,7 +78,7 @@ create or replace type body ut_logical_suite as
   overriding member procedure mark_as_errored(self in out nocopy ut_logical_suite, a_error_stack_trace varchar2) is
   begin
     ut_utils.debug_log('ut_logical_suite.fail');
-    ut_event_manager.trigger_event(ut_utils.gc_before_suite, self);
+    ut_event_manager.trigger_event(ut_event_manager.gc_before_suite, self);
     self.start_time := current_timestamp;
     for i in 1 .. self.items.count loop
       -- execute the item (test or suite)
@@ -86,7 +86,7 @@ create or replace type body ut_logical_suite as
     end loop;
     self.calc_execution_result();
     self.end_time := self.start_time;
-    ut_event_manager.trigger_event(ut_utils.gc_after_suite, self);
+    ut_event_manager.trigger_event(ut_event_manager.gc_after_suite, self);
   end;
 
   overriding member function get_error_stack_traces return ut_varchar2_list is

--- a/source/core/types/ut_output_reporter_base.tpb
+++ b/source/core/types/ut_output_reporter_base.tpb
@@ -78,5 +78,10 @@ create or replace type body ut_output_reporter_base is
     self.output_buffer.close();
   end;
 
+  overriding member procedure on_initialize(self in out nocopy ut_output_reporter_base, a_run in ut_run) is
+  begin
+    self.output_buffer.send_line(null, 'initialize');
+  end;
+
 end;
 /

--- a/source/core/types/ut_output_reporter_base.tps
+++ b/source/core/types/ut_output_reporter_base.tps
@@ -28,7 +28,8 @@ create or replace type ut_output_reporter_base under ut_reporter_base(
   final member function get_lines(a_initial_timeout natural := null, a_timeout_sec natural := null) return ut_output_data_rows pipelined,
   final member function get_lines_cursor(a_initial_timeout natural := null, a_timeout_sec natural := null) return sys_refcursor,
   final member procedure lines_to_dbms_output(self in ut_output_reporter_base, a_initial_timeout natural := null, a_timeout_sec natural := null),
-  overriding final member procedure on_finalize(self in out nocopy ut_output_reporter_base, a_run in ut_run)
+  overriding final member procedure on_finalize(self in out nocopy ut_output_reporter_base, a_run in ut_run),
+  overriding member procedure on_initialize(self in out nocopy ut_output_reporter_base, a_run in ut_run)
 )
 not final not instantiable
 /

--- a/source/core/types/ut_reporter_base.tpb
+++ b/source/core/types/ut_reporter_base.tpb
@@ -139,74 +139,77 @@ create or replace type body ut_reporter_base is
   overriding member function get_supported_events return ut_varchar2_list is
   begin
     return ut_varchar2_list(
-      ut_utils.gc_before_run,
-      ut_utils.gc_before_suite,
-      ut_utils.gc_before_test,
-      ut_utils.gc_before_before_all,
-      ut_utils.gc_before_before_each,
-      ut_utils.gc_before_before_test,
-      ut_utils.gc_before_test_execute,
-      ut_utils.gc_before_after_test,
-      ut_utils.gc_before_after_each,
-      ut_utils.gc_before_after_all,
-      ut_utils.gc_after_run,
-      ut_utils.gc_after_suite,
-      ut_utils.gc_after_test,
-      ut_utils.gc_after_before_all,
-      ut_utils.gc_after_before_each,
-      ut_utils.gc_after_before_test,
-      ut_utils.gc_after_test_execute,
-      ut_utils.gc_after_after_test,
-      ut_utils.gc_after_after_each,
-      ut_utils.gc_after_after_all,
-      ut_utils.gc_finalize
+      ut_event_manager.gc_initialize,
+      ut_event_manager.gc_before_run,
+      ut_event_manager.gc_before_suite,
+      ut_event_manager.gc_before_test,
+      ut_event_manager.gc_before_before_all,
+      ut_event_manager.gc_before_before_each,
+      ut_event_manager.gc_before_before_test,
+      ut_event_manager.gc_before_test_execute,
+      ut_event_manager.gc_before_after_test,
+      ut_event_manager.gc_before_after_each,
+      ut_event_manager.gc_before_after_all,
+      ut_event_manager.gc_after_run,
+      ut_event_manager.gc_after_suite,
+      ut_event_manager.gc_after_test,
+      ut_event_manager.gc_after_before_all,
+      ut_event_manager.gc_after_before_each,
+      ut_event_manager.gc_after_before_test,
+      ut_event_manager.gc_after_test_execute,
+      ut_event_manager.gc_after_after_test,
+      ut_event_manager.gc_after_after_each,
+      ut_event_manager.gc_after_after_all,
+      ut_event_manager.gc_finalize
     );
   end;
 
   overriding member procedure on_event( self in out nocopy ut_reporter_base, a_event_name varchar2, a_event_item ut_event_item) is
   begin
     case a_event_name
-      when ut_utils.gc_before_run
+      when ut_event_manager.gc_initialize
+      then self.on_initialize(treat(a_event_item as ut_run));
+      when ut_event_manager.gc_before_run
       then self.before_calling_run(treat(a_event_item as ut_run));
-      when ut_utils.gc_before_suite
+      when ut_event_manager.gc_before_suite
       then self.before_calling_suite(treat(a_event_item as ut_logical_suite));
-      when ut_utils.gc_before_before_all
+      when ut_event_manager.gc_before_before_all
       then self.before_calling_before_all(treat(a_event_item as ut_executable));
-      when ut_utils.gc_before_before_each
+      when ut_event_manager.gc_before_before_each
       then self.before_calling_before_each(treat(a_event_item as ut_executable));
-      when ut_utils.gc_before_test
+      when ut_event_manager.gc_before_test
       then self.before_calling_test(treat(a_event_item as ut_test));
-      when ut_utils.gc_before_before_test
+      when ut_event_manager.gc_before_before_test
       then self.before_calling_before_test(treat(a_event_item as ut_executable));
-      when ut_utils.gc_before_test_execute
+      when ut_event_manager.gc_before_test_execute
       then self.before_calling_test_execute(treat(a_event_item as ut_executable));
-      when ut_utils.gc_before_after_test
+      when ut_event_manager.gc_before_after_test
       then self.before_calling_after_test(treat(a_event_item as ut_executable));
-      when ut_utils.gc_before_after_each
+      when ut_event_manager.gc_before_after_each
       then self.before_calling_after_each(treat(a_event_item as ut_executable));
-      when ut_utils.gc_before_after_all
+      when ut_event_manager.gc_before_after_all
       then self.before_calling_after_all(treat(a_event_item as ut_executable));
-      when ut_utils.gc_after_run
+      when ut_event_manager.gc_after_run
       then self.after_calling_run(treat(a_event_item as ut_run));
-      when ut_utils.gc_after_suite
+      when ut_event_manager.gc_after_suite
       then self.after_calling_suite(treat(a_event_item as ut_logical_suite));
-      when ut_utils.gc_after_before_all
+      when ut_event_manager.gc_after_before_all
       then self.after_calling_before_all(treat(a_event_item as ut_executable));
-      when ut_utils.gc_after_before_each
+      when ut_event_manager.gc_after_before_each
       then self.after_calling_before_each(treat(a_event_item as ut_executable));
-      when ut_utils.gc_after_test
+      when ut_event_manager.gc_after_test
       then self.after_calling_test(treat(a_event_item as ut_test));
-      when ut_utils.gc_after_before_test
+      when ut_event_manager.gc_after_before_test
       then self.after_calling_before_test(treat(a_event_item as ut_executable));
-      when ut_utils.gc_after_test_execute
+      when ut_event_manager.gc_after_test_execute
       then self.after_calling_test_execute(treat(a_event_item as ut_executable));
-      when ut_utils.gc_after_after_test
+      when ut_event_manager.gc_after_after_test
       then self.after_calling_after_test(treat(a_event_item as ut_executable));
-      when ut_utils.gc_after_after_each
+      when ut_event_manager.gc_after_after_each
       then self.after_calling_after_each(treat(a_event_item as ut_executable));
-      when ut_utils.gc_after_after_all
+      when ut_event_manager.gc_after_after_all
       then self.after_calling_after_all(treat(a_event_item as ut_executable));
-      when ut_utils.gc_finalize
+      when ut_event_manager.gc_finalize
       then self.on_finalize(treat(a_event_item as ut_run));
     end case;
   end;

--- a/source/core/types/ut_reporter_base.tps
+++ b/source/core/types/ut_reporter_base.tps
@@ -64,6 +64,9 @@ create or replace type ut_reporter_base under ut_event_listener (
   -- This way, you may close all open outputs, files, connections etc. that need closing before the run finishes
   not instantiable member procedure on_finalize(self in out nocopy ut_reporter_base, a_run in ut_run),
 
+  -- This method is executed when run is getting initialized
+  not instantiable member procedure on_initialize(self in out nocopy ut_reporter_base, a_run in ut_run),
+
   /**
   * Returns the list of events that are supported by particular implementation of the reporter
   */

--- a/source/core/types/ut_run.tpb
+++ b/source/core/types/ut_run.tpb
@@ -56,7 +56,7 @@ create or replace type body ut_run as
   begin
     ut_utils.debug_log('ut_run.execute');
 
-    ut_event_manager.trigger_event(ut_utils.gc_before_run, self);
+    ut_event_manager.trigger_event(ut_event_manager.gc_before_run, self);
     self.start_time := current_timestamp;
 
     -- clear anything that might stay in the session's cache
@@ -70,7 +70,7 @@ create or replace type body ut_run as
 
     self.end_time := current_timestamp;
 
-    ut_event_manager.trigger_event(ut_utils.gc_after_run, self);
+    ut_event_manager.trigger_event(ut_event_manager.gc_after_run, self);
 
     return l_completed_without_errors;
   end;

--- a/source/core/types/ut_suite.tpb
+++ b/source/core/types/ut_suite.tpb
@@ -46,7 +46,7 @@ create or replace type body ut_suite  as
     if self.get_disabled_flag() then
       self.mark_as_skipped();
     else
-      ut_event_manager.trigger_event(ut_utils.gc_before_suite, self);
+      ut_event_manager.trigger_event(ut_event_manager.gc_before_suite, self);
       self.start_time := current_timestamp;
 
       l_suite_savepoint := self.create_savepoint_if_needed();
@@ -78,7 +78,7 @@ create or replace type body ut_suite  as
 
       self.calc_execution_result();
       self.end_time := current_timestamp;
-      ut_event_manager.trigger_event(ut_utils.gc_after_suite, self);
+      ut_event_manager.trigger_event(ut_event_manager.gc_after_suite, self);
     end if;
 
     ut_utils.set_action(null);

--- a/source/core/types/ut_test.tpb
+++ b/source/core/types/ut_test.tpb
@@ -36,13 +36,13 @@ create or replace type body ut_test as
 
   overriding member procedure mark_as_skipped(self in out nocopy ut_test) is
   begin
-    ut_event_manager.trigger_event(ut_utils.gc_before_test, self);
+    ut_event_manager.trigger_event(ut_event_manager.gc_before_test, self);
     self.start_time := current_timestamp;
     self.result := ut_utils.gc_disabled;
     ut_utils.debug_log('ut_test.execute - disabled');
     self.results_count.set_counter_values(self.result);
     self.end_time := self.start_time;
-    ut_event_manager.trigger_event(ut_utils.gc_after_test, self);
+    ut_event_manager.trigger_event(ut_event_manager.gc_after_test, self);
   end;
 
   overriding member function do_execute(self in out nocopy ut_test) return boolean is
@@ -55,7 +55,7 @@ create or replace type body ut_test as
     if self.get_disabled_flag() then
       mark_as_skipped();
     else
-      ut_event_manager.trigger_event(ut_utils.gc_before_test, self);
+      ut_event_manager.trigger_event(ut_event_manager.gc_before_test, self);
       self.start_time := current_timestamp;
 
       l_savepoint := self.create_savepoint_if_needed();
@@ -91,7 +91,7 @@ create or replace type body ut_test as
 
       self.calc_execution_result();
       self.end_time := current_timestamp;
-      ut_event_manager.trigger_event(ut_utils.gc_after_test, self);
+      ut_event_manager.trigger_event(ut_event_manager.gc_after_test, self);
     end if;
     return l_no_errors;
   end;
@@ -117,12 +117,12 @@ create or replace type body ut_test as
   overriding member procedure mark_as_errored(self in out nocopy ut_test, a_error_stack_trace varchar2) is
   begin
     ut_utils.debug_log('ut_test.fail');
-    ut_event_manager.trigger_event(ut_utils.gc_before_test, self);
+    ut_event_manager.trigger_event(ut_event_manager.gc_before_test, self);
     self.start_time := current_timestamp;
     self.parent_error_stack_trace := a_error_stack_trace;
     self.calc_execution_result();
     self.end_time := self.start_time;
-    ut_event_manager.trigger_event(ut_utils.gc_after_test, self);
+    ut_event_manager.trigger_event(ut_event_manager.gc_after_test, self);
   end;
 
   overriding member function get_error_stack_traces(self ut_test) return ut_varchar2_list is

--- a/source/core/ut_suite_builder.pkb
+++ b/source/core/ut_suite_builder.pkb
@@ -336,7 +336,7 @@ create or replace package body ut_suite_builder is
     a_owner            t_object_name,
     a_package_name     t_object_name,
     a_annotation_texts tt_annotation_texts,
-    a_event_name       ut_utils.t_event_name
+    a_event_name       ut_event_manager.t_event_name
   ) return tt_executables is
     l_executables     ut_executables;
     l_result          tt_executables;

--- a/source/core/ut_utils.pks
+++ b/source/core/ut_utils.pks
@@ -23,28 +23,6 @@ create or replace package ut_utils authid definer is
 
   gc_version                 constant varchar2(50) := 'v3.1.4.2559-develop';
 
-  /* Constants: Event names */
-  subtype t_event_name           is varchar2(30);
-  gc_before_run                  constant t_event_name := 'before_run';
-  gc_before_suite                constant t_event_name := 'before_suite';
-  gc_before_before_all           constant t_event_name := 'before_beforeall';
-  gc_before_before_each          constant t_event_name := 'before_beforeeach';
-  gc_before_before_test          constant t_event_name := 'before_beforetest';
-  gc_before_test_execute         constant t_event_name := 'before_test';
-  gc_before_after_test           constant t_event_name := 'before_aftertest';
-  gc_before_after_each           constant t_event_name := 'before_aftereach';
-  gc_before_after_all            constant t_event_name := 'before_afterall';
-  gc_after_run                   constant t_event_name := 'after_run';
-  gc_after_suite                 constant t_event_name := 'after_suite';
-  gc_after_before_all            constant t_event_name := 'after_beforeall';
-  gc_after_before_each           constant t_event_name := 'after_beforeeach';
-  gc_after_before_test           constant t_event_name := 'after_beforetest';
-  gc_after_test_execute          constant t_event_name := 'after_test';
-  gc_after_after_test            constant t_event_name := 'after_aftertest';
-  gc_after_after_each            constant t_event_name := 'after_aftereach';
-  gc_after_after_all             constant t_event_name := 'after_afterall';
-  gc_finalize                    constant t_event_name := 'finalize';
-
   subtype t_executable_type      is varchar2(30);
   gc_before_all                  constant t_executable_type := 'beforeall';
   gc_before_each                 constant t_executable_type := 'beforeeach';
@@ -105,10 +83,15 @@ create or replace package ut_utils authid definer is
   gc_some_tests_failed constant pls_integer := -20213;
   pragma exception_init(ex_some_tests_failed, -20213);
 
-  -- Any of tests failed
+  -- Version number provided is not in valid format
   ex_invalid_version_no exception;
   gc_invalid_version_no constant pls_integer := -20214;
   pragma exception_init(ex_invalid_version_no, -20214);
+
+  -- Version number provided is not in valid format
+  ex_out_buffer_timeout exception;
+  gc_out_buffer_timeout constant pls_integer := -20215;
+  pragma exception_init(ex_out_buffer_timeout, -20215);
 
   ex_invalid_package exception;
   gc_invalid_package constant pls_integer := -6550;

--- a/test/core/reporters/test_realtime_reporter.pkb
+++ b/test/core/reporters/test_realtime_reporter.pkb
@@ -112,7 +112,8 @@ create or replace package body test_realtime_reporter as
       -- consume
       select test_event_object(item_type, xmltype(text))
         bulk collect into g_events
-        from table(ut3.ut_output_table_buffer(l_reporter.output_buffer.output_id).get_lines());        
+        from table(ut3.ut_output_table_buffer(l_reporter.output_buffer.output_id).get_lines())
+        where trim(text) is not null and item_type is not null;
     end run_report_and_cache_result;
   end create_test_suites_and_run;
   


### PR DESCRIPTION
Default initial timeout was changed from 4 hours to 15 seconds.
All output reporters will now produce an extra leading line at the start of a test run.
Resolves #840