### PR TITLE
Fixed issue with parsing via trigger source with leading comments

### DIFF
--- a/source/core/annotations/ut_annotation_manager.pkb
+++ b/source/core/annotations/ut_annotation_manager.pkb
@@ -267,10 +267,11 @@ create or replace package body ut_annotation_manager as
       l_sql_text    ora_name_list_t := a_sql_text;
     begin
       if a_parts > 0 then
-        l_sql_text(1) := regexp_replace(l_sql_text(1),'^\s*create(\s+or\s+replace){0,1}(\s+(editionable|noneditionable)){0,1}\s+{0,1}', modifier => 'i');
         for i in 1..a_parts loop
           ut_utils.append_to_clob(l_sql_clob, l_sql_text(i));
         end loop;
+        l_sql_clob := ut3.ut_utils.replace_multiline_comments(l_sql_clob);
+        l_sql_clob := regexp_replace(l_sql_clob, '^(.*?[^-]{2,}\s*create(\s+or\s+replace){0,1}(\s+(editionable|noneditionable))?\s+?)((package|type).*)', '\5', 1, 1, 'ni');
         l_sql_lines := ut_utils.convert_collection( ut_utils.clob_to_table(l_sql_clob) );
       end if;
       open l_result for

--- a/source/core/annotations/ut_annotation_manager.pkb
+++ b/source/core/annotations/ut_annotation_manager.pkb
@@ -271,7 +271,7 @@ create or replace package body ut_annotation_manager as
         end loop;
         l_sql_clob := ut_utils.replace_multiline_comments(l_sql_clob);
         -- replace comment lines that contain "-- create or replace"
-        l_sql_clob := regexp_replace(l_sql_clob, '^.*[-]{2,}\s*create(\s+or\s+replace).*$', modiafier => 'mi');
+        l_sql_clob := regexp_replace(l_sql_clob, '^.*[-]{2,}\s*create(\s+or\s+replace).*$', modifier => 'mi');
         -- remove the "create [or replace] [[non]editionable] " so that we have only "type|package" for parsing
         -- needed for dbms_preprocessor
         l_sql_clob := regexp_replace(l_sql_clob, '^(.*?\s*create(\s+or\s+replace)?(\s+(editionable|noneditionable))?\s+?)((package|type).*)', '\5', 1, 1, 'ni');

--- a/source/core/annotations/ut_annotation_manager.pkb
+++ b/source/core/annotations/ut_annotation_manager.pkb
@@ -264,14 +264,17 @@ create or replace package body ut_annotation_manager as
       l_sql_clob    clob;
       l_sql_lines   ut_varchar2_rows := ut_varchar2_rows();
       l_result      sys_refcursor;
-      l_sql_text    ora_name_list_t := a_sql_text;
     begin
       if a_parts > 0 then
         for i in 1..a_parts loop
-          ut_utils.append_to_clob(l_sql_clob, l_sql_text(i));
+          ut_utils.append_to_clob(l_sql_clob, a_sql_text(i));
         end loop;
         l_sql_clob := ut_utils.replace_multiline_comments(l_sql_clob);
-        l_sql_clob := regexp_replace(l_sql_clob, '^(.*?[^-]{2,}\s*create(\s+or\s+replace){0,1}(\s+(editionable|noneditionable))?\s+?)((package|type).*)', '\5', 1, 1, 'ni');
+        -- replace comment lines that contain "-- create or replace"
+        l_sql_clob := regexp_replace(l_sql_clob, '^.*[-]{2,}\s*create(\s+or\s+replace).*$', modiafier => 'mi');
+        -- remove the "create [or replace] [[non]editionable] " so that we have only "type|package" for parsing
+        -- needed for dbms_preprocessor
+        l_sql_clob := regexp_replace(l_sql_clob, '^(.*?\s*create(\s+or\s+replace)?(\s+(editionable|noneditionable))?\s+?)((package|type).*)', '\5', 1, 1, 'ni');
         l_sql_lines := ut_utils.convert_collection( ut_utils.clob_to_table(l_sql_clob) );
       end if;
       open l_result for

