### PR TITLE
Added test to confirm that long column names are suported in 3.1.7

### DIFF
--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -23,6 +23,7 @@ if [[ "${TRAVIS_JOB_NUMBER}" =~ \.2$ ]]; then
     time "$SQLCLI" sys/$ORACLE_PWD@//$CONNECTION_STR AS SYSDBA <<-SQL
     set feedback off
     set verify off
+    whenever sqlerror exit failure rollback
 
     @uninstall_all.sql $UT3_OWNER
     whenever sqlerror exit failure rollback

--- a/source/uninstall_objects.sql
+++ b/source/uninstall_objects.sql
@@ -194,8 +194,6 @@ drop table ut_compound_data_diff_tmp purge;
 
 drop table ut_json_data_diff_tmp;
 
-drop trigger ut_trigger_annotation_parsing;
-
 drop package ut_annotation_manager;
 
 drop package ut_annotation_parser;

--- a/source/uninstall_objects.sql
+++ b/source/uninstall_objects.sql
@@ -1,8 +1,28 @@
+set echo off
+set serverout on
+declare
+  procedure drop_if_exists(a_object_type varchar2, a_object_name varchar2) is
+    l_count integer;
+  begin
+    select count(1)
+      into l_count
+      from all_objects
+     where owner = sys_context('USERENV','CURRENT_SCHEMA')
+       and object_type = a_object_type
+       and object_name = a_object_name;
+    if l_count > 0 then
+      execute immediate 'drop '||a_object_type||' '||a_object_name;
+      dbms_output.put_line(initcap(a_object_type)||' '||a_object_name||' dropped.');
+    else
+      dbms_output.put_line(initcap(a_object_type)||' '||a_object_name||' was not dropped, '||lower(a_object_type)||' does not exist.');
+    end if;
+  end;
+begin
+  drop_if_exists('TRIGGER', 'UT_TRIGGER_ANNOTATION_PARSING');
+  drop_if_exists('SYNONYM','UT3_TRIGGER_ALIVE');
+end;
+/
 set echo on
-
-drop trigger ut_trigger_annotation_parsing;
-
-drop synonym ut3_trigger_alive;
 
 drop synonym be_between;
 

--- a/test/ut3_user/expectations/test_expectations_cursor.pkb
+++ b/test/ut3_user/expectations/test_expectations_cursor.pkb
@@ -2849,15 +2849,19 @@ Check the query and data for errors.';
     l_expected sys_refcursor;
   begin
     -- populate actual
-    open l_actual for
-      select rownum as id, '1' some_column_with_a_pretty_long_enough_name from dual;
+    $if dbms_db_version.version = 12 and dbms_db_version.release >= 2 or dbms_db_version.version > 12 $then
+      open l_actual for
+        select rownum as id, '1' some_column_with_a_pretty_long_enough_name from dual;
 
-    open l_expected for
-      select rownum as id, '1' some_column_with_a_pretty_long_enough_name from dual;
+      open l_expected for
+        select rownum as id, '1' some_column_with_a_pretty_long_enough_name from dual;
 
-    ut3.ut.expect(l_actual).to_equal(l_expected).include('ID,SOME_COLUMN_WITH_A_PRETTY_LONG_ENOUGH_NAME').join_by('ID');
-    --Assert
-    ut.expect(ut3_tester_helper.main_helper.get_failed_expectations_num).to_equal(0);
+      ut3.ut.expect(l_actual).to_equal(l_expected).include('ID,SOME_COLUMN_WITH_A_PRETTY_LONG_ENOUGH_NAME').join_by('ID');
+      --Assert
+      ut.expect(ut3_tester_helper.main_helper.get_failed_expectations_num).to_equal(0);
+    $else
+      null;
+    $end
   end;
 
 end;

--- a/test/ut3_user/expectations/test_expectations_cursor.pkb
+++ b/test/ut3_user/expectations/test_expectations_cursor.pkb
@@ -2843,5 +2843,22 @@ Check the query and data for errors.';
     ut3.ut.expect(v_actual).to_equal(v_expected).exclude('ID');
     ut.expect(ut3_tester_helper.main_helper.get_failed_expectations_num).to_equal(0);
   end;
+
+  procedure compare_long_column_names is
+    l_actual   sys_refcursor;
+    l_expected sys_refcursor;
+  begin
+    -- populate actual
+    open l_actual for
+      select rownum as id, '1' some_column_with_a_pretty_long_enough_name from dual;
+
+    open l_expected for
+      select rownum as id, '1' some_column_with_a_pretty_long_enough_name from dual;
+
+    ut3.ut.expect(l_actual).to_equal(l_expected).include('ID,SOME_COLUMN_WITH_A_PRETTY_LONG_ENOUGH_NAME').join_by('ID');
+    --Assert
+    ut.expect(ut3_tester_helper.main_helper.get_failed_expectations_num).to_equal(0);
+  end;
+
 end;
 /

--- a/test/ut3_user/expectations/test_expectations_cursor.pks
+++ b/test/ut3_user/expectations/test_expectations_cursor.pks
@@ -462,5 +462,8 @@ create or replace package test_expectations_cursor is
   --%test( Mixed column order exclusion  )
   procedure uc_columns_exclude;
 
+  --%test(Compares cursors with long column names - Issue #952 )
+  procedure compare_long_column_names;
+
 end;
 /


### PR DESCRIPTION
Resolves: #952

Added safety check on drop of optional objects.
Added safety harness to fail build if any of uninstall steps raises exceptions.