### PR TITLE
Moving a compare SQL into helper function to avoid privs issue

### DIFF
--- a/source/expectations/data_values/ut_compound_data_helper.pkb
+++ b/source/expectations/data_values/ut_compound_data_helper.pkb
@@ -586,6 +586,18 @@ create or replace package body ut_compound_data_helper is
      end;
   end;
 
+  function get_compare_cursor(a_diff_cursor_text in clob,a_self_id raw, a_other_id raw) return sys_refcursor is
+    l_diff_cursor sys_refcursor;
+  begin
+    open l_diff_cursor for a_diff_cursor_text using a_self_id, a_other_id;
+    return l_diff_cursor;
+  exception when others then
+    if l_diff_cursor%isopen then
+      close l_diff_cursor;
+    end if;
+    raise;
+  end;
+  
 begin
   g_anytype_name_map(dbms_types.typecode_date)             := 'DATE';
   g_anytype_name_map(dbms_types.typecode_number)           := 'NUMBER';

--- a/source/expectations/data_values/ut_compound_data_helper.pks
+++ b/source/expectations/data_values/ut_compound_data_helper.pks
@@ -89,6 +89,8 @@ create or replace package ut_compound_data_helper authid definer is
   function is_sql_compare_allowed(a_type_name varchar2) return boolean;
   
   function get_column_type_desc(a_type_code in integer, a_dbms_sql_desc in boolean) return varchar2;
-
+  
+  function get_compare_cursor(a_diff_cursor_text in clob,a_self_id raw, a_other_id raw) return sys_refcursor;
+  
 end;
 /

--- a/source/expectations/data_values/ut_data_value_refcursor.tpb
+++ b/source/expectations/data_values/ut_data_value_refcursor.tpb
@@ -306,7 +306,8 @@ create or replace type body ut_data_value_refcursor as
       l_diff_id       := ut_compound_data_helper.get_hash(a_self.data_id||a_other.data_id);
       
       begin
-        open l_cursor for a_diff_cursor_text using a_self.data_id, a_other.data_id;
+        l_cursor := ut_compound_data_helper.get_compare_cursor(a_diff_cursor_text,
+          a_self.data_id, a_other.data_id);
         --fetch and save rows for display of diff
         fetch l_cursor bulk collect into l_diff_tab limit ut_utils.gc_diff_max_rows;
       

--- a/test/core/min_grant_user/test_min_grant_user.pkb
+++ b/test/core/min_grant_user/test_min_grant_user.pkb
@@ -55,6 +55,17 @@ create or replace package body test_min_grant_user is
     '%1 tests, 0 failed, 0 errored, 0 disabled, 0 warning(s)%' );
 
   end;
+
+  procedure test_equal_non_diff_sql is
+    l_results clob;
+  begin
+    execute immediate 'begin ut3$user#.test_cursor_grants.run_test_equal_non_diff_sql(); end;';
+    l_results := core.get_dbms_output_as_clob();
+    --Assert
+    ut.expect( l_results ).to_be_like( '%execute test with non diff datatype [% sec]' ||
+    '%1 tests, 0 failed, 0 errored, 0 disabled, 0 warning(s)%' );
+
+  end;
   
 end;
 /

--- a/test/core/min_grant_user/test_min_grant_user.pks
+++ b/test/core/min_grant_user/test_min_grant_user.pks
@@ -18,5 +18,8 @@ create or replace package test_min_grant_user is
    --%test(execute empty test)
   procedure test_empty_cursor;  
 
+  --%test(execute test with non diff datatype)
+  procedure test_equal_non_diff_sql;
+
 end;
 /

--- a/test/helpers/ut3user#.test_cursor_grants.pkb
+++ b/test/helpers/ut3user#.test_cursor_grants.pkb
@@ -24,6 +24,11 @@ create or replace package body ut3$user#.test_cursor_grants is
   begin
     ut3.ut.run('test_cursor_grants.test_empty_cursor');
   end;
+  
+  procedure run_test_equal_non_diff_sql is  
+  begin
+    ut3.ut.run('test_cursor_grants.test_equal_non_diff_sql');
+  end;
     
   procedure test_join_by_cursor is
     l_actual   SYS_REFCURSOR;
@@ -90,6 +95,19 @@ create or replace package body ut3$user#.test_cursor_grants is
       select value(x) as item from table(ut3_tester.test_dummy_object_list()) x;             
     --Act
     ut3.ut.expect(l_expected).to_be_empty();
+  end;
+  
+  procedure test_equal_non_diff_sql is
+    l_actual   SYS_REFCURSOR;
+    l_expected SYS_REFCURSOR;
+  begin
+    open l_actual for
+      select to_clob('test1') as item from dual;   
+
+    open l_expected for
+      select to_clob('test1') as item from dual;
+      
+    ut3.ut.expect(l_actual).to_equal(l_expected);   
   end;
   
 end;

--- a/test/helpers/ut3user#.test_cursor_grants.pks
+++ b/test/helpers/ut3user#.test_cursor_grants.pks
@@ -6,7 +6,8 @@ create or replace package ut3$user#.test_cursor_grants is
   procedure run_test_not_empty_cursor;
   procedure run_test_have_count_cursor;
   procedure run_test_empty_cursor;  
-
+  procedure run_test_equal_non_diff_sql; 
+  
   --%test(execute join by test)
   procedure test_join_by_cursor;
   
@@ -21,6 +22,9 @@ create or replace package ut3$user#.test_cursor_grants is
   
   --%test(execute empty test)
   procedure test_empty_cursor;  
+  
+  --%test(execute test with non diff datatype)
+  procedure test_equal_non_diff_sql;
   
 end;
 /


### PR DESCRIPTION
Fixes #870
Fixing issue when cursor was opened with privs of the user instead of framework when accessing internal function.