### PR TITLE
Fix message id in output buffer

### DIFF
--- a/source/core/output_buffers/ut_output_clob_table_buffer.tpb
+++ b/source/core/output_buffers/ut_output_clob_table_buffer.tpb
@@ -66,7 +66,7 @@ create or replace type body ut_output_clob_table_buffer is
     select self.output_id, self.last_message_id + rownum, t.column_value, a_item_type
       from table(a_text_list) t
      where t.column_value is not null or a_item_type is not null;
-    self.last_message_id := self.last_message_id + a_text_list.count;
+    self.last_message_id := self.last_message_id + SQL%rowcount;
     commit;
   end;
 

--- a/source/core/output_buffers/ut_output_table_buffer.tpb
+++ b/source/core/output_buffers/ut_output_table_buffer.tpb
@@ -75,7 +75,7 @@ create or replace type body ut_output_table_buffer is
     select self.output_id, self.last_message_id + rownum, t.column_value, a_item_type
       from table(a_text_list) t
      where t.column_value is not null or a_item_type is not null;
-    self.last_message_id := self.last_message_id + a_text_list.count;
+    self.last_message_id := self.last_message_id + SQL%rowcount;
     commit;
   end;
 

--- a/test/ut3_tester/core/test_output_buffer.pkb
+++ b/test/ut3_tester/core/test_output_buffer.pkb
@@ -47,7 +47,7 @@ create or replace package body test_output_buffer is
   end;
   
   
-  procedure test_doesnt_send_multiline_on_null_text is
+  procedure test_doesnt_send_on_null_elem is
     l_cur    sys_refcursor;
     l_result integer;
     l_buffer ut3.ut_output_buffer_base := ut3.ut_output_table_buffer();

--- a/test/ut3_tester/core/test_output_buffer.pkb
+++ b/test/ut3_tester/core/test_output_buffer.pkb
@@ -46,6 +46,24 @@ create or replace package body test_output_buffer is
     ut.expect(l_cur).to_be_empty;
   end;
   
+  
+  procedure test_doesnt_send_multiline_on_null_text is
+    l_cur    sys_refcursor;
+    l_result integer;
+    l_buffer ut3.ut_output_buffer_base := ut3.ut_output_table_buffer();
+    l_message_id varchar2(255);
+    l_text varchar2(4000);
+  begin
+    ut3_tester_helper.run_helper.delete_buffer();
+    --Act
+    l_buffer.send_lines(ut_varchar2_rows(null));
+    l_buffer.send_lines(ut_varchar2_rows('test'));
+
+    select message_id, text into l_message_id, l_text from table(ut3_tester_helper.run_helper.ut_output_buffer_tmp);
+    ut.expect(l_message_id).to_equal('1');
+    ut.expect(l_text).to_equal('test');
+  end;  
+  
   procedure test_send_line is
     l_result   varchar2(4000);
     c_expected constant varchar2(4000) := lpad('a text',4000,',a text');

--- a/test/ut3_tester/core/test_output_buffer.pkb
+++ b/test/ut3_tester/core/test_output_buffer.pkb
@@ -56,8 +56,8 @@ create or replace package body test_output_buffer is
   begin
     ut3_tester_helper.run_helper.delete_buffer();
     --Act
-    l_buffer.send_lines(ut_varchar2_rows(null));
-    l_buffer.send_lines(ut_varchar2_rows('test'));
+    l_buffer.send_lines(ut3.ut_varchar2_rows(null));
+    l_buffer.send_lines(ut3.ut_varchar2_rows('test'));
 
     select message_id, text into l_message_id, l_text from table(ut3_tester_helper.run_helper.ut_output_buffer_tmp);
     ut.expect(l_message_id).to_equal('1');

--- a/test/ut3_tester/core/test_output_buffer.pks
+++ b/test/ut3_tester/core/test_output_buffer.pks
@@ -10,7 +10,7 @@ create or replace package test_output_buffer is
   procedure test_doesnt_send_on_null_text;
   
   --%test(Does not send line if null text given for multiline case)
-  procedure test_doesnt_send_multiline_on_null_text;
+  procedure test_doesnt_send_on_null_elem;
   
   --%test(Sends a line into buffer table)
   procedure test_send_line;

--- a/test/ut3_tester/core/test_output_buffer.pks
+++ b/test/ut3_tester/core/test_output_buffer.pks
@@ -9,6 +9,9 @@ create or replace package test_output_buffer is
   --%test(Does not send line if null text given)
   procedure test_doesnt_send_on_null_text;
   
+  --%test(Does not send line if null text given for multiline case)
+  procedure test_doesnt_send_multiline_on_null_text;
+  
   --%test(Sends a line into buffer table)
   procedure test_send_line;
   


### PR DESCRIPTION
We have gaps in message_id of output_buffers if line are reported using bulk procedure with null `text` value. Small fix eliminate such gaps and improves queries on output_buffers as they are limited by message_id range.