### PR TITLE
Fixed storage for `clob` in output buffer table - make it inline.

### DIFF
--- a/source/core/output_buffers/ut_message_id_seq.sql
+++ b/source/core/output_buffers/ut_message_id_seq.sql
@@ -1,1 +1,0 @@
-create sequence ut_message_id_seq nocycle cache 100;

--- a/source/core/output_buffers/ut_output_buffer_base.tps
+++ b/source/core/output_buffers/ut_output_buffer_base.tps
@@ -18,10 +18,10 @@ create or replace type ut_output_buffer_base authid definer as object(
 
   output_id                 raw(32),
   member procedure init(self in out nocopy ut_output_buffer_base),
-  not instantiable member procedure close(self in ut_output_buffer_base),
-  not instantiable member procedure send_line(self in ut_output_buffer_base, a_text varchar2, a_item_type varchar2 := null),
-  not instantiable member procedure send_lines(self in ut_output_buffer_base, a_text_list ut_varchar2_rows, a_item_type varchar2 := null),
-  not instantiable member procedure send_clob(self in ut_output_buffer_base, a_text clob, a_item_type varchar2 := null),
+  not instantiable member procedure close(self in out nocopy ut_output_buffer_base),
+  not instantiable member procedure send_line(self in out nocopy ut_output_buffer_base, a_text varchar2, a_item_type varchar2 := null),
+  not instantiable member procedure send_lines(self in out nocopy ut_output_buffer_base, a_text_list ut_varchar2_rows, a_item_type varchar2 := null),
+  not instantiable member procedure send_clob(self in out nocopy ut_output_buffer_base, a_text clob, a_item_type varchar2 := null),
   not instantiable member function get_lines(a_initial_timeout natural := null, a_timeout_sec natural := null) return ut_output_data_rows pipelined,
   not instantiable member function get_lines_cursor(a_initial_timeout natural := null, a_timeout_sec natural := null) return sys_refcursor,
   not instantiable member procedure lines_to_dbms_output(self in ut_output_buffer_base, a_initial_timeout natural := null, a_timeout_sec natural := null)

--- a/source/core/output_buffers/ut_output_buffer_tmp.sql
+++ b/source/core/output_buffers/ut_output_buffer_tmp.sql
@@ -32,14 +32,15 @@ begin
          is_finished = 0 and (text is not null or item_type is not null )
       or is_finished = 1 and text is null and item_type is null ),
   constraint ut_output_buffer_fk1 foreign key (output_id) references ut_output_buffer_info_tmp$(output_id)
-) organization index overflow nologging initrans 100 ';
+) nologging initrans 100
+';
   begin
     execute immediate
-      v_table_sql || 'lob(text) store as securefile ut_output_text(retention none)';
+      v_table_sql || 'lob(text) store as securefile ut_output_text(retention none enable storage in row)';
   exception
     when e_non_assm then
       execute immediate
-        v_table_sql || 'lob(text) store as basicfile ut_output_text(pctversion 0)';
+        v_table_sql || 'lob(text) store as basicfile ut_output_text(pctversion 0 enable storage in row)';
 
   end;
 end;

--- a/source/core/output_buffers/ut_output_table_buffer.tpb
+++ b/source/core/output_buffers/ut_output_table_buffer.tpb
@@ -20,6 +20,7 @@ create or replace type body ut_output_table_buffer is
   begin
     self.output_id := coalesce(a_output_id, sys_guid());
     self.start_date := sysdate;
+    self.last_message_id := 0;
     self.init();
     self.cleanup_buffer();
     return;
@@ -38,41 +39,44 @@ create or replace type body ut_output_table_buffer is
     commit;
   end;
 
-  overriding member procedure close(self in ut_output_table_buffer) is
+  overriding member procedure close(self in out nocopy ut_output_table_buffer) is
     pragma autonomous_transaction;
   begin
+    self.last_message_id := self.last_message_id + 1;
     insert into ut_output_buffer_tmp(output_id, message_id, is_finished)
-    values (self.output_id, ut_message_id_seq.nextval, 1);
+    values (self.output_id, self.last_message_id, 1);
     commit;
   end;
 
-  overriding member procedure send_line(self in ut_output_table_buffer, a_text varchar2, a_item_type varchar2 := null) is
+  overriding member procedure send_line(self in out nocopy ut_output_table_buffer, a_text varchar2, a_item_type varchar2 := null) is
     pragma autonomous_transaction;
   begin
     if a_text is not null or a_item_type is not null then
