### PR TITLE
fix/ORA-00907 when comparing ref cursors with BINARY_... columns

### DIFF
--- a/source/expectations/data_values/ut_compound_data_helper.pkb
+++ b/source/expectations/data_values/ut_compound_data_helper.pkb
@@ -231,7 +231,8 @@ create or replace package body ut_compound_data_helper is
     elsif  a_data_info.is_sql_diffable = 1  and a_data_info.column_type in ('DATE','TIMESTAMP','TIMESTAMP WITH TIME ZONE',
       'TIMESTAMP WITH LOCAL TIME ZONE') then
       l_col_type := 'VARCHAR2(50)';
-    elsif  a_data_info.is_sql_diffable = 1  and a_data_info.column_type in ('INTERVAL DAY TO SECOND','INTERVAL YEAR TO MONTH') then
+    elsif  a_data_info.is_sql_diffable = 1  and a_data_info.column_type in ('INTERVAL DAY TO SECOND',
+      'INTERVAL YEAR TO MONTH', 'BINARY_FLOAT', 'BINARY_DOUBLE') then
       l_col_type := a_data_info.column_type;
     else 
       l_col_type := a_data_info.column_type

--- a/test/ut3_user/expectations/test_expectations_cursor.pkb
+++ b/test/ut3_user/expectations/test_expectations_cursor.pkb
@@ -82,7 +82,7 @@ create or replace package body test_expectations_cursor is
     ut3.ut.reset_nls;
   end;
 
-  procedure success_on_same_data_with_float
+  procedure success_on_same_data_float
   as
     l_expected sys_refcursor;
     l_actual   sys_refcursor;

--- a/test/ut3_user/expectations/test_expectations_cursor.pkb
+++ b/test/ut3_user/expectations/test_expectations_cursor.pkb
@@ -82,6 +82,28 @@ create or replace package body test_expectations_cursor is
     ut3.ut.reset_nls;
   end;
 
+  procedure success_on_same_data_with_float
+  as
+    l_expected sys_refcursor;
+    l_actual   sys_refcursor;
+  begin
+    -- Arrange
+    ut3.ut.set_nls;
+    open l_expected for
+      select cast(3.14 as binary_double) as pi_double,
+             cast(3.14 as binary_float) as pi_float
+      from dual;
+    open l_actual for
+      select cast(3.14 as binary_double) as pi_double,
+             cast(3.14 as binary_float) as pi_float
+      from dual;
+    --Act
+    ut3.ut.expect( l_actual ).to_equal( l_expected );
+    --Assert
+    ut.expect(expectations.failed_expectations_data()).to_be_empty();
+    ut3.ut.reset_nls;
+  end;
+
   procedure success_on_empty
   as
     l_expected sys_refcursor;

--- a/test/ut3_user/expectations/test_expectations_cursor.pkb
+++ b/test/ut3_user/expectations/test_expectations_cursor.pkb
@@ -100,7 +100,7 @@ create or replace package body test_expectations_cursor is
     --Act
     ut3.ut.expect( l_actual ).to_equal( l_expected );
     --Assert
-    ut.expect(expectations.failed_expectations_data()).to_be_empty();
+    ut.expect(ut3_tester_helper.main_helper.get_failed_expectations_num).to_equal(0);
     ut3.ut.reset_nls;
   end;
 

--- a/test/ut3_user/expectations/test_expectations_cursor.pks
+++ b/test/ut3_user/expectations/test_expectations_cursor.pks
@@ -17,6 +17,9 @@ create or replace package test_expectations_cursor is
   --%test(Gives success for identical data)
   procedure success_on_same_data;
 
+  --%test(Gives success for identical data with floats)
+  procedure success_on_same_data_with_float;
+
   --%test(Gives success when both cursors are empty)
   procedure success_on_empty;
 

--- a/test/ut3_user/expectations/test_expectations_cursor.pks
+++ b/test/ut3_user/expectations/test_expectations_cursor.pks
@@ -18,7 +18,7 @@ create or replace package test_expectations_cursor is
   procedure success_on_same_data;
 
   --%test(Gives success for identical data with floats)
-  procedure success_on_same_data_with_float;
+  procedure success_on_same_data_float;
 
   --%test(Gives success when both cursors are empty)
   procedure success_on_empty;


### PR DESCRIPTION
fixing "ORA-00907: missing right parenthesis" when comparing ref cursors with BINARY_DOUBLE/BINARY_FLOAT columns, because these column types do not support type length

Stack trace:
  1) ut_get_data
      ORA-00907: missing right parenthesis
      ORA-06512: at "UT3.UT_DATA_VALUE_REFCURSOR", line 318
      ORA-06512: at "UT3.UT_COMPOUND_DATA_HELPER", line 596
      ORA-06512: at "UT3.UT_DATA_VALUE_REFCURSOR", line 309
      ORA-06512: at "UT3.UT_DATA_VALUE_REFCURSOR", line 366
      ORA-06512: at "UT3.UT_EQUAL", line 225
      ORA-06512: at "UT3.UT_EXPECTATION", line 26
      ORA-06512: at "UT3.UT_EXPECTATION", line 138
      ORA-06512: at "TDS2.UT_TDSPATANSINTPKG", line 117
      ORA-06512: at "TDS2.UT_TDSPATANSINTPKG", line 117
      ORA-06512: at "UT3.UT_DATA_VALUE_REFCURSOR", line 318
      ORA-06512: at "UT3.UT_COMPOUND_DATA_HELPER", line 596
      ORA-06512: at "UT3.UT_DATA_VALUE_REFCURSOR", line 309
      ORA-06512: at "UT3.UT_DATA_VALUE_REFCURSOR", line 366
      ORA-06512: at "UT3.UT_EQUAL", line 225
      ORA-06512: at "UT3.UT_EXPECTATION", line 26
      ORA-06512: at "UT3.UT_EXPECTATION", line 138
      ORA-06512: at "TDS2.UT_TDSPATANSINTPKG", line 117
      ORA-06512: at "TDS2.UT_TDSPATANSINTPKG", line 117
