### PR TITLE
Switched to use sequence for savepoint names.

### DIFF
--- a/source/core/types/ut_suite_item.tpb
+++ b/source/core/types/ut_suite_item.tpb
@@ -54,7 +54,7 @@ create or replace type body ut_suite_item as
   begin
     if get_rollback_type() = ut_utils.gc_rollback_auto then
       l_savepoint := ut_utils.gen_savepoint_name();
-      dbms_transaction.savepoint(l_savepoint);
+      execute immediate 'savepoint ' || l_savepoint;
     end if;
     return l_savepoint;
   end;
@@ -65,7 +65,7 @@ create or replace type body ut_suite_item as
     pragma exception_init(ex_savepoint_not_exists, -1086);
   begin
     if get_rollback_type() = ut_utils.gc_rollback_auto and a_savepoint is not null then
-      dbms_transaction.rollback_savepoint( a_savepoint );
+      execute immediate 'rollback to ' || a_savepoint;
     end if;
   exception
     when ex_savepoint_not_exists then

--- a/source/core/ut_savepoint_seq.sql
+++ b/source/core/ut_savepoint_seq.sql
@@ -1,0 +1,15 @@
+create sequence ut_savepoint_seq
+  /*
+  utPLSQL - Version 3
+  Copyright 2016 - 2018 utPLSQL Project
+  Licensed under the Apache License, Version 2.0 (the "License"):
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  */
+  start with 1 cache 20;

--- a/source/core/ut_utils.pkb
+++ b/source/core/ut_utils.pkb
@@ -52,7 +52,7 @@ create or replace package body ut_utils is
 
   function gen_savepoint_name return varchar2 is
   begin
-    return '"'|| utl_raw.cast_to_varchar2(utl_encode.base64_encode(sys_guid()))||'"';
+    return 's'||trim(to_char(ut_savepoint_seq.nextval,'0000000000000000000000000000'));
   end;
 
   procedure debug_log(a_message varchar2) is

--- a/source/install.sql
+++ b/source/install.sql
@@ -50,6 +50,7 @@ alter session set current_schema = &&ut3_owner;
 @@install_component.sql 'core/types/ut_reporters_info.tps'
 @@install_component.sql 'core/ut_utils.pks'
 @@install_component.sql 'core/ut_metadata.pks'
+@@install_component.sql 'core/ut_savepoint_seq.sql'
 @@install_component.sql 'core/ut_utils.pkb'
 @@install_component.sql 'core/ut_metadata.pkb'
 @@install_component.sql 'reporters/ut_ansiconsole_helper.pks'

--- a/source/uninstall_objects.sql
+++ b/source/uninstall_objects.sql
@@ -179,6 +179,8 @@ drop package ut_ansiconsole_helper;
 
 drop package ut_utils;
 
+drop sequence ut_savepoint_seq;
+
 drop type ut_documentation_reporter force;
 
 drop type ut_teamcity_reporter force;

--- a/test/api/test_ut_run.pkb
+++ b/test/api/test_ut_run.pkb
@@ -808,9 +808,9 @@ Failures:%
   procedure drop_test_suite is
     pragma autonomous_transaction;
   begin
+    drop_db_link;
     execute immediate 'drop package stateful_package';
     execute immediate 'drop package test_stateful';
-    drop_db_link;
   end;
 
   procedure run_in_invalid_state is
@@ -1007,9 +1007,9 @@ Failures:%
   procedure drop_suite_with_link is
     pragma autonomous_transaction;
   begin
+    drop_db_link;
     execute immediate 'drop table tst';
     execute immediate 'drop package test_distributed_savepoint';
-    drop_db_link;
   end;
 
 end;


### PR DESCRIPTION
Removed calls to `dbms_transaction` as they were causing library pin locks on our tests.