--- a/source/core/annotations/ut_annotation_manager.pkb
+++ b/source/core/annotations/ut_annotation_manager.pkb
@@ -270,7 +270,7 @@ create or replace package body ut_annotation_manager as
         for i in 1..a_parts loop
           ut_utils.append_to_clob(l_sql_clob, l_sql_text(i));
         end loop;
-        l_sql_clob := ut3.ut_utils.replace_multiline_comments(l_sql_clob);
+        l_sql_clob := ut_utils.replace_multiline_comments(l_sql_clob);
         l_sql_clob := regexp_replace(l_sql_clob, '^(.*?[^-]{2,}\s*create(\s+or\s+replace){0,1}(\s+(editionable|noneditionable))?\s+?)((package|type).*)', '\5', 1, 1, 'ni');
         l_sql_lines := ut_utils.convert_collection( ut_utils.clob_to_table(l_sql_clob) );
       end if;

--- a/source/core/ut_utils.pkb
+++ b/source/core/ut_utils.pkb
@@ -241,7 +241,9 @@ create or replace package body ut_utils is
   begin
     while l_offset <= l_length loop
       l_amount := a_max_amount - coalesce( length(l_last_line), 0 );
-      dbms_lob.read(a_clob, l_amount, l_offset, l_buffer);
+--      dbms_lob.read(a_clob, l_amount, l_offset, l_buffer);
+      l_buffer := substr(a_clob, l_offset, l_amount);
+      l_amount := length(l_buffer);
       l_offset := l_offset + l_amount;
 
       l_string_results := string_to_table( l_last_line || l_buffer, a_delimiter, l_skip_leading_delimiter );

--- a/test/ut3_tester/core/annotations/test_annotation_manager.pkb
+++ b/test/ut3_tester/core/annotations/test_annotation_manager.pkb
@@ -39,10 +39,19 @@ create or replace package body test_annotation_manager is
   procedure create_dummy_test_package is
     pragma autonomous_transaction;
   begin
-    execute immediate q'[create or replace package dummy_test_package as
+    execute immediate q'[
+      /*
+      * Some multiline comments before package spec
+      create or replace package dummy_test_package dummy comment to prove that we pick the right piece of code
+      */
+      -- create or replace package dummy_test_package dummy comment to prove that we pick the right piece of code
+      --Some single-line comment before package spec
+      create or replace package dummy_test_package as
         --%suite(dummy_test_suite)
         --%rollback(manual)
 
+        --create or replace package dummy_test_package dummy comment to prove that we pick the right piece of code
+        
         --%test(dummy_test)
         --%beforetest(some_procedure)
         procedure some_dummy_test_procedure;
@@ -142,9 +151,9 @@ create or replace package body test_annotation_manager is
         from dual union all
       select 3, 'rollback' , 'manual', '' as subobject_name
         from dual union all
-      select 5, 'test' , 'dummy_test', 'some_dummy_test_procedure' as subobject_name
+      select 7, 'test' , 'dummy_test', 'some_dummy_test_procedure' as subobject_name
         from dual union all
-      select 6, 'beforetest' , 'some_procedure', 'some_dummy_test_procedure' as subobject_name
+      select 8, 'beforetest' , 'some_procedure', 'some_dummy_test_procedure' as subobject_name
         from dual;
 
     ut.expect(l_actual).to_equal(l_expected);


### PR DESCRIPTION
Resolves problem when sources are passed via JDBC or dynamic SQL for compilation and source code contains leading comments.
The code was adjusted to properly read sources even when they are getting passed with leading comments containing create package statement.
Now, the following will be properly parsed:
```sql
  begin
    execute immediate q'[
      /*
      * Some multiline comments before package spec
      create or replace package dummy_test_package dummy comment to prove that we pick the right piece of code
      */
      -- create or replace package dummy_test_package dummy comment to prove that we pick the right piece of code
      --Some single-line comment before package spec
      create or replace package dummy_test_package as
        --%suite(dummy_test_suite)
        --%rollback(manual)

        --create or replace package dummy_test_package dummy comment to prove that we pick the right piece of code
        
        --%test(dummy_test)
        --%beforetest(some_procedure)
        procedure some_dummy_test_procedure;
      end;]';
  end;
/
```