### PR TITLE
Feature/add warnings to realtime reporter

### DIFF
--- a/source/reporters/ut_realtime_reporter.tpb
+++ b/source/reporters/ut_realtime_reporter.tpb
@@ -141,6 +141,7 @@ create or replace type body ut_realtime_reporter is
     self.print_end_node('counter');
     self.print_cdata_node('errorStack', ut_utils.table_to_clob(a_suite.get_error_stack_traces()));
     self.print_cdata_node('serverOutput', a_suite.get_serveroutputs());
+    self.print_cdata_node('warnings', ut_utils.table_to_clob(a_suite.warnings));
     self.print_end_node('suite');
     self.print_end_node('event');
     self.flush_print_buffer('post-suite');
@@ -196,6 +197,7 @@ create or replace type body ut_realtime_reporter is
       end loop expectations;
       self.print_end_node('failedExpectations');
     end if;
+    self.print_cdata_node('warnings', ut_utils.table_to_clob(a_test.warnings));
     self.print_end_node('test');
     self.print_end_node('event');
     self.flush_print_buffer('post-test');

--- a/test/ut3_user/reporters/test_realtime_reporter.pkb
+++ b/test/ut3_user/reporters/test_realtime_reporter.pkb
@@ -454,6 +454,7 @@ create or replace package body test_realtime_reporter as
     execute immediate 'drop package check_realtime_reporting1';
     execute immediate 'drop package check_realtime_reporting2';
     execute immediate 'drop package check_realtime_reporting3';
+    execute immediate 'drop package check_realtime_reporting4';
   end remove_test_suites;
 
 end test_realtime_reporter;

--- a/test/ut3_user/reporters/test_realtime_reporter.pks
+++ b/test/ut3_user/reporters/test_realtime_reporter.pks
@@ -44,7 +44,13 @@ create or replace package test_realtime_reporter as
 
   --%test(Provide the error stack of a testsuite)
   procedure error_stack_of_testsuite;
-  
+
+  --%test(Provide warnings of a test)
+  procedure warnings_of_test;
+
+  --%test(Provide warnings of a testsuite)
+  procedure warnings_of_testsuite;
+
   --%test(Provide a description of the reporter explaining the use for SQL Developer)
   procedure get_description;
 


### PR DESCRIPTION
I've run also the test case provided in the issue #936 . I'm using here the development version of to `ut_realtime_reporter`. This call:

```sql
set serveroutput on
exec ut3.ut.run('check_realtime_reporting4', ut3.ut_realtime_reporter());
```

produces this result (look for new `warnings` tags):

```xml
<?xml version="1.0"?>
<event type="pre-run">
  <items>
    <suite id="realtime_reporting">
      <name>realtime_reporting</name>
      <items>
        <suite id="realtime_reporting.check_realtime_reporting4">
          <name>check_realtime_reporting4</name>
          <items>
            <test id="realtime_reporting.check_realtime_reporting4.test_8_with_warning">
              <executableType>test</executableType>
              <ownerName>UT3$USER#</ownerName>
              <objectName>check_realtime_reporting4</objectName>
              <procedureName>test_8_with_warning</procedureName>
              <disabled>false</disabled>
              <name>test_8_with_warning</name>
              <testNumber>1</testNumber>
            </test>
          </items>
        </suite>
      </items>
    </suite>
  </items>
  <totalNumberOfTests>1</totalNumberOfTests>
</event>

<?xml version="1.0"?>
<event type="pre-suite">
  <suite id="realtime_reporting">
  </suite>
</event>

<?xml version="1.0"?>
<event type="pre-suite">
  <suite id="realtime_reporting.check_realtime_reporting4">
  </suite>
</event>

<?xml version="1.0"?>
<event type="pre-test">
  <test id="realtime_reporting.check_realtime_reporting4.test_8_with_warning">
    <testNumber>1</testNumber>
    <totalNumberOfTests>1</totalNumberOfTests>
  </test>
</event>

<?xml version="1.0"?>
<event type="post-test">
  <test id="realtime_reporting.check_realtime_reporting4.test_8_with_warning">
    <testNumber>1</testNumber>
    <totalNumberOfTests>1</totalNumberOfTests>
    <startTime>2019-06-12T16:13:13.652171</startTime>
    <endTime>2019-06-12T16:13:13.658354</endTime>
    <executionTime>.006183</executionTime>
    <counter>
      <disabled>0</disabled>
      <success>1</success>
      <failure>0</failure>
      <error>0</error>
      <warning>1</warning>
    </counter>
    <warnings><![CDATA[Unable to perform automatic rollback after test. An implicit or explicit commit/rollback occurred in procedures:
  ut3$user#.check_realtime_reporting4.test_8_with_warning
Use the "--%rollback(manual)" annotation or remove commit/rollback/ddl statements that are causing the issue.]]></warnings>
  </test>
</event>

<?xml version="1.0"?>
<event type="post-suite">
  <suite id="realtime_reporting.check_realtime_reporting4">
    <startTime>2019-06-12T16:13:13.648098</startTime>
    <endTime>2019-06-12T16:13:13.663282</endTime>
    <executionTime>.015184</executionTime>
    <counter>
      <disabled>0</disabled>
      <success>1</success>
      <failure>0</failure>
      <error>0</error>
      <warning>3</warning>
    </counter>
    <warnings><![CDATA["--%tags" annotation requires a tag value populated. Annotation ignored.
at "UT3$USER#.CHECK_REALTIME_REPORTING4", line 5
Unable to perform automatic rollback after test suite. An implicit or explicit commit/rollback occurred in procedures:
  ut3$user#.check_realtime_reporting4.test_8_with_warning
Use the "--%rollback(manual)" annotation or remove commit/rollback/ddl statements that are causing the issue.]]></warnings>
  </suite>
</event>

<?xml version="1.0"?>
<event type="post-suite">
  <suite id="realtime_reporting">
    <startTime>2019-06-12T16:13:13.646379</startTime>
    <endTime>2019-06-12T16:13:13.666403</endTime>
    <executionTime>.020024</executionTime>
    <counter>
      <disabled>0</disabled>
      <success>1</success>
      <failure>0</failure>
      <error>0</error>
      <warning>3</warning>
    </counter>
  </suite>
</event>

<?xml version="1.0"?>
<event type="post-run">
  <run>
    <startTime>2019-06-12T16:13:13.644619</startTime>
    <endTime>2019-06-12T16:13:13.670886</endTime>
    <executionTime>.026267</executionTime>
    <counter>
      <disabled>0</disabled>
      <success>1</success>
      <failure>0</failure>
      <error>0</error>
      <warning>3</warning>
    </counter>
  </run>
</event>
```
