### PR TITLE
Number precision from dbms_sql not correct

### DIFF
--- a/source/expectations/data_values/ut_compound_data_helper.pkb
+++ b/source/expectations/data_values/ut_compound_data_helper.pkb
@@ -235,6 +235,9 @@ create or replace package body ut_compound_data_helper is
       l_col_type := 'VARCHAR2(50)';
     elsif  a_data_info.is_sql_diffable = 1  and type_no_length(a_data_info.column_type) then
       l_col_type := a_data_info.column_type;
+    elsif a_data_info.is_sql_diffable = 1 and a_data_info.column_type in ('NUMBER') then
+      --We cannot use a precision and scale as dbms_sql.describe_columns3 return precision 0 for dual table
+      l_col_type := a_data_info.column_type;
     else 
       l_col_type := a_data_info.column_type
         ||case when a_data_info.column_len is not null

--- a/source/expectations/data_values/ut_compound_data_helper.pkb
+++ b/source/expectations/data_values/ut_compound_data_helper.pkb
@@ -237,6 +237,7 @@ create or replace package body ut_compound_data_helper is
       l_col_type := a_data_info.column_type;
     elsif a_data_info.is_sql_diffable = 1 and a_data_info.column_type in ('NUMBER') then
       --We cannot use a precision and scale as dbms_sql.describe_columns3 return precision 0 for dual table
+      -- there is also no need for that as we not process data but only read and compare as they are stored
       l_col_type := a_data_info.column_type;
     else 
       l_col_type := a_data_info.column_type

--- a/source/expectations/data_values/ut_cursor_column.tpb
+++ b/source/expectations/data_values/ut_cursor_column.tpb
@@ -4,13 +4,16 @@ create or replace type body ut_cursor_column as
      self in out nocopy ut_cursor_column,
      a_col_name varchar2, a_col_schema_name varchar2,
      a_col_type_name varchar2, a_col_max_len integer, a_parent_name varchar2 := null, a_hierarchy_level integer := 1,
-     a_col_position integer, a_col_type varchar2, a_collection integer,a_access_path in varchar2
+     a_col_position integer, a_col_type varchar2, a_collection integer,a_access_path in varchar2, a_col_precision in integer,
+     a_col_scale integer
    ) is
    begin
       self.parent_name      := a_parent_name; --Name of the parent if its nested
       self.hierarchy_level  := a_hierarchy_level; --Hierarchy level
       self.column_position  := a_col_position; --Position of the column in cursor/ type
       self.column_len       := a_col_max_len; --length of column
