### PR TITLE
Bugfix/issue 891

### DIFF
--- a/docs/userguide/expectations.md
+++ b/docs/userguide/expectations.md
@@ -272,7 +272,9 @@ begin
 end;
 ```
 
-Parameters `a_mask` and `a_escape_char` represent valid parameters of the [Oracle LIKE condition](https://docs.oracle.com/database/121/SQLRF/conditions007.htm#SQLRF52142)
+Parameters `a_mask` and `a_escape_char` represent valid parameters of the [Oracle LIKE condition](https://docs.oracle.com/database/121/SQLRF/conditions007.htm#SQLRF52142).
+
+If you use Oracle Database version 11.2.0.4, you may run into Oracle Bug 14402514: WRONG RESULTS WITH LIKE ON CLOB USING ESCAPE CHARACTER. In this case we recommend to use `match` instead of `be_like`.
 
 
 ## be_not_null

--- a/test/core/test_suite_builder.pkb
+++ b/test/core/test_suite_builder.pkb
@@ -608,11 +608,11 @@ create or replace package body test_suite_builder is
     --Act
     l_actual := invoke_builder_for_annotations(l_annotations, 'SOME_PACKAGE');
     --Assert
-    ut.expect(l_actual).to_be_like('%<WARNINGS>%Annotation &quot;--\%beforeall&quot;%line 2%</WARNINGS>%', '\');
-    ut.expect(l_actual).to_be_like('%<WARNINGS>%Annotation &quot;--\%beforeeach&quot;%line 3%</WARNINGS>%', '\');
-    ut.expect(l_actual).to_be_like('%<WARNINGS>%Annotation &quot;--\%aftereach&quot;%line 4%</WARNINGS>%', '\');
-    ut.expect(l_actual).to_be_like('%<WARNINGS>%Annotation &quot;--\%afterall&quot; cannot be used with &quot;--\%test&quot;. Annotation ignored.'
-                                   ||'%at &quot;UT3_TESTER.SOME_PACKAGE.DO_STUFF&quot;, line 5%</WARNINGS>%', '\');
+    ut.expect(l_actual).to_match('(.*)(<WARNINGS>)(.*)(Annotation &quot;--%beforeall&quot;)(.*)(line 2)(.*)(</WARNINGS>)(.*)', 'n');
+    ut.expect(l_actual).to_match('(.*)(<WARNINGS>)(.*)(Annotation &quot;--%beforeeach&quot;)(.*)(line 3)(.*)(</WARNINGS>)(.*)', 'n');
+    ut.expect(l_actual).to_match('(.*)(<WARNINGS>)(.*)(Annotation &quot;--%aftereach&quot;)(.*)(line 4)(.*)(</WARNINGS>)(.*)', 'n');
+    ut.expect(l_actual).to_match('(.*)(<WARNINGS>)(.*)(Annotation &quot;--%afterall&quot; cannot be used with &quot;--%test&quot;. Annotation ignored.)'
+                               ||'(.*)(at &quot;UT3_TESTER.SOME_PACKAGE.DO_STUFF&quot;, line 5)(.*)(</WARNINGS>)(.*)', 'n');
     ut.expect(l_actual).not_to_be_like('%<BEFORE_EACH_LIST>%');
     ut.expect(l_actual).not_to_be_like('%<AFTER_EACH_LIST>%');
     ut.expect(l_actual).not_to_be_like('%<BEFORE_ALL_LIST>%');
@@ -1095,7 +1095,7 @@ create or replace package body test_suite_builder is
     --Act
     l_actual := invoke_builder_for_annotations(l_annotations, 'SOME_PACKAGE');
     --Assert
-    ut.expect(l_actual).to_be_like('%<WARNINGS><VARCHAR2>Unsupported annotation &quot;--\%bad_procedure_annotation&quot;. Annotation ignored.% line 2</VARCHAR2></WARNINGS>%', '\');
+    ut.expect(l_actual).to_match('(.*)(<WARNINGS><VARCHAR2>Unsupported annotation &quot;--%bad_procedure_annotation&quot;\. Annotation ignored\.)(.*)( line 2</VARCHAR2></WARNINGS>)(.*)', 'n');
   end;
 
   procedure test_bad_package_annotation is
@@ -1111,7 +1111,7 @@ create or replace package body test_suite_builder is
       --Act
       l_actual := invoke_builder_for_annotations(l_annotations, 'SOME_PACKAGE');
       --Assert
-      ut.expect(l_actual).to_be_like('%<WARNINGS><VARCHAR2>Unsupported annotation &quot;--\%bad_package_annotation&quot;. Annotation ignored.% line 17</VARCHAR2></WARNINGS>%', '\');
+      ut.expect(l_actual).to_match('(.*)(<WARNINGS><VARCHAR2>Unsupported annotation &quot;--%bad_package_annotation&quot;\. Annotation ignored\.)(.*)( line 17</VARCHAR2></WARNINGS>)(.*)', 'n');
   end;
 
 end test_suite_builder;


### PR DESCRIPTION
used `to_match` instead of `to_be_like` to make it work on all 11.2.0.4 Oracle Database instances.