+      self.last_message_id := self.last_message_id + 1;
       insert into ut_output_buffer_tmp(output_id, message_id, text, item_type)
-      values (self.output_id, ut_message_id_seq.nextval, a_text, a_item_type);
+      values (self.output_id, self.last_message_id, a_text, a_item_type);
     end if;
     commit;
   end;
 
-  overriding member procedure send_lines(self in ut_output_table_buffer, a_text_list ut_varchar2_rows, a_item_type varchar2 := null) is
+  overriding member procedure send_lines(self in out nocopy ut_output_table_buffer, a_text_list ut_varchar2_rows, a_item_type varchar2 := null) is
     pragma autonomous_transaction;
   begin
     insert into ut_output_buffer_tmp(output_id, message_id, text, item_type)
-    select self.output_id, ut_message_id_seq.nextval, t.column_value, a_item_type
+    select self.output_id, self.last_message_id + rownum, t.column_value, a_item_type
       from table(a_text_list) t
      where t.column_value is not null or a_item_type is not null;
-
+    self.last_message_id := self.last_message_id + a_text_list.count;
     commit;
   end;
 
-  overriding member procedure send_clob(self in ut_output_table_buffer, a_text clob, a_item_type varchar2 := null) is
+  overriding member procedure send_clob(self in out nocopy ut_output_table_buffer, a_text clob, a_item_type varchar2 := null) is
     pragma autonomous_transaction;
   begin
     if a_text is not null and a_text != empty_clob() or a_item_type is not null then
+      self.last_message_id := self.last_message_id + 1;
       insert into ut_output_buffer_tmp(output_id, message_id, text, item_type)
-      values (self.output_id, ut_message_id_seq.nextval, a_text, a_item_type);
+      values (self.output_id, self.last_message_id, a_text, a_item_type);
     end if;
     commit;
   end;
@@ -91,7 +95,8 @@ create or replace type body ut_output_table_buffer is
     lc_long_sleep_time   constant number(1) := 1;     --sleep for 1 s when waiting long
     lc_long_wait_time    constant number(1) := 1;     --waiting more than 1 sec
     l_sleep_time         number(2,1) := lc_short_sleep_time;
-    lc_bulk_limit        constant integer := 3000;
+    lc_bulk_limit        constant integer := 1000;
+    l_max_message_id     integer := lc_bulk_limit;
 
     procedure remove_read_data(a_message_rowids t_rowid_tab) is
       pragma autonomous_transaction;
@@ -113,15 +118,15 @@ create or replace type body ut_output_table_buffer is
     begin
     while not l_finished loop
       with ordered_buffer as (
-        select a.rowid, ut_output_data_row(a.text, a.item_type), is_finished
+        select /*+ index(a) */ a.rowid, ut_output_data_row(a.text, a.item_type), is_finished
           from ut_output_buffer_tmp a
          where a.output_id = self.output_id
+           and a.message_id <= l_max_message_id
          order by a.message_id
       )
       select b.*
         bulk collect into l_message_rowids, l_buffer_data, l_finished_flags
-        from ordered_buffer b
-       where rownum <= lc_bulk_limit;
+        from ordered_buffer b;
 
       --nothing fetched from output, wait and try again
       if l_buffer_data.count = 0 then
@@ -159,6 +164,7 @@ create or replace type body ut_output_table_buffer is
           );
         end if;
       end if;
+      l_max_message_id := l_max_message_id + lc_bulk_limit;
     end loop;
     return;
   end;

--- a/source/core/output_buffers/ut_output_table_buffer.tpb
+++ b/source/core/output_buffers/ut_output_table_buffer.tpb
@@ -95,7 +95,7 @@ create or replace type body ut_output_table_buffer is
     lc_long_sleep_time   constant number(1) := 1;     --sleep for 1 s when waiting long
     lc_long_wait_time    constant number(1) := 1;     --waiting more than 1 sec
     l_sleep_time         number(2,1) := lc_short_sleep_time;
-    lc_bulk_limit        constant integer := 1000;
+    lc_bulk_limit        constant integer := 5000;
     l_max_message_id     integer := lc_bulk_limit;
 
     procedure remove_read_data(a_message_rowids t_rowid_tab) is
