### PR TITLE
Fixed issue with missing newlines in cobertura coverage

### DIFF
--- a/source/reporters/ut_coverage_cobertura_reporter.tpb
+++ b/source/reporters/ut_coverage_cobertura_reporter.tpb
@@ -39,7 +39,7 @@ create or replace type body ut_coverage_cobertura_reporter is
       l_line_no := a_unit_coverage.lines.first;
       if l_line_no is null then
         for i in 1 .. a_unit_coverage.total_lines loop
-          ut_utils.append_to_clob(l_result, '<line number="'||i||'" hits="0" branch="false"/>');
+          ut_utils.append_to_clob(l_result, '<line number="'||i||'" hits="0" branch="false"/>'||chr(10));
         end loop;
       else
         while l_line_no is not null loop

--- a/test/install_and_run_tests.sh
+++ b/test/install_and_run_tests.sh
@@ -20,10 +20,11 @@ time utPLSQL-cli/bin/utplsql run ${UT3_TESTER_HELPER}/${UT3_TESTER_HELPER_PASSWO
 -source_path=source -owner=ut3 \
 -p='ut3_tester,ut3$user#' \
 -test_path=test -c \
--f=ut_coverage_sonar_reporter -o=coverage.xml \
--f=ut_coverage_html_reporter  -o=coverage.html \
--f=ut_coveralls_reporter      -o=coverage.json \
--f=ut_sonar_test_reporter     -o=test_results.xml \
--f=ut_junit_reporter          -o=junit_test_results.xml \
--f=ut_tfs_junit_reporter      -o=tfs_test_results.xml \
--f=ut_documentation_reporter  -o=test_results.log -s
+-f=ut_coverage_sonar_reporter     -o=coverage.xml \
+-f=ut_coverage_cobertura_reporter -o=cobertura.xml \
+-f=ut_coverage_html_reporter      -o=coverage.html \
+-f=ut_coveralls_reporter          -o=coverage.json \
+-f=ut_sonar_test_reporter         -o=test_results.xml \
+-f=ut_junit_reporter              -o=junit_test_results.xml \
+-f=ut_tfs_junit_reporter          -o=tfs_test_results.xml \
+-f=ut_documentation_reporter      -o=test_results.log -s

--- a/test/ut3_user/reporters/test_coverage/test_cov_cobertura_reporter.pkb
+++ b/test/ut3_user/reporters/test_coverage/test_cov_cobertura_reporter.pkb
@@ -41,5 +41,61 @@ create or replace package body test_cov_cobertura_reporter is
     ut.expect(l_actual).to_be_like(l_expected);
   end;
 
+  procedure report_zero_coverage is
+    l_results   ut3.ut_varchar2_list;
+    l_expected  clob;
+    l_actual    clob;
+  begin
+    --Arrange
+    l_expected :=
+    q'[<?xml version="1.0"?>
+<!DOCTYPE coverage SYSTEM "http://cobertura.sourceforge.net/xml/coverage-04.dtd">
+<coverage line-rate="0" branch-rate="0.0" lines-covered="0" lines-valid="15" branches-covered="0" branches-valid="0" complexity="0" version="1" timestamp="%">
+<sources>
+<source>ut3.dummy_coverage</source>
+</sources>
+<packages>
+<package name="DUMMY_COVERAGE" line-rate="0.0" branch-rate="0.0" complexity="0.0">
+<class name="DUMMY_COVERAGE" filename="ut3.dummy_coverage" line-rate="0.0" branch-rate="0.0" complexity="0.0">
+<lines>
+<line number="1" hits="0" branch="false"/>
+<line number="2" hits="0" branch="false"/>
+<line number="3" hits="0" branch="false"/>
+<line number="4" hits="0" branch="false"/>
+<line number="5" hits="0" branch="false"/>
+<line number="6" hits="0" branch="false"/>
+<line number="7" hits="0" branch="false"/>
+<line number="8" hits="0" branch="false"/>
+<line number="9" hits="0" branch="false"/>
+<line number="10" hits="0" branch="false"/>
+<line number="11" hits="0" branch="false"/>
+<line number="12" hits="0" branch="false"/>
+<line number="13" hits="0" branch="false"/>
+<line number="14" hits="0" branch="false"/>
+<line number="15" hits="0" branch="false"/>
+</lines>
+</class>
+</package>
+</packages>
+</coverage>]';
+
+    test_coverage.cleanup_dummy_coverage;
+    --Act
+    select *
+      bulk collect into l_results
+      from table(
+        ut3.ut.run(
+          a_path => 'ut3.test_dummy_coverage',
+          a_reporter=> ut3.ut_coverage_cobertura_reporter( ),
+          a_include_objects => ut3.ut_varchar2_list('UT3.DUMMY_COVERAGE')
+        )
+      );
+    l_actual := ut3_tester_helper.main_helper.table_to_clob(l_results);
+    --Assert
+    ut.expect(l_actual).to_be_like(l_expected);
+    --Cleanup
+    test_coverage.setup_dummy_coverage;
+  end;
+
 end;
 /

--- a/test/ut3_user/reporters/test_coverage/test_cov_cobertura_reporter.pks
+++ b/test/ut3_user/reporters/test_coverage/test_cov_cobertura_reporter.pks
@@ -6,5 +6,8 @@ create or replace package test_cov_cobertura_reporter is
   --%test(reports on a project file mapped to database object)
   procedure report_on_file;
 
+  --%test(reports zero coverage on each line of non-executed database object - Issue #917)
+  procedure report_zero_coverage;
+
 end test_cov_cobertura_reporter;
 /


### PR DESCRIPTION
Fixed issue with missing newlines in cobertura coverage for non-executed packages.

Resolves #917