+      self.column_precision := a_col_precision;
+      self.column_scale     := a_col_scale;
       self.column_name      := TRIM( BOTH '''' FROM a_col_name); --name of the column
       self.column_type_name := coalesce(a_col_type_name,a_col_type); --type name e.g. test_dummy_object or varchar2
       self.xml_valid_name   := ut_utils.get_valid_xml_name(self.column_name);
@@ -49,10 +52,12 @@ create or replace type body ut_cursor_column as
    constructor function ut_cursor_column( self in out nocopy ut_cursor_column,
      a_col_name varchar2, a_col_schema_name varchar2,
      a_col_type_name varchar2, a_col_max_len integer, a_parent_name varchar2 := null, a_hierarchy_level integer := 1,
-     a_col_position integer, a_col_type in varchar2, a_collection integer,a_access_path in varchar2
+     a_col_position integer, a_col_type in varchar2, a_collection integer,a_access_path in varchar2, a_col_precision in integer,
+     a_col_scale integer
    ) return self as result is
    begin
-     init(a_col_name, a_col_schema_name, a_col_type_name, a_col_max_len, a_parent_name,a_hierarchy_level, a_col_position, a_col_type, a_collection,a_access_path);
+     init(a_col_name, a_col_schema_name, a_col_type_name, a_col_max_len, a_parent_name,a_hierarchy_level, a_col_position, 
+       a_col_type, a_collection,a_access_path,a_col_precision,a_col_scale);
    return;
    end;
    

--- a/source/expectations/data_values/ut_cursor_column.tps
+++ b/source/expectations/data_values/ut_cursor_column.tps
@@ -28,18 +28,22 @@ create or replace type ut_cursor_column force authid current_user as object (
    column_type_name varchar2(128),
    column_schema    varchar2(128),
    column_len       integer,
+   column_precision integer,
+   column_scale     integer,
    is_sql_diffable  number(1, 0),
    is_collection    number(1, 0),
 
    member procedure init(self in out nocopy ut_cursor_column,
      a_col_name varchar2, a_col_schema_name varchar2,
      a_col_type_name varchar2, a_col_max_len integer, a_parent_name varchar2 := null, a_hierarchy_level integer := 1,
-     a_col_position integer, a_col_type in varchar2, a_collection integer,a_access_path in varchar2),
+     a_col_position integer, a_col_type in varchar2, a_collection integer,a_access_path in varchar2, a_col_precision in integer,
+     a_col_scale integer),
      
    constructor function ut_cursor_column( self in out nocopy ut_cursor_column,
      a_col_name varchar2, a_col_schema_name varchar2,
      a_col_type_name varchar2, a_col_max_len integer, a_parent_name varchar2 := null, a_hierarchy_level integer := 1,
-     a_col_position integer, a_col_type in varchar2, a_collection integer, a_access_path in varchar2)
+     a_col_position integer, a_col_type in varchar2, a_collection integer, a_access_path in varchar2, a_col_precision in integer,
+     a_col_scale integer)
    return self as result,
    
   constructor function ut_cursor_column( self in out nocopy ut_cursor_column) return self as result

--- a/source/expectations/data_values/ut_cursor_details.tpb
+++ b/source/expectations/data_values/ut_cursor_details.tpb
@@ -39,7 +39,9 @@ create or replace type body ut_cursor_details as
           l_idx,
           ut_compound_data_helper.get_column_type_desc(l_elements_info.type_code,false),
           ut_utils.boolean_to_int(l_is_collection),
-          a_access_path
+          a_access_path,
+          l_elements_info.precision,
+          l_elements_info.scale
         );
       if l_element_info.attr_elt_type is not null then
         desc_compound_data(
@@ -63,7 +65,9 @@ create or replace type body ut_cursor_details as
             l_idx,
             ut_compound_data_helper.get_column_type_desc(l_element_info.type_code,false),
             ut_utils.boolean_to_int(l_is_collection),
-            a_access_path
+            a_access_path,
+            l_elements_info.precision,
+            l_elements_info.scale
           );
         if l_element_info.attr_elt_type is not null then
           desc_compound_data(
@@ -114,7 +118,9 @@ create or replace type body ut_cursor_details as
           pos,
           ut_compound_data_helper.get_column_type_desc(l_columns_desc(pos).col_type,true),
           ut_utils.boolean_to_int(l_is_collection),
-          null
+          null,
+          l_columns_desc(pos).col_precision,
+          l_columns_desc(pos).col_scale
         );
 
       if l_columns_desc(pos).col_type = dbms_sql.user_defined_type or l_is_collection then

--- a/test/ut3_user/expectations/test_expectations_cursor.pkb
+++ b/test/ut3_user/expectations/test_expectations_cursor.pkb
@@ -2677,5 +2677,15 @@ Check the query and data for errors.';
     
   end;  
   
+  procedure number_from_dual is
+    l_actual   sys_refcursor;
+    l_expected sys_refcursor;
+  begin
+    open l_expected for select 12345 as test from dual;
+    open l_actual   for select 12345 as test from dual;
+    ut3.ut.expect(l_actual).to_equal(l_expected);
+    ut.expect(ut3_tester_helper.main_helper.get_failed_expectations_num).to_equal(0);
+   end;
+  
 end;
 /

--- a/test/ut3_user/expectations/test_expectations_cursor.pkb
+++ b/test/ut3_user/expectations/test_expectations_cursor.pkb
@@ -2681,8 +2681,25 @@ Check the query and data for errors.';
     l_actual   sys_refcursor;
     l_expected sys_refcursor;
   begin
-    open l_expected for select 12345 as test from dual;
-    open l_actual   for select 12345 as test from dual;
+    open l_expected for select 
+      12345 as n1,
+      cast(7456123.89 as number(7,-2)) as n2,
+      cast(7456123.89 as number(9,1)) as n3,
+      cast(7456123.89 as number(9,2)) as n4,
+      cast(7456123.89 as number(9)) as n5,
+      cast(7456123.89 as number(*,1)) as n6,
+      7456123.89 as n7
+    from dual;
+    
+    open l_actual for select 
+      12345 as n1,
+      7456100 as n2,
+      7456123.9 as n3,
+      7456123.89 as n4,
+      7456124 as n5,
+      7456123.9 as n6,
+      7456123.89 as n7
+    from dual;
     ut3.ut.expect(l_actual).to_equal(l_expected);
     ut.expect(ut3_tester_helper.main_helper.get_failed_expectations_num).to_equal(0);
    end;

--- a/test/ut3_user/expectations/test_expectations_cursor.pks
+++ b/test/ut3_user/expectations/test_expectations_cursor.pks
@@ -418,5 +418,8 @@ create or replace package test_expectations_cursor is
   --%test(Check that column name accept non xml characters fix #902)
   procedure nonxmlchar_part_of_colname;
       
+  --%test(Check precision of number from dual)
+  procedure number_from_dual;
+  
 end;
 /

--- a/test/ut3_user/expectations/test_expectations_cursor.pks
+++ b/test/ut3_user/expectations/test_expectations_cursor.pks
@@ -418,7 +418,7 @@ create or replace package test_expectations_cursor is
   --%test(Check that column name accept non xml characters fix #902)
   procedure nonxmlchar_part_of_colname;
       
-  --%test(Check precision of number from dual)
+  --%test(Check precision of number from dual #907)
   procedure number_from_dual;
   
 end;


### PR DESCRIPTION
Fixes #907 
Number precision was incorrect when using max_col_len for data from dual.
This was changed to used a simple number with no precision.