@@ -154,6 +154,7 @@ create or replace type body ut_output_table_buffer is
           end if;
         end loop;
         remove_read_data(l_message_rowids);
+        l_max_message_id := l_max_message_id + lc_bulk_limit;
       end if;
       if l_finished or l_already_waited_for >= l_wait_for then
         remove_buffer_info();
@@ -164,7 +165,6 @@ create or replace type body ut_output_table_buffer is
           );
         end if;
       end if;
-      l_max_message_id := l_max_message_id + lc_bulk_limit;
     end loop;
     return;
   end;

--- a/source/core/output_buffers/ut_output_table_buffer.tps
+++ b/source/core/output_buffers/ut_output_table_buffer.tps
@@ -17,12 +17,13 @@ create or replace type ut_output_table_buffer under ut_output_buffer_base (
   */
 
   start_date                date,
+  last_message_id           number(38,0),
   constructor function ut_output_table_buffer(self in out nocopy ut_output_table_buffer, a_output_id raw := null) return self as result,
   overriding member procedure init(self in out nocopy ut_output_table_buffer),
-  overriding member procedure send_line(self in ut_output_table_buffer, a_text varchar2, a_item_type varchar2 := null),
-  overriding member procedure send_lines(self in ut_output_table_buffer, a_text_list ut_varchar2_rows, a_item_type varchar2 := null),
-  overriding member procedure send_clob(self in ut_output_table_buffer, a_text clob, a_item_type varchar2 := null),
-  overriding member procedure close(self in ut_output_table_buffer),
+  overriding member procedure send_line(self in out nocopy ut_output_table_buffer, a_text varchar2, a_item_type varchar2 := null),
+  overriding member procedure send_lines(self in out nocopy ut_output_table_buffer, a_text_list ut_varchar2_rows, a_item_type varchar2 := null),
+  overriding member procedure send_clob(self in out nocopy ut_output_table_buffer, a_text clob, a_item_type varchar2 := null),
+  overriding member procedure close(self in out nocopy ut_output_table_buffer),
   overriding member function get_lines(a_initial_timeout natural := null, a_timeout_sec natural := null) return ut_output_data_rows pipelined,
   overriding member function get_lines_cursor(a_initial_timeout natural := null, a_timeout_sec natural := null) return sys_refcursor,
   overriding member procedure lines_to_dbms_output(self in ut_output_table_buffer, a_initial_timeout natural := null, a_timeout_sec natural := null),

--- a/source/install.sql
+++ b/source/install.sql
@@ -99,7 +99,6 @@ alter session set current_schema = &&ut3_owner;
 --output buffer table
 @@install_component.sql 'core/output_buffers/ut_output_buffer_info_tmp.sql'
 @@install_component.sql 'core/output_buffers/ut_output_buffer_tmp.sql'
-@@install_component.sql 'core/output_buffers/ut_message_id_seq.sql'
 --output buffer table api
 @@install_component.sql 'core/output_buffers/ut_output_table_buffer.tps'
 @@install_component.sql 'core/output_buffers/ut_output_table_buffer.tpb'

--- a/source/install.sql
+++ b/source/install.sql
@@ -194,7 +194,6 @@ prompt Installing DBMSPLSQL Tables objects into &&ut3_owner schema
 @@install_component.sql 'expectations/data_values/ut_cursor_column.tps'
 @@install_component.sql 'expectations/data_values/ut_cursor_column_tab.tps'
 @@install_component.sql 'expectations/data_values/ut_cursor_details.tps'
-@@install_component.sql 'expectations/data_values/ut_data_value_anydata.tps'
 @@install_component.sql 'expectations/data_values/ut_data_value_blob.tps'
 @@install_component.sql 'expectations/data_values/ut_data_value_boolean.tps'
 @@install_component.sql 'expectations/data_values/ut_data_value_clob.tps'

--- a/source/uninstall_objects.sql
+++ b/source/uninstall_objects.sql
@@ -257,8 +257,6 @@ drop view ut_output_buffer_info_tmp;
 
 drop table ut_output_buffer_info_tmp$;
 
-drop sequence ut_message_id_seq;
-
 drop type ut_output_data_rows force;
 
 drop type ut_output_data_row force;


### PR DESCRIPTION
Changed how delete from output buffer table is handled - use ROWID.
Increased fetch size from 100 to 3000 rows for output buffer.
Resolves #882