### PR TITLE
Fix/exclude column position

### DIFF
--- a/source/expectations/data_values/ut_cursor_details.tpb
+++ b/source/expectations/data_values/ut_cursor_details.tpb
@@ -201,7 +201,7 @@ create or replace type body ut_cursor_details as
       for i in (
       select parent_name, access_path, display_path, has_nested_col,
         transformed_name, hierarchy_level, 
-        row_number() over (order by column_position) as new_position, xml_valid_name,
+        rownum as new_position, xml_valid_name,
         column_name, column_type, column_type_name, column_schema,
         column_len, column_precision ,column_scale ,is_sql_diffable, is_collection,value(x) col_info
       from table(l_result.cursor_columns_info) x

--- a/source/expectations/data_values/ut_cursor_details.tpb
+++ b/source/expectations/data_values/ut_cursor_details.tpb
@@ -204,7 +204,9 @@ create or replace type body ut_cursor_details as
         row_number() over (partition by parent_name,transformed_name order by column_position) as new_position, xml_valid_name,
         column_name, column_type, column_type_name, column_schema,
         column_len, column_precision ,column_scale ,is_sql_diffable, is_collection,value(x) col_info
-      from table(l_result.cursor_columns_info) x) loop
+      from table(l_result.cursor_columns_info) x
+	  order by x.column_position asc
+	  ) loop
         l_column := i.col_info;
         l_column.column_position := i.new_position;
         l_column_tab.extend;

--- a/source/expectations/data_values/ut_cursor_details.tpb
+++ b/source/expectations/data_values/ut_cursor_details.tpb
@@ -201,7 +201,7 @@ create or replace type body ut_cursor_details as
       for i in (
       select parent_name, access_path, display_path, has_nested_col,
         transformed_name, hierarchy_level, 
-        row_number() over (partition by parent_name,transformed_name order by column_position) as new_position, xml_valid_name,
+        row_number() over (order by column_position) as new_position, xml_valid_name,
         column_name, column_type, column_type_name, column_schema,
         column_len, column_precision ,column_scale ,is_sql_diffable, is_collection,value(x) col_info
       from table(l_result.cursor_columns_info) x

--- a/source/expectations/data_values/ut_cursor_details.tpb
+++ b/source/expectations/data_values/ut_cursor_details.tpb
@@ -160,6 +160,8 @@ create or replace type body ut_cursor_details as
 
   member procedure filter_columns(self in out nocopy ut_cursor_details, a_match_options ut_matcher_options) is
     l_result            ut_cursor_details := self;
+    l_column_tab        ut_cursor_column_tab := ut_cursor_column_tab();
+    l_column            ut_cursor_column;
     c_xpath_extract_reg constant varchar2(50) := '^((/ROW/)|^(//)|^(/\*/))?(.*)';
   begin
     if l_result.cursor_columns_info is not null then
@@ -194,6 +196,22 @@ create or replace type body ut_cursor_details as
              select 1 from excluded_columns f where regexp_like( '/'||x.access_path, '^/?'||f.col_names||'($|/.*)' )
            );
       end if;
+      
+      --Rewrite column order after columns been excluded
+      for i in (
+      select parent_name, access_path, display_path, has_nested_col,
+        transformed_name, hierarchy_level, 
+        row_number() over (partition by parent_name,transformed_name order by column_position) as new_position, xml_valid_name,
+        column_name, column_type, column_type_name, column_schema,
+        column_len, column_precision ,column_scale ,is_sql_diffable, is_collection,value(x) col_info
+      from table(l_result.cursor_columns_info) x) loop
+        l_column := i.col_info;
+        l_column.column_position := i.new_position;
+        l_column_tab.extend;
+        l_column_tab(l_column_tab.last) := l_column;
+      end loop;
+      
+      l_result.cursor_columns_info := l_column_tab;      
       self := l_result;
     end if;
   end;

--- a/test/ut3_user/expectations/test_expectations_cursor.pkb
+++ b/test/ut3_user/expectations/test_expectations_cursor.pkb
@@ -2842,5 +2842,6 @@ Check the query and data for errors.';
 
     ut3.ut.expect(v_actual).to_equal(v_expected).exclude('ID');
     ut.expect(ut3_tester_helper.main_helper.get_failed_expectations_num).to_equal(0);
+  end;
 end;
 /

--- a/test/ut3_user/expectations/test_expectations_cursor.pkb
+++ b/test/ut3_user/expectations/test_expectations_cursor.pkb
@@ -2831,5 +2831,16 @@ Check the query and data for errors.';
     $end
   end;
 
+  procedure uc_columns_exclude is
+    v_actual   SYS_REFCURSOR;
+    v_expected SYS_REFCURSOR;
+  begin
+    open v_expected for
+    select to_Char(null) id, 'ok' name from dual;
+    open v_actual for
+    select 'ok' name, to_number(null) id from dual;
+
+    ut3.ut.expect(v_actual).to_equal(v_expected).exclude('ID');
+    ut.expect(ut3_tester_helper.main_helper.get_failed_expectations_num).to_equal(0);
 end;
 /

--- a/test/ut3_user/expectations/test_expectations_cursor.pks
+++ b/test/ut3_user/expectations/test_expectations_cursor.pks
@@ -459,5 +459,8 @@ create or replace package test_expectations_cursor is
 
   type t_num_tab is table of t_num_rec index by binary_integer;
 
+  --%test( Mixed column order exclusion  )
+  procedure uc_columns_exclude;
+
 end;
 /


### PR DESCRIPTION
Fixes #911
This address an issue when the column was removed from cursor comparison by a filter.
If the column was at front or a middle it created an gap in column positions number and could lead to cursor mismatch on column position.
Fix is to re number the column position based on position after filter out.