### PR TITLE
Modify a code to fail when inserting a suitepath over 1k long.

### DIFF
--- a/source/core/types/ut_suite_item.tps
+++ b/source/core/types/ut_suite_item.tps
@@ -36,7 +36,7 @@ create or replace type ut_suite_item force under ut_event_item (
   /**
   * Full path of the invocation of the item (including the items name itself)
   */
-  path          varchar2(4000 byte),
+  path          varchar2(1000 byte),
   /**
   * The type of the rollback behavior
   */

--- a/source/core/ut_suite_cache.sql
+++ b/source/core/ut_suite_cache.sql
@@ -73,8 +73,6 @@ create table ut_suite_cache (
     where rownum < 0
 /
 
-alter table ut_suite_cache modify (path varchar2( 1000 ))
-/
 alter table ut_suite_cache modify (object_owner not null, path not null, self_type not null, object_name not null, name not null, parse_time not null)
 /
 alter table ut_suite_cache add constraint ut_suite_cache_pk primary key (id)
@@ -87,8 +85,6 @@ alter table ut_suite_cache add constraint ut_suite_cache_uk2 unique (object_owne
 alter table ut_suite_cache add constraint ut_suite_cache_schema_fk foreign key (object_owner, object_name)
 references ut_suite_cache_package(object_owner, object_name) on delete cascade
 /
-
-
 
 drop type ut_tests
 /

--- a/source/core/ut_suite_cache.sql
+++ b/source/core/ut_suite_cache.sql
@@ -73,6 +73,8 @@ create table ut_suite_cache (
     where rownum < 0
 /
 
+alter table ut_suite_cache modify (path varchar2( 1000 ))
+/
 alter table ut_suite_cache modify (object_owner not null, path not null, self_type not null, object_name not null, name not null, parse_time not null)
 /
 alter table ut_suite_cache add constraint ut_suite_cache_pk primary key (id)
@@ -85,6 +87,8 @@ alter table ut_suite_cache add constraint ut_suite_cache_uk2 unique (object_owne
 alter table ut_suite_cache add constraint ut_suite_cache_schema_fk foreign key (object_owner, object_name)
 references ut_suite_cache_package(object_owner, object_name) on delete cascade
 /
+
+
 
 drop type ut_tests
 /

--- a/source/core/ut_utils.pkb
+++ b/source/core/ut_utils.pkb
@@ -77,50 +77,66 @@ create or replace package body ut_utils is
     $end
   end;
 
-  function to_string(a_value varchar2, a_qoute_char varchar2 := '''', a_max_output_len in number := gc_max_output_string_length) return varchar2 is
-    l_len                     integer := coalesce(length(a_value),0);
+  function to_string(
+    a_value varchar2,
+    a_quote_char varchar2 := '''',
+    a_max_output_len in number := gc_max_output_string_length
+  ) return varchar2 is
     l_result                  varchar2(32767);
-    l_max_input_string_length integer := a_max_output_len - 2;--we need to remove 2 chars for quotes around string
-    l_overflow_substr_len     integer := l_max_input_string_length - length(gc_more_data_string);
+    c_length                  constant integer := coalesce( length( a_value ), 0 );
+    c_max_input_string_length constant integer := a_max_output_len - coalesce( length( a_quote_char ) * 2, 0 );
+    c_overflow_substr_len     constant integer := c_max_input_string_length - gc_more_data_string_len;
   begin
-    if l_len = 0 then
+    if c_length = 0 then
       l_result := gc_null_string;
-    elsif l_len <= l_max_input_string_length then
-      l_result := surround_with(a_value, a_qoute_char);
+    elsif c_length <= c_max_input_string_length then
+      l_result := surround_with(a_value, a_quote_char);
     else
-      l_result := surround_with(substr(a_value,1,l_overflow_substr_len),a_qoute_char) || gc_more_data_string;
+      l_result := surround_with(substr(a_value, 1, c_overflow_substr_len ), a_quote_char) || gc_more_data_string;
     end if ;
     return l_result;
   end;
 
-  function to_string(a_value clob, a_qoute_char varchar2 := '''') return varchar2 is
-    l_len integer := coalesce(dbms_lob.getlength(a_value), 0);
-    l_result varchar2(32767);
+  function to_string(
+    a_value clob,
+    a_quote_char varchar2 := '''',
+    a_max_output_len in number := gc_max_output_string_length
+  ) return varchar2 is
+    l_result                  varchar2(32767);
+    c_length                  constant integer := coalesce(dbms_lob.getlength(a_value), 0);
+    c_max_input_string_length constant integer := a_max_output_len - coalesce( length( a_quote_char ) * 2, 0 );
+    c_overflow_substr_len     constant integer := c_max_input_string_length - gc_more_data_string_len;
   begin
     if a_value is null then
       l_result := gc_null_string;
-    elsif l_len = 0 then
+    elsif c_length = 0 then
       l_result := gc_empty_string;
-    elsif l_len <= gc_max_input_string_length then
-      l_result := surround_with(a_value,a_qoute_char);
+    elsif c_length <= c_max_input_string_length then
+      l_result := surround_with(a_value,a_quote_char);
     else
-      l_result := surround_with(dbms_lob.substr(a_value, gc_overflow_substr_len),a_qoute_char) || gc_more_data_string;
+      l_result := surround_with(dbms_lob.substr(a_value, c_overflow_substr_len), a_quote_char) || gc_more_data_string;
     end if;
     return l_result;
   end;
 
-  function to_string(a_value blob, a_qoute_char varchar2 := '''') return varchar2 is
-    l_len integer := coalesce(dbms_lob.getlength(a_value), 0);
-    l_result varchar2(32767);
+  function to_string(
+    a_value blob,
+    a_quote_char varchar2 := '''',
+    a_max_output_len in number := gc_max_output_string_length
+  ) return varchar2 is
+    l_result                  varchar2(32767);
+    c_length                  constant integer := coalesce(dbms_lob.getlength(a_value), 0);
+    c_max_input_string_length constant integer := a_max_output_len - coalesce( length( a_quote_char ) * 2, 0 );
+    c_overflow_substr_len     constant integer := c_max_input_string_length - gc_more_data_string_len;
   begin
     if a_value is null then
       l_result := gc_null_string;
-    elsif l_len = 0 then
+    elsif c_length = 0 then
       l_result := gc_empty_string;
-    elsif l_len <= gc_max_input_string_length then
-      l_result := surround_with(rawtohex(a_value),a_qoute_char);
+    elsif c_length <= c_max_input_string_length then
+      l_result := surround_with(rawtohex(a_value),a_quote_char);
     else
-      l_result := to_string( rawtohex(dbms_lob.substr(a_value, gc_overflow_substr_len)) );
+      l_result := to_string( rawtohex(dbms_lob.substr(a_value, c_overflow_substr_len)) );
     end if ;
     return l_result;
   end;

--- a/source/core/ut_utils.pkb
+++ b/source/core/ut_utils.pkb
@@ -77,16 +77,18 @@ create or replace package body ut_utils is
     $end
   end;
 
-  function to_string(a_value varchar2, a_qoute_char varchar2 := '''') return varchar2 is
-    l_len integer := coalesce(length(a_value),0);
-    l_result varchar2(32767);
+  function to_string(a_value varchar2, a_qoute_char varchar2 := '''', a_max_output_len in number := gc_max_output_string_length) return varchar2 is
+    l_len                     integer := coalesce(length(a_value),0);
+    l_result                  varchar2(32767);
+    l_max_input_string_length integer := a_max_output_len - 2;--we need to remove 2 chars for quotes around string
+    l_overflow_substr_len     integer := l_max_input_string_length - length(gc_more_data_string);
   begin
     if l_len = 0 then
       l_result := gc_null_string;
-    elsif l_len <= gc_max_input_string_length then
+    elsif l_len <= l_max_input_string_length then
       l_result := surround_with(a_value, a_qoute_char);
     else
-      l_result := surround_with(substr(a_value,1,gc_overflow_substr_len),a_qoute_char) || gc_more_data_string;
+      l_result := surround_with(substr(a_value,1,l_overflow_substr_len),a_qoute_char) || gc_more_data_string;
     end if ;
     return l_result;
   end;

--- a/source/core/ut_utils.pks
+++ b/source/core/ut_utils.pks
@@ -111,9 +111,8 @@ create or replace package ut_utils authid definer is
 
   gc_max_storage_varchar2_len constant integer := 4000;
   gc_max_output_string_length constant integer := 4000;
-  gc_max_input_string_length  constant integer := gc_max_output_string_length - 2; --we need to remove 2 chars for quotes around string
   gc_more_data_string         constant varchar2(5) := '[...]';
-  gc_overflow_substr_len      constant integer := gc_max_input_string_length - length(gc_more_data_string);
+  gc_more_data_string_len     constant integer := length( gc_more_data_string );
   gc_number_format            constant varchar2(100) := 'TM9';
   gc_date_format              constant varchar2(100) := 'yyyy-mm-dd"T"hh24:mi:ss';
   gc_timestamp_format         constant varchar2(100) := 'yyyy-mm-dd"T"hh24:mi:ssxff';
@@ -155,11 +154,23 @@ create or replace package ut_utils authid definer is
 
   procedure debug_log(a_message clob);
 
-  function to_string(a_value varchar2, a_qoute_char varchar2 := '''', a_max_output_len in number := gc_max_output_string_length) return varchar2;
+  function to_string(
+    a_value varchar2,
+    a_quote_char varchar2 := '''',
+    a_max_output_len in number := gc_max_output_string_length
+  ) return varchar2;
 
-  function to_string(a_value clob, a_qoute_char varchar2 := '''') return varchar2;
+  function to_string(
+    a_value clob,
+    a_quote_char varchar2 := '''',
+    a_max_output_len in number := gc_max_output_string_length
+  ) return varchar2;
 
-  function to_string(a_value blob, a_qoute_char varchar2 := '''') return varchar2;
+  function to_string(
+    a_value blob,
+    a_quote_char varchar2 := '''',
+    a_max_output_len in number := gc_max_output_string_length
+  ) return varchar2;
 
   function to_string(a_value boolean) return varchar2;
 

--- a/source/core/ut_utils.pks
+++ b/source/core/ut_utils.pks
@@ -102,8 +102,12 @@ create or replace package ut_utils authid definer is
   pragma exception_init (ex_failure_for_all, -24381);
 
   ex_dml_for_all exception;
-  gc_dml_for_all constant pls_integer := -20215;
-  pragma exception_init (ex_dml_for_all, -20215);
+  gc_dml_for_all constant pls_integer := -20216;
+  pragma exception_init (ex_dml_for_all, -20216);
+
+  ex_value_too_large exception;
+  gc_value_too_large constant pls_integer := -20217;
+  pragma exception_init (ex_value_too_large, -20217);
 
   gc_max_storage_varchar2_len constant integer := 4000;
   gc_max_output_string_length constant integer := 4000;
@@ -151,7 +155,7 @@ create or replace package ut_utils authid definer is
 
   procedure debug_log(a_message clob);
 
-  function to_string(a_value varchar2, a_qoute_char varchar2 := '''') return varchar2;
+  function to_string(a_value varchar2, a_qoute_char varchar2 := '''', a_max_output_len in number := gc_max_output_string_length) return varchar2;
 
   function to_string(a_value clob, a_qoute_char varchar2 := '''') return varchar2;
 

--- a/test/core/test_suite_manager.pkb
+++ b/test/core/test_suite_manager.pkb
@@ -1484,12 +1484,12 @@ end;]';
     l_actual    ut3.ut_object_names;
     l_expected_message varchar2(500);
   begin
-    l_expected_message := q'[ORA-20217: 'Suitepath exceeds 1000 CHAR on: UT3.DUMMY_LONG_TEST_PACKAGE,UT3.DUMMY_LONG_TEST_PACKAGE1']';
+    l_expected_message := q'[ORA-20217: 'Suitepath exceeds 1000 CHAR on: UT3.DUMMY_LONG_TEST_PACKAGE,UT3.DUMMY_LONG_TEST_PACKAGE1'%]';
     l_actual := ut3.ut_suite_manager.get_schema_ut_packages(ut3.ut_varchar2_rows('UT3'));
     ut.fail('Expected exception for suitpaths over 1k for two packages');
   exception
     when others then
-      ut.expect(SQLERRM).to_equal(l_expected_message);
+      ut.expect(dbms_utility.format_error_stack()).to_be_like(l_expected_message);
       ut.expect(SQLCODE).to_equal(ut3.ut_utils.gc_value_too_large);
   end;
 

--- a/test/core/test_suite_manager.pkb
+++ b/test/core/test_suite_manager.pkb
@@ -3,6 +3,35 @@ create or replace package body test_suite_manager is
   ex_obj_doesnt_exist exception;
   pragma exception_init(ex_obj_doesnt_exist, -04043);
 
+  procedure create_dummy_long_test_package is
+    pragma autonomous_transaction;
+  begin
+    execute immediate q'[create or replace package ut3.dummy_long_test_package as
+        
+        --%suitepath(verylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtext)
+        --%suite(dummy_test_suite)
+
+        --%test(dummy_test)
+        procedure some_dummy_test_procedure;
+      end;]';
+      
+    execute immediate q'[create or replace package ut3.dummy_long_test_package1 as
+        
+        --%suitepath(verylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtextverylongtext)
+        --%suite(dummy_test_suite1)
+
+        --%test(dummy_test)
+        procedure some_dummy_test_procedure;
+      end;]';
+  end;
+
+  procedure drop_dummy_long_test_package is
+    pragma autonomous_transaction;
+  begin
+    execute immediate q'[drop package ut3.dummy_long_test_package]';
+    execute immediate q'[drop package ut3.dummy_long_test_package1]';
+  end;
+
   procedure compile_dummy_packages is
     pragma autonomous_transaction;
   begin
@@ -1449,6 +1478,19 @@ end;]';
     pragma autonomous_transaction;
   begin
     execute immediate q'[drop package ut3.some_test_package]';
+  end;
+
+  procedure add_new_long_test_package is
+    l_actual    ut3.ut_object_names;
+    l_expected_message varchar2(500);
+  begin
+    l_expected_message := q'[ORA-20217: 'Suitepath exceeds 1000 CHAR on: UT3.DUMMY_LONG_TEST_PACKAGE,UT3.DUMMY_LONG_TEST_PACKAGE1']';
+    l_actual := ut3.ut_suite_manager.get_schema_ut_packages(ut3.ut_varchar2_rows('UT3'));
+    ut.fail('Expected exception for suitpaths over 1k for two packages');
+  exception
+    when others then
+      ut.expect(SQLERRM).to_equal(l_expected_message);
+      ut.expect(SQLCODE).to_equal(ut3.ut_utils.gc_value_too_large);
   end;
 
 end test_suite_manager;

--- a/test/core/test_suite_manager.pks
+++ b/test/core/test_suite_manager.pks
@@ -3,6 +3,10 @@ create or replace package test_suite_manager is
   --%suite(suite_manager)
   --%suitepath(utplsql.core)
 
+  procedure create_dummy_long_test_package;
+
+  procedure drop_dummy_long_test_package;
+
   --%beforeall
   procedure compile_dummy_packages;
   --%afterall
@@ -161,6 +165,11 @@ create or replace package test_suite_manager is
   procedure drop_ut3_suite;
 
   --%endcontext
+
+  --%test(Adds suitepath to cache over 1k characters long)
+  --%beforetest(create_dummy_long_test_package)
+  --%aftertest(drop_dummy_long_test_package)
+  procedure add_new_long_test_package;
 
 end test_suite_manager;
 /


### PR DESCRIPTION
This will iterate over all objects and report back any object that tries to insert an suitepath over 1k character.
Fixes  #848