### PR TITLE
Ability to run expectations without test

### DIFF
--- a/.travis/install_utplsql_release.sh
+++ b/.travis/install_utplsql_release.sh
@@ -43,6 +43,8 @@ fi
 
 "$SQLCLI" sys/$ORACLE_PWD@//$CONNECTION_STR AS SYSDBA <<SQL
 alter session set plsql_optimize_level=0;
+alter session set plsql_ccflags = 'SELF_TESTING_INSTALL:TRUE';
+
 @${INSTALL_FILE} ${UT3_RELEASE_VERSION_SCHEMA}
 exit
 SQL

--- a/docs/userguide/advanced_data_comparison.md
+++ b/docs/userguide/advanced_data_comparison.md
@@ -49,7 +49,7 @@ When specifying column/attribute names, keep in mind that the names are **case s
 
 Consider the following examples
 ```sql
-procedure test_cur_skip_columns_eq is
+declare
   l_expected sys_refcursor;
   l_actual   sys_refcursor;
 begin
@@ -57,8 +57,8 @@ begin
   open l_actual   for select sysdate "ADate",  d.* from user_tables d;
   ut.expect( l_actual ).to_equal( l_expected ).exclude( 'IGNORE_ME,ADate' );
 end;
-
-procedure test_cur_skip_columns_cn is
+/
+declare
   l_expected sys_refcursor;
   l_actual   sys_refcursor;
 begin
@@ -66,42 +66,67 @@ begin
   open l_actual   for select sysdate "ADate",  d.* from user_tables d;
   ut.expect( l_actual ).to_contain( l_expected ).exclude( 'IGNORE_ME,ADate' );
 end;
+/
+```
+Produces:
+```
+SUCCESS
+  Actual: refcursor [ count = 23 ] was expected to equal: refcursor [ count = 23 ]
+
+SUCCESS
+  Actual: refcursor [ count = 23 ] was expected to contain: refcursor [ count = 1 ]
 ```
 
-Columns 'ignore_me' and "ADate" will get excluded from cursor comparison.
-The cursor data is equal or includes expected, when those columns are excluded.
+Columns 'ignore_me' and "ADate" will get excluded from data comparison.
+The actual data is equal/contains expected, when those columns are excluded.
 
-This option is useful in scenarios, when you need to exclude incomparable/unpredictable column data like CREATE_DATE of a record that is maintained by default value on a table column.
+**Note**
+>This option is useful in scenarios, when you need to exclude incomparable/unpredictable column data like CREATE_DATE of a record that is maintained by default value on a table column.
 
 ## Selecting columns for data comparison
 
 Consider the following example
 ```sql
-procedure include_col_as_csv_eq is
-    l_actual   sys_refcursor;
-    l_expected sys_refcursor;
+declare
+  l_actual   sys_refcursor;
+  l_expected sys_refcursor;
 begin
-    open l_expected for select rownum as rn, 'a' as "A_Column", 'x' SOME_COL from dual a connect by level < 4;
-    open l_actual   for select rownum as rn, 'a' as "A_Column", 'x' SOME_COL, a.* from all_objects a where rownum < 4;
-    ut.expect( l_actual ).to_equal( l_expected ).include( 'RN,A_Column,SOME_COL' );
+  open l_expected for select rownum as rn, 'a' as "A_Column", 'x' SOME_COL from dual a connect by level < 4;
+  open l_actual   for select rownum as rn, 'a' as "A_Column", 'x' SOME_COL, a.* from all_objects a where rownum < 4;
+  ut.expect( l_actual ).to_equal( l_expected ).include( 'RN,A_Column,SOME_COL' );
 end;
-
-procedure include_col_as_csv_cn is
-    l_actual   sys_refcursor;
-    l_expected sys_refcursor;
+/
+declare
+  l_actual   sys_refcursor;
+  l_expected sys_refcursor;
 begin
-    open l_expected for select rownum as rn, 'a' as "A_Column", 'x' SOME_COL from dual a connect by level < 4;
-    open l_actual   for select rownum as rn, 'a' as "A_Column", 'x' SOME_COL, a.* from all_objects a where rownum < 6;
-    ut.expect( l_actual ).to_contain( l_expected ).include( 'RN,A_Column,SOME_COL' );
+  open l_expected for select rownum as rn, 'a' as "A_Column", 'x' SOME_COL from dual a connect by level < 4;
+  open l_actual   for select rownum as rn, 'a' as "A_Column", 'x' SOME_COL, a.* from all_objects a where rownum < 6;
+  ut.expect( l_actual ).to_contain( l_expected ).include( 'RN,A_Column,SOME_COL' );
 end;
+/
 ```
+Produces:
+```
+SUCCESS
+  Actual: refcursor [ count = 3 ] was expected to equal: refcursor [ count = 3 ]
+
+SUCCESS
+  Actual: refcursor [ count = 5 ] was expected to contain: refcursor [ count = 3 ]
+```
+
+Only columns `RN`,`A_Column` and `SOME_COL `  will be included in data comparison.
+The actual data is equal/contains expected, when only those columns are included.
+
+**Note**
+>This option can be useful in scenarios where you need to narrow-down the scope of test so that the test is only focused on very specific data.  
 
 ## Combining include/exclude options
 You can chain the advanced options in an expectation and mix the `varchar2` with `ut_varchar2_list` arguments.
 When doing so, the final list of items to include/exclude will be a concatenation of all items.   
 
 ```sql
-procedure include_col_as_csv_eq is
+declare
     l_actual   sys_refcursor;
     l_expected sys_refcursor;
 begin
@@ -112,8 +137,8 @@ begin
       .include( ut_varchar2_list( 'A_Column', 'SOME_COL' ) )
       .exclude( 'SOME_COL' );
 end;
-
-procedure include_col_as_csv_cn is
+/
+declare
     l_actual   sys_refcursor;
     l_expected sys_refcursor;
 begin
@@ -124,12 +149,21 @@ begin
       .include( ut_varchar2_list( 'A_Column', 'SOME_COL' ) )
       .exclude( 'SOME_COL' );
 end;
+/
+```
 
+Results:
+```
+SUCCESS
+  Actual: refcursor [ count = 3 ] was expected to equal: refcursor [ count = 3 ]
+
+SUCCESS
+  Actual: refcursor [ count = 5 ] was expected to contain: refcursor [ count = 3 ]
 ```
 
 Example of `include / exclude` for anydata.convertCollection
 
-```plsql
+```sql
 create or replace type person as object(
   name varchar2(100),
   age  integer
@@ -138,77 +172,46 @@ create or replace type person as object(
 create or replace type people as table of person
 /
 
-create or replace package ut_anydata_inc_exc IS
+declare
+  l_actual           people := people(person('Matt',45));
+  l_expected         people :=people(person('Matt',47));
+begin
+  ut3.ut.expect(anydata.convertCollection(l_actual)).to_equal(anydata.convertCollection(l_expected)).include('NAME');  
+end;
 
-   --%suite(Anydata)
+declare
+  l_actual           people := people(person('Matt',45));
+  l_expected         people :=people(person('Matt',47));
+begin
+  ut3.ut.expect(anydata.convertCollection(l_actual)).to_equal(anydata.convertCollection(l_expected)).exclude('AGE');   
+end;
 
-   --%test(Anydata include)
-   procedure ut_anydata_test_inc;
-
-   --%test(Anydata exclude)
-   procedure ut_anydata_test_exc;
-   
-   --%test(Fail on age)
-   procedure ut_fail_anydata_test;
-   
-end ut_anydata_inc_exc;
+declare
+  l_actual           people := people(person('Matt',45));
+  l_expected         people :=people(person('Matt',47));
+begin
+  ut3.ut.expect(anydata.convertCollection(l_actual)).to_equal(anydata.convertCollection(l_expected)).include('AGE');   
+end;
 /
-
-create or replace package body ut_anydata_inc_exc IS
-
-   procedure ut_anydata_test_inc IS
-    l_actual           people := people(person('Matt',45));
-    l_expected         people :=people(person('Matt',47));
-  begin
-    ut3.ut.expect(anydata.convertCollection(l_actual)).to_equal(anydata.convertCollection(l_expected)).include('NAME');  
-   end;
-
-   procedure ut_anydata_test_exc IS
-    l_actual           people := people(person('Matt',45));
-    l_expected         people :=people(person('Matt',47));
-  begin
-    --Arrange
-    ut3.ut.expect(anydata.convertCollection(l_actual)).to_equal(anydata.convertCollection(l_expected)).exclude('AGE');   
-   end;
-
-   procedure ut_fail_anydata_test IS
-    l_actual           people := people(person('Matt',45));
-    l_expected         people :=people(person('Matt',47));
-  begin
-    --Arrange
-    ut3.ut.expect(anydata.convertCollection(l_actual)).to_equal(anydata.convertCollection(l_expected)).include('AGE');   
-  end;
-
-end ut_anydata_inc_exc;
-/
-
 ```
 
-will result in :
-
-```sql
-Anydata
-  Anydata include [.044 sec]
-  Anydata exclude [.035 sec]
-  Fail on age [.058 sec] (FAILED - 1)
- 
-Failures:
- 
-  1) ut_fail_anydata_test
-      Actual: ut3.people [ count = 1 ] was expected to equal: ut3.people [ count = 1 ]
-      Diff:
-      Rows: [ 1 differences ]
-        Row No. 1 - Actual:   <AGE>45</AGE>
-        Row No. 1 - Expected: <AGE>47</AGE>
+Results:
 ```
+SUCCESS
+  Actual: ut3.people [ count = 1 ] was expected to equal: ut3.people [ count = 1 ]
 
+SUCCESS
+  Actual: ut3.people [ count = 1 ] was expected to equal: ut3.people [ count = 1 ]
 
+FAILURE
+  Actual: ut3.people [ count = 1 ] was expected to equal: ut3.people [ count = 1 ]
+  Diff:
+  Rows: [ 1 differences ]
+    Row No. 1 - Actual:   <AGE>45</AGE>
+    Row No. 1 - Expected: <AGE>47</AGE>
+  at "anonymous block", line 5
 
-Example of exclude
-
-Only the columns 'RN', "A_Column" will be compared. Column 'SOME_COL' is excluded.
-
-This option can be useful in scenarios where you need to narrow-down the scope of test so that the test is only focused on very specific data.  
+```
 
 ## Unordered
 
@@ -217,35 +220,37 @@ Unordered option allows for quick comparison of two compound data types without 
 Result of such comparison will be limited to only information about row existing or not existing in given set without actual information about exact differences.
 
 ```sql
-procedure unordered_tst is
-    l_actual   sys_refcursor;
-    l_expected sys_refcursor;
+declare
+  l_actual   sys_refcursor;
+  l_expected sys_refcursor;
 begin
-    open l_expected for
-      select username, user_id from all_users
-      union all
-      select 'TEST' username, -600 user_id from dual
-      order by 1 desc;
-    open l_actual for 
-      select username, user_id from all_users
-      union all
-      select 'TEST' username, -610 user_id from dual
-      order by 1 asc;
-    ut.expect( l_actual ).to_equal( l_expected ).unordered;
+  open l_expected for
+    select username, user_id from all_users
+    union all
+    select 'TEST' username, -600 user_id from dual
+    order by 1 desc;
+  open l_actual for 
+    select username, user_id from all_users
+    union all
+    select 'TEST' username, -610 user_id from dual
+    order by 1 asc;
+  ut.expect( l_actual ).to_equal( l_expected ).unordered;
 end;
+/
 ```
 
 Above test will result in two differences of one row extra and one row missing. 
-
-```sql
-      Diff:
-      Rows: [ 2 differences ]
-      Missing:  <ROW><USERNAME>TEST</USERNAME><USER_ID>-600</USER_ID></ROW>
-      Extra:    <ROW><USERNAME>TEST</USERNAME><USER_ID>-610</USER_ID></ROW>
 ```
-
+FAILURE
+  Actual: refcursor [ count = 29 ] was expected to equal: refcursor [ count = 29 ]
+  Diff:
+  Rows: [ 2 differences ]
+  Extra:    <USERNAME>TEST</USERNAME><USER_ID>-610</USER_ID>
+  Missing:  <USERNAME>TEST</USERNAME><USER_ID>-600</USER_ID>
+  at "anonymous block", line 15
+```
 **Note**
-
+> `join_by` matcher is much faster on performing data comparison, consider using `join_by` over unordered
 > `contain` matcher is not considering order of compared data-sets. Using `unordered` makes no difference (it's default)
 
 
@@ -262,82 +267,99 @@ Join by option can be used in conjunction with include or exclude options.
 However if any of the join keys is part of exclude set, comparison will fail and report to user that sets could not be joined on specific key, as the key was excluded.
 
 ```sql
-procedure join_by_username is
-    l_actual   sys_refcursor;
-    l_expected sys_refcursor;
+declare
+  l_actual   sys_refcursor;
+  l_expected sys_refcursor;
 begin
-    open l_expected for 
-      select username, user_id from all_users
-      union all
-      select 'TEST' username, -600 user_id from dual
-      order by 1 desc;
-    open l_actual for 
-      select username, user_id from all_users
-      union all
-      select 'TEST' username, -610 user_id from dual
-      order by 1 asc;
-    ut.expect( l_actual ).to_equal( l_expected ).join_by('USERNAME');
+  open l_expected for 
+    select username, user_id from all_users
+    union all
+    select 'TEST' username, -600 user_id from dual
+    order by 1 desc;
+  open l_actual for 
+    select username, user_id from all_users
+    union all
+    select 'TEST' username, -610 user_id from dual
+    order by 1 asc;
+  ut.expect( l_actual ).to_equal( l_expected ).join_by('USERNAME');
 end;
+/
 ```
 
 Above test will result in a difference in row 'TEST' regardless of data order.
-
-```sql
-      Rows: [ 1 differences ]
-        PK <USERNAME>TEST</USERNAME> - Expected: <USER_ID>-600</USER_ID>
-        PK <USERNAME>TEST</USERNAME> - Actual:   <USER_ID>-610</USER_ID>
+```
+FAILURE
+  Actual: refcursor [ count = 29 ] was expected to equal: refcursor [ count = 29 ]
+  Diff:
+  Rows: [ 1 differences ]
+    PK <USERNAME>TEST</USERNAME> - Actual:   <USER_ID>-610</USER_ID>
+    PK <USERNAME>TEST</USERNAME> - Expected: <USER_ID>-600</USER_ID>
+    PK <USERNAME>TEST</USERNAME> - Extra:    <USERNAME>TEST</USERNAME><USER_ID>-610</USER_ID>
+  at "anonymous block", line 15
 ```
 
 **Note** 
 
 > When using `join_by`, the join column(s) are displayed first (as PK) to help you identify the mismatched rows/columns.
 
-You can use `join_by` extended syntax in combination with `contain / include ` matcher.
+You can use `join_by` syntax in combination with `contain` matcher.
 
 ```sql
-procedure join_by_username_cn is
-    l_actual   sys_refcursor;
-    l_expected sys_refcursor;
+declare
+  l_actual   sys_refcursor;
+  l_expected sys_refcursor;
 begin
-    open l_actual   for select username, user_id from all_users;
-    open l_expected for 
-      select username, user_id from all_users
-      union all
-      select 'TEST' username, -610 user_id from dual;
-    
-    ut.expect( l_actual ).to_contain( l_expected ).join_by('USERNAME');
+  open l_actual   for select username, user_id from all_users;
+  open l_expected for 
+    select username, user_id from all_users
+    union all
+    select 'TEST' username, -610 user_id from dual;
+  
+  ut.expect( l_actual ).to_contain( l_expected ).join_by('USERNAME');
 end;
+/
 ```
 
 Above test will indicate that in actual data-set
-
 ```sql
-     Actual: refcursor [ count = 43 ] was expected to contain: refcursor [ count = 44 ]
-     Diff:
-     Rows: [ 1 differences ]
-       PK <USERNAME>TEST</USERNAME> - Missing   <USER_ID>-610</USER_ID>
+FAILURE
+  Actual: refcursor [ count = 28 ] was expected to contain: refcursor [ count = 29 ]
+  Diff:
+  Rows: [ 1 differences ]
+    PK <USERNAME>TEST</USERNAME> - Missing:  <USERNAME>TEST</USERNAME><USER_ID>-610</USER_ID>
+  at "anonymous block", line 11
 ```
-
 
 ### Joining using multiple columns
 
 You can specify multiple columns in `join_by`
 
 ```sql
-procedure test_join_by_many_columns is
-    l_actual   sys_refcursor;
-    l_expected sys_refcursor;
+declare
+  l_actual   sys_refcursor;
+  l_expected sys_refcursor;
 begin
-    open l_expected for
-      select username, user_id, created from all_users
-       order by 1 desc;
-    open l_actual for
-      select username, user_id, created  from all_users
-       union all
-      select 'TEST' username, -610 user_id, sysdate from dual
-       order by 1 asc;
-    ut.expect( l_actual ).to_equal( l_expected ).join_by('USERNAME, USER_ID');
+  open l_expected for
+    select username, user_id, created from all_users
+     order by 1 desc;
+  open l_actual for
+    select username, user_id, created  from all_users
+     union all
+    select 'TEST' username, -610 user_id, sysdate from dual
+     order by 1 asc;
+  ut.expect( l_actual ).to_equal( l_expected ).join_by('USERNAME, USER_ID');
 end;
+/
+```
+
+Produces:
+```
+FAILURE
+  Actual: refcursor [ count = 29 ] was expected to equal: refcursor [ count = 28 ]
+  Diff:
+  Rows: [ 1 differences ]
+    PK <USERNAME>TEST</USERNAME><USER_ID>-610</USER_ID> - Extra:    <USERNAME>TEST</USERNAME><USER_ID>-610</USER_ID><CREATED>2019-07-11</CREATED>
+  at "anonymous block", line 13 
 ```
 
 ### Joining using attributes of object in column list
@@ -357,33 +379,34 @@ create or replace type person as object(
 create or replace type people as table of person
 /
 
-create or replace package test_join_by is
---%suite
-
---%test
-procedure test_join_by_object_attribute;
-
+declare
+  l_actual   sys_refcursor;
+  l_expected sys_refcursor;
+begin
+  open l_expected for
+    select person('Jack',42) someone from dual union all
+    select person('Pat', 44) someone from dual union all
+    select person('Matt',45) someone from dual;
+  open l_actual for
+    select person('Matt',55) someone from dual union all
+    select person('Pat', 44) someone from dual;
+  ut.expect( l_actual ).to_equal( l_expected ).join_by( 'SOMEONE/NAME' );
 end;
 /
+```
 
-create or replace package body test_join_by is
-  procedure test_join_by_object_attribute is
-    l_actual   sys_refcursor;
-    l_expected sys_refcursor;
-  begin
-    open l_expected for
-      select person('Jack',42) someone from dual union all
-      select person('Pat', 44) someone from dual union all
-      select person('Matt',45) someone from dual;
-    open l_actual for
-      select person('Matt',55) someone from dual union all
-      select person('Pat', 44) someone from dual;
-    ut.expect( l_actual ).to_equal( l_expected ).join_by( 'SOMEONE/NAME' );
-  end;
-
-end;
-/
-
+Produces:
+```
+FAILURE
+  Actual: refcursor [ count = 2 ] was expected to equal: refcursor [ count = 3 ]
+  Diff:
+  Rows: [ 2 differences ]
+    PK <NAME>Matt</NAME> - Actual:   <SOMEONE><NAME>Matt</NAME><AGE>55</AGE></SOMEONE>
+    PK <NAME>Matt</NAME> - Actual:   <AGE>55</AGE>
+    PK <NAME>Matt</NAME> - Expected: <SOMEONE><NAME>Matt</NAME><AGE>45</AGE></SOMEONE>
+    PK <NAME>Matt</NAME> - Expected: <AGE>45</AGE>
+    PK <NAME>Jack</NAME> - Missing:  <SOMEONE><NAME>Jack</NAME><AGE>42</AGE></SOMEONE>
+  at "anonymous block", line 12
 ```
 
 **Note**
@@ -397,15 +420,6 @@ create or replace type person as object(
 )
 /
 create or replace type people as table of person
-/
-
-create or replace package test_join_by is
---%suite
-
---%test
-procedure test_join_by_collection_elem;
-
-end;
 /
 
 create or replace package body test_join_by is
@@ -423,36 +437,51 @@ end;
 ```
 
 ```
-Actual: refcursor [ count = 1 ] was expected to equal: refcursor [ count = 1 ]
-Diff:
-Unable to join sets:
-  Join key PERSONS/PERSON/NAME does not exists in expected
-  Join key PERSONS/PERSON/NAME does not exists in actual
-  Please make sure that your join clause is not refferring to collection element
+FAILURE
+  Actual: refcursor [ count = 1 ] was expected to equal: refcursor [ count = 1 ]
+  Diff:
+  Unable to join sets:
+    Join key PERSONS/PERSON/NAME does not exists in expected
+    Join key PERSONS/PERSON/NAME does not exists in actual
+    Please make sure that your join clause is not refferring to collection element
+  
+  at "anonymous block", line 7
 ```
 
 **Note**
->`join_by` option is slower to process as it needs to perform a cursor join.
+>`join_by` option is slower to process as it needs to perform a cursor join. It is still faster than the `unordered`. 
 
 ## Defining item lists in option
-XPath expressions are deprecated. They are currently still supported but in future versions they can be removed completely. Please use a current standard of defining items filter.
 
-When using item list expression, keep in mind the following:
+You may provide items for `include`/`exclude`/`join_by` as a single varchar2 value containing comma-separated list of attributes.
 
+You may provide items for `include`/`exclude`/`join_by` as a a ut_varchar2_list of attributes.   
+
+**Note**
 - object type attributes are nested under `<OBJECTY_TYPE>` element
 - nested table and varray items type attributes are nested under `<ARRAY><OBJECTY_TYPE>` elements
 
 Example of a valid parameter to include columns: `RN`, `A_Column`, `SOME_COL` in data comparison. 
 ```sql
-procedure include_col_list is
+declare
     l_actual   sys_refcursor;
     l_expected sys_refcursor;
 begin
     open l_expected for select rownum as rn, 'a' as "A_Column", 'x' SOME_COL from dual a connect by level < 4;
     open l_actual   for select rownum as rn, 'a' as "A_Column", 'x' SOME_COL, a.* from all_objects a where rownum < 4;
     ut.expect( l_actual ).to_equal( l_expected ).include( 'RN,A_Column,SOME_COL' );
+    open l_expected for select rownum as rn, 'a' as "A_Column", 'x' SOME_COL from dual a connect by level < 4;
+    open l_actual   for select rownum as rn, 'a' as "A_Column", 'x' SOME_COL, a.* from all_objects a where rownum < 4;
     ut.expect( l_actual ).to_equal( l_expected ).include( ut_varchar2_list( 'RN', 'A_Column', 'SOME_COL' ) );
 end;
+/
+```
+
+```
+SUCCESS
+  Actual: refcursor [ count = 3 ] was expected to equal: refcursor [ count = 3 ]
+SUCCESS
+  Actual: refcursor [ count = 3 ] was expected to equal: refcursor [ count = 3 ]
 ```
 
 ## Unordered columns / uc option
@@ -465,44 +494,24 @@ Expectations that compare compound data type data with `unordered_columns` optio
 This option can be useful whn we have no control over the ordering of the column or the column order is not of importance from testing perspective.
 
 ```sql
-create or replace package test_unordered_columns as
-  --%suite
+declare
+  l_actual   sys_refcursor;
+  l_expected sys_refcursor;
+begin
+  --Arrange
+  open   l_actual for select owner, object_name, object_type from all_objects where owner = user
+  order by 1,2,3 asc;
+  open l_expected for select object_type, owner, object_name from all_objects where owner = user
+  and rownum < 20;
 
-  --%test
-  procedure cursor_include_unordered_cols;
+  --Assert
+  ut.expect(l_actual).to_contain(l_expected).unordered_columns();
 end;
 /
-
-create or replace package body test_unordered_columns as
-
-  procedure cursor_include_unordered_cols is
-    l_actual   sys_refcursor;
-    l_expected sys_refcursor;
-  begin
-    --Arrange
-    open l_actual for select owner, object_name,object_type from all_objects where owner = user
-    order by 1,2,3 asc;
-    open l_expected for select object_type, owner, object_name from all_objects where owner = user
-    and rownum < 20;
-
-    --Assert
-    ut.expect(l_actual).to_contain(l_expected).unordered_columns();
-  end;
-end;
-/
-
-exec ut.run('test_unordered_columns');
 ```
 
-The above test is successful despite the fact that column ordering in cursor is different.
-
+Produces:
 ```
-test_unordered_columns
-  cursor_include_unordered_cols [.042 sec]
- 
-Finished in .046193 seconds
-1 tests, 0 failed, 0 errored, 0 disabled, 0 warning(s)
+SUCCESS
+  Actual: refcursor [ count = 348 ] was expected to contain: refcursor [ count = 19 ]
 ```
-
-
-

--- a/docs/userguide/annotations.md
+++ b/docs/userguide/annotations.md
@@ -1733,6 +1733,113 @@ When processing the test suite `test_employee_pkg` defined in [Example of annota
 >
 >Order of execution within multiple occurrences of `before`/`after` procedures is determined by the order of annotations in specific block (context/suite) of package specification.
 
+## sys_context
+
+It is possible to access information about currently running suite, test and befire/after procedure form within PLSQL procedure using SYS_CONTEXT.
+
+The information is available by calling `sys_context( 'UT3_INFO', attribute )`.
+
+Following attributes are populated:
+- Always:
+    - `sys_context( 'UT3_INFO', 'RUN_PATHS' );` - list of suitepaths / suitenames used as input parameters for call to `ut.run(...)` or `ut_runner.run(...)`
+    - `sys_context( 'UT3_INFO', 'SUITE_DESCRIPTION' );` - the description of test suite that is currently being executed
+    - `sys_context( 'UT3_INFO', 'SUITE_PACKAGE' );` -  the owner and name of test suite package that is currently being executed
+    - `sys_context( 'UT3_INFO', 'SUITE_PATH' );` - the suitepath for the test suite package that is currently being executed
+    - `sys_context( 'UT3_INFO', 'SUITE_START_TIME' );` - the execution start timestamp of test suite package that is currently being executed
+    - `sys_context( 'UT3_INFO', 'CURRENT_EXECUTABLE_NAME' );` - the owner.package.procedure of currently running test suite executable
+    - `sys_context( 'UT3_INFO', 'CURRENT_EXECUTABLE_TYPE' );` - the type of currently running test suite executable (one of: `beforeall`, `beforeeach`, `beforetest`, `test`, `aftertest`, `aftereach`, `afterall`
+
+- When running in suite context
+    - `sys_context( 'UT3_INFO', 'CONTEXT_DESCRIPTION' );` - the description of test suite context that is currently being executed 
+    - `sys_context( 'UT3_INFO', 'CONTEXT_NAME' );` - the name of test suite context that is currently being executed 
+    - `sys_context( 'UT3_INFO', 'CONTEXT_PATH' );` - the suitepath for the currently executed test suite context
+    - `sys_context( 'UT3_INFO', 'CONTEXT_START_TIME' );` - the execution start timestamp for the currently executed test suite context
+- When running a suite executable procedure that is a `test` or `beforeeach`, `aftereach`, `beforetest`, `aftertest`
+    - `sys_context( 'UT3_INFO', 'TEST_DESCRIPTION' );` - the description of test for which the current executable is being invoked
+    - `sys_context( 'UT3_INFO', 'TEST_NAME' );` -  the name of test for which the current executable is being invoked
+    - `sys_context( 'UT3_INFO', 'TEST_START_TIME' );` - the execution start timestamp of test that is currently being executed (the time when first `beforeeach`/`beforetest` was called for that test)
+ 
+Example:
+```sql
+create or replace procedure which_procecure_called_me is
+begin
+  dbms_output.put_line(
+    'Currently running utPLSQL ' ||sys_context( 'ut3_info', 'current_executable_type' )
+    ||' ' ||sys_context( 'ut3_info', 'current_executable_name' )
+  );
+end;
+/
+
+create or replace package test_call is
+
+  --%suite
+
+  --%beforeall
+  procedure beforeall;
+  
+  --%beforeeach
+  procedure beforeeach;
+  
+  --%test
+  procedure test1;
+
+  --%test
+  procedure test2;
+  
+end;
+/
+
+create or replace package body test_call is
+
+  procedure beforeall is
+  begin
+    which_procecure_called_me();
+    dbms_output.put_line('Current test procedure is: '||sys_context('ut3_info','test_name'));
+  end;
+
+  procedure beforeeach is
+  begin
+    which_procecure_called_me();
+    dbms_output.put_line('Current test procedure is: '||sys_context('ut3_info','test_name'));
+  end;
+  
+  procedure test1 is
+  begin
+    which_procecure_called_me();
+    ut.expect(sys_context('ut3_info','suite_package')).to_equal(user||'.test_call');
+  end;
+
+  procedure test2 is
+  begin
+    which_procecure_called_me();
+    ut.expect(sys_context('ut3_info','test_name')).to_equal(user||'.test_call.test2');
+  end;
+  
+end;
+/
+```
+
+```sql
+exec ut.run('test_call');
+```
+
+```
+test_call
+  Currently running utPLSQL beforeall UT3.test_call.beforeall
+  Current test procedure is: 
+  test1 [.008 sec]
+  Currently running utPLSQL beforeeach UT3.test_call.beforeeach
+  Current test procedure is: UT3.test_call.test1
+  Currently running utPLSQL test UT3.test_call.test1
+  test2 [.004 sec]
+  Currently running utPLSQL beforeeach UT3.test_call.beforeeach
+  Current test procedure is: UT3.test_call.test2
+  Currently running utPLSQL test UT3.test_call.test2
+ 
+Finished in .021295 seconds
+2 tests, 0 failed, 0 errored, 0 disabled, 0 warning(s)
+```
+
 
 ## Annotation cache
 

--- a/docs/userguide/running-unit-tests.md
+++ b/docs/userguide/running-unit-tests.md
@@ -31,6 +31,8 @@ curl -Lk "${DOWNLOAD_URL}" -o utplsql-cli.zip
 unzip -q utplsql-cli.zip
 ```
 
+Keep in mind that you will need to download/provide Oracle JDBC driver separately, as it is not part of utPLSQL-cli due to licensing restrictions.
+
 # ut.run
 
 The `ut` package contains overloaded `run` procedures and functions.
@@ -167,11 +169,63 @@ The main difference compared to the `ut.run` API is that `ut_runner.run` does no
 `ut_runner.run` accepts multiple reporters. Each reporter pipes to a separate output (uniquely identified by output_id).
 Outputs of multiple reporters can be consumed in parallel. This allows for live reporting of test execution progress with threads and several database sessions.
 
-The concept is pretty simple.
+`ut_runner.run` API is used by utPLSQL-cli, utPLSQL-SQLDeveloper extension and utPLSQL-maven-plugin and allows for:
+- deciding on the scope of test run (by schema names, object names, suite paths or tags )
+- running tests with several concurrent reporters
+- real-time reporting of test execution progress
+- controlling colored text output to the screen
+- controlling scope of code coverage reports
+- mapping of database source code to project files
+- controlling behavior on test-failures
+- controlling client character set for HTML and XML reports
+- controlling rollback behavior of test-run
+- controlling random order of test execution
+
+Running with multiple reporters.
 
 - in the main thread (session), define the reporters to be used. Each reporter has it's output_id and so you need to extract and store those output_ids.
 - as a separate thread, start `ut_runner.run` and pass reporters with previously defined output_ids.
-- for each reporter start a separate thread and read outputs from the `ut_output_buffer.get_lines` table function by providing the output_id defined in the main thread.
+- for each reporter start a separate thread and read outputs from the `reporter.get_lines` table function or from `reporter.get_lines_cursor()` by providing the `reporter_id` defined in the main thread.
+- each reporter for each test-run must have a unique `reporter_id`. The `reporter_id` is used between two sessions to identify the data stream 
+
+Example:
+```sql
+--main test run ( session 1 )
+declare
+  l_reporter      ut_realtime_reporter := ut_realtime_reporter();
+begin
+  l_reporter.set_reporter_id( 'd8a79e85915640a6a4e1698fdf90ba74' );
+  l_reporter.output_buffer.init();
+  ut_runner.run (ut_varchar2_list ('ut3_tester','ut3$user#'), ut_reporters( l_reporter ) );
+end;
+/
+```
+
+```sql
+--report consumer ( session 2 )
+set arraysize 1
+set pagesize 0
+
+select * 
+  from table(
+         ut_realtime_reporter()
+           .set_reporter_id('d8a79e85915640a6a4e1698fdf90ba74')
+           .get_lines()
+  );
+```
+
+```sql
+--alternative version of report consumer ( session 2 )
+set arraysize 1
+set pagesize 0
+
+select
+    ut_realtime_reporter()
+      .set_reporter_id('d8a79e85915640a6a4e1698fdf90ba74')
+      .get_lines_cursor()
+  from dual;
+```
+
   
 # Order of test execution
 

--- a/source/api/ut_runner.pkb
+++ b/source/api/ut_runner.pkb
@@ -109,6 +109,7 @@ create or replace package body ut_runner is
     else
       ut_event_manager.add_listener( ut_documentation_reporter() );
     end if;
+    ut_event_manager.add_listener( ut_session_info() );
 
     ut_event_manager.trigger_event(ut_event_manager.gc_initialize);
     ut_event_manager.trigger_event(ut_event_manager.gc_debug, ut_run_info());

--- a/source/core/session_context/ut_session_context.pkb
+++ b/source/core/session_context/ut_session_context.pkb
@@ -1,0 +1,52 @@
+create or replace package body ut_session_context as
+  /*
+  utPLSQL - Version 3
+  Copyright 2016 - 2019 utPLSQL Project
+
+  Licensed under the Apache License, Version 2.0 (the "License"):
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  */
+  $IF $$SELF_TESTING_INSTALL $THEN
+  gc_context_name constant varchar2(30) := ut_utils.ut_owner()||'_INFO';
+  $ELSE
+  gc_context_name constant varchar2(30) := 'UT3_INFO';
+  $END
+
+  procedure set_context(a_name varchar2, a_value varchar2) is
+  begin
+    dbms_session.set_context( gc_context_name, a_name, a_value );
+  end;
+
+  procedure clear_context(a_name varchar2) is
+  begin
+    dbms_session.clear_context( namespace => gc_context_name, attribute => a_name );
+  end;
+
+  procedure clear_all_context is
+  begin
+    dbms_session.clear_all_context( namespace => gc_context_name );
+  end;
+
+  function is_ut_run return boolean is
+    l_paths    varchar2(32767);
+  begin
+    l_paths := sys_context(gc_context_name, 'RUN_PATHS');
+    return l_paths is not null;
+  end;
+
+  function get_namespace return varchar2 is
+  begin
+    return gc_context_name;
+  end;
+
+end;
+/

--- a/source/core/session_context/ut_session_context.pks
+++ b/source/core/session_context/ut_session_context.pks
@@ -1,4 +1,4 @@
-create or replace type ut_reporter_info as object (
+create or replace package ut_session_context as
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2019 utPLSQL Project
@@ -15,9 +15,31 @@ create or replace type ut_reporter_info as object (
   See the License for the specific language governing permissions and
   limitations under the License.
   */
-  object_name          varchar2(250), 
-  is_output_reporter   varchar2(1),
-  is_instantiable      varchar2(1),
-  is_final             varchar2(1)
-)
+
+  /*
+  * Sets value of a context
+  */
+  procedure set_context(a_name varchar2, a_value varchar2);
+
+  /*
+  * Clears value of a context
+  */
+  procedure clear_context(a_name varchar2);
+
+  /*
+  * Clears entire context for utPLSQL run
+  */
+  procedure clear_all_context;
+
+  /*
+  * Returns true, if session context UT3_INFO is not empty
+  */
+  function is_ut_run return boolean;
+    
+  /*
+  * Returns utPLSQL session context namespace name
+  */
+  function get_namespace return varchar2;
+
+end;
 /

--- a/source/core/session_context/ut_session_info.tpb
+++ b/source/core/session_context/ut_session_info.tpb
@@ -1,0 +1,199 @@
+create or replace type body ut_session_info as
+  /*
+  utPLSQL - Version 3
+  Copyright 2016 - 2019 utPLSQL Project
+
+  Licensed under the Apache License, Version 2.0 (the "License"):
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  */
+
+  constructor function ut_session_info(self in out nocopy ut_session_info) return self as result is
+  begin
+    self.self_type   := $$plsql_unit;
+    dbms_application_info.read_client_info( client_info );
+    dbms_application_info.read_module( module, action );
+    return;
+  end;
+
+  -- run hooks
+  member procedure before_calling_run(self in out nocopy ut_session_info, a_run in ut_run) is
+  begin
+    ut_session_context.set_context( 'run_paths', ut_utils.to_string( ut_utils.table_to_clob( a_run.run_paths,',' ), null ) );
+    dbms_application_info.set_module( 'utPLSQL', null );
+  end;
+
+  member procedure after_calling_run(self in out nocopy ut_session_info, a_run in ut_run) is
+  begin
+    ut_session_context.clear_context( 'run_paths' );
+    dbms_application_info.set_module( module, action );
+    dbms_application_info.set_client_info( client_info );
+  end;
+
+  -- suite hooks
+  member procedure before_calling_suite(self in out nocopy ut_session_info, a_suite in ut_logical_suite) is
+  begin
+    if a_suite is not of (ut_suite_context) then
+      suite_start_time := a_suite.start_time;
+      ut_session_context.set_context( 'suite_path',        a_suite.path );
+      ut_session_context.set_context( 'suite_package',     a_suite.object_owner||'.'||a_suite.object_name );
+      ut_session_context.set_context( 'suite_description', a_suite.description );
+      ut_session_context.set_context( 'suite_start_time',  ut_utils.to_string(suite_start_time)  );
+      dbms_application_info.set_module( 'utPLSQL',         a_suite.object_name );
+    else
+      context_start_time := a_suite.start_time;
+      ut_session_context.set_context( 'context_name',        a_suite.name );
+      ut_session_context.set_context( 'context_path',        a_suite.path);
+      ut_session_context.set_context( 'context_description', a_suite.description );
+      ut_session_context.set_context( 'context_start_time',  ut_utils.to_string(context_start_time)  );
+    end if;
+  end;
+
+  member procedure after_calling_suite(self in out nocopy ut_session_info, a_suite in ut_logical_suite) is
+  begin
+    if a_suite is not of (ut_suite_context) then
+      ut_session_context.clear_context( 'suite_package' );
+      ut_session_context.clear_context( 'suite_path' );
+      ut_session_context.clear_context( 'suite_description' );
+      ut_session_context.clear_context( 'suite_start_time' );
+      ut_session_context.clear_context( 'time_in_suite' );
+      suite_start_time := null;
+    else
+      ut_session_context.clear_context( 'context_name' );
+      ut_session_context.clear_context( 'context_path' );
+      ut_session_context.clear_context( 'context_description' );
+      ut_session_context.clear_context( 'context_start_time' );
+      ut_session_context.clear_context( 'time_in_context' );
+      context_start_time := null;
+    end if;
+  end;
+
+
+  member procedure before_calling_test(self in out nocopy ut_session_info, a_test in ut_test) is
+  begin
+    test_start_time := a_test.start_time;
+    ut_session_context.set_context( 'test_name', a_test.object_owner||'.'||a_test.object_name||'.'||a_test.name );
+    ut_session_context.set_context( 'test_description', a_test.description );
+    ut_session_context.set_context( 'test_start_time',  ut_utils.to_string(test_start_time)  );
+  end;
+
+  member procedure after_calling_test (self in out nocopy ut_session_info, a_test in ut_test) is
+  begin
+    ut_session_context.clear_context( 'test_name' );
+    ut_session_context.clear_context( 'test_description' );
+    ut_session_context.clear_context( 'test_start_time' );
+    ut_session_context.clear_context( 'time_in_test' );
+    test_start_time := null;
+  end;
+
+  member procedure before_calling_executable(self in out nocopy ut_session_info, a_executable in ut_executable) is
+  begin
+    ut_session_context.set_context( 'current_executable_type', a_executable.executable_type );
+    ut_session_context.set_context(
+      'current_executable_name',
+      a_executable.owner_name||'.'||a_executable.object_name||'.'||a_executable.procedure_name
+    );
+    dbms_application_info.set_client_info( a_executable.procedure_name );
+    if suite_start_time is not null then
+      ut_session_context.set_context( 'time_in_suite', current_timestamp - suite_start_time );
+      if context_start_time is not null then
+        ut_session_context.set_context( 'time_in_context', current_timestamp - context_start_time );
+      end if;
+      if test_start_time is not null then
+        ut_session_context.set_context( 'time_in_test', current_timestamp - test_start_time );
+      end if;
+    end if;
+  end;
+
+  member procedure after_calling_executable(self in out nocopy ut_session_info, a_executable in ut_executable) is
+  begin
+    ut_session_context.clear_context( 'current_executable_type' );
+    ut_session_context.clear_context( 'current_executable_name' );
+    dbms_application_info.set_client_info( null );
+  end;
+
+  member procedure on_finalize(self in out nocopy ut_session_info, a_run in ut_run) is
+  begin
+    dbms_application_info.set_client_info( client_info );
+    dbms_application_info.set_module( module, action );
+    ut_session_context.clear_all_context();
+  end;
+
+  overriding member function get_supported_events return ut_varchar2_list is
+  begin
+    return ut_varchar2_list(
+      ut_event_manager.gc_before_run,
+      ut_event_manager.gc_before_suite,
+      ut_event_manager.gc_before_test,
+      ut_event_manager.gc_before_before_all,
+      ut_event_manager.gc_before_before_each,
+      ut_event_manager.gc_before_before_test,
+      ut_event_manager.gc_before_test_execute,
+      ut_event_manager.gc_before_after_test,
+      ut_event_manager.gc_before_after_each,
+      ut_event_manager.gc_before_after_all,
+      ut_event_manager.gc_after_run,
+      ut_event_manager.gc_after_suite,
+      ut_event_manager.gc_after_test,
+      ut_event_manager.gc_after_before_all,
+      ut_event_manager.gc_after_before_each,
+      ut_event_manager.gc_after_before_test,
+      ut_event_manager.gc_after_test_execute,
+      ut_event_manager.gc_after_after_test,
+      ut_event_manager.gc_after_after_each,
+      ut_event_manager.gc_after_after_all,
+      ut_event_manager.gc_finalize
+      );
+  end;
+
+  overriding member procedure on_event( self in out nocopy ut_session_info, a_event_name varchar2, a_event_item ut_event_item) is
+  begin
+    case
+      when a_event_name in (
+          ut_event_manager.gc_before_before_all,
+          ut_event_manager.gc_before_before_each,
+          ut_event_manager.gc_before_before_test,
+          ut_event_manager.gc_before_test_execute,
+          ut_event_manager.gc_before_after_test,
+          ut_event_manager.gc_before_after_each,
+          ut_event_manager.gc_before_after_all
+        )
+        then before_calling_executable(treat(a_event_item as ut_executable));
+      when a_event_name in (
+          ut_event_manager.gc_after_before_all,
+          ut_event_manager.gc_after_before_each,
+          ut_event_manager.gc_after_before_test,
+          ut_event_manager.gc_after_test_execute,
+          ut_event_manager.gc_after_after_test,
+          ut_event_manager.gc_after_after_each,
+          ut_event_manager.gc_after_after_all
+        )
+        then after_calling_executable(treat(a_event_item as ut_executable));
+      when a_event_name = ut_event_manager.gc_before_test
+        then self.before_calling_test(treat(a_event_item as ut_test));
+      when a_event_name = ut_event_manager.gc_after_test
+        then self.after_calling_test(treat(a_event_item as ut_test));
+      when a_event_name = ut_event_manager.gc_after_suite
+        then after_calling_suite(treat(a_event_item as ut_logical_suite));
+      when a_event_name = ut_event_manager.gc_before_suite
+        then before_calling_suite(treat(a_event_item as ut_logical_suite));
+      when a_event_name = ut_event_manager.gc_before_run
+        then before_calling_run(treat(a_event_item as ut_run));
+      when a_event_name = ut_event_manager.gc_after_run
+        then after_calling_run(treat(a_event_item as ut_run));
+      when a_event_name = ut_event_manager.gc_finalize
+        then on_finalize(treat(a_event_item as ut_run));
+      else null;
+      end case;
+  end;
+
+end;
+/

--- a/source/core/session_context/ut_session_info.tpb
+++ b/source/core/session_context/ut_session_info.tpb
@@ -42,18 +42,16 @@ create or replace type body ut_session_info as
   member procedure before_calling_suite(self in out nocopy ut_session_info, a_suite in ut_logical_suite) is
   begin
     if a_suite is not of (ut_suite_context) then
-      suite_start_time := a_suite.start_time;
       ut_session_context.set_context( 'suite_path',        a_suite.path );
       ut_session_context.set_context( 'suite_package',     a_suite.object_owner||'.'||a_suite.object_name );
       ut_session_context.set_context( 'suite_description', a_suite.description );
-      ut_session_context.set_context( 'suite_start_time',  ut_utils.to_string(suite_start_time)  );
+      ut_session_context.set_context( 'suite_start_time',  ut_utils.to_string(a_suite.start_time)  );
       dbms_application_info.set_module( 'utPLSQL',         a_suite.object_name );
     else
-      context_start_time := a_suite.start_time;
       ut_session_context.set_context( 'context_name',        a_suite.name );
       ut_session_context.set_context( 'context_path',        a_suite.path);
       ut_session_context.set_context( 'context_description', a_suite.description );
-      ut_session_context.set_context( 'context_start_time',  ut_utils.to_string(context_start_time)  );
+      ut_session_context.set_context( 'context_start_time',  ut_utils.to_string(a_suite.start_time)  );
     end if;
   end;
 
@@ -64,25 +62,20 @@ create or replace type body ut_session_info as
       ut_session_context.clear_context( 'suite_path' );
       ut_session_context.clear_context( 'suite_description' );
       ut_session_context.clear_context( 'suite_start_time' );
-      ut_session_context.clear_context( 'time_in_suite' );
-      suite_start_time := null;
     else
       ut_session_context.clear_context( 'context_name' );
       ut_session_context.clear_context( 'context_path' );
       ut_session_context.clear_context( 'context_description' );
       ut_session_context.clear_context( 'context_start_time' );
-      ut_session_context.clear_context( 'time_in_context' );
-      context_start_time := null;
     end if;
   end;
 
 
   member procedure before_calling_test(self in out nocopy ut_session_info, a_test in ut_test) is
   begin
-    test_start_time := a_test.start_time;
     ut_session_context.set_context( 'test_name', a_test.object_owner||'.'||a_test.object_name||'.'||a_test.name );
     ut_session_context.set_context( 'test_description', a_test.description );
-    ut_session_context.set_context( 'test_start_time',  ut_utils.to_string(test_start_time)  );
+    ut_session_context.set_context( 'test_start_time',  ut_utils.to_string(a_test.start_time)  );
   end;
 
   member procedure after_calling_test (self in out nocopy ut_session_info, a_test in ut_test) is
@@ -90,8 +83,6 @@ create or replace type body ut_session_info as
     ut_session_context.clear_context( 'test_name' );
     ut_session_context.clear_context( 'test_description' );
     ut_session_context.clear_context( 'test_start_time' );
-    ut_session_context.clear_context( 'time_in_test' );
-    test_start_time := null;
   end;
 
   member procedure before_calling_executable(self in out nocopy ut_session_info, a_executable in ut_executable) is
@@ -102,15 +93,6 @@ create or replace type body ut_session_info as
       a_executable.owner_name||'.'||a_executable.object_name||'.'||a_executable.procedure_name
     );
     dbms_application_info.set_client_info( a_executable.procedure_name );
-    if suite_start_time is not null then
-      ut_session_context.set_context( 'time_in_suite', current_timestamp - suite_start_time );
-      if context_start_time is not null then
-        ut_session_context.set_context( 'time_in_context', current_timestamp - context_start_time );
-      end if;
-      if test_start_time is not null then
-        ut_session_context.set_context( 'time_in_test', current_timestamp - test_start_time );
-      end if;
-    end if;
   end;
 
   member procedure after_calling_executable(self in out nocopy ut_session_info, a_executable in ut_executable) is

--- a/source/core/session_context/ut_session_info.tps
+++ b/source/core/session_context/ut_session_info.tps
@@ -1,0 +1,52 @@
+create or replace type ut_session_info under ut_event_listener (
+  /*
+  utPLSQL - Version 3
+  Copyright 2016 - 2019 utPLSQL Project
+
+  Licensed under the Apache License, Version 2.0 (the "License"):
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  */
+
+  module             varchar2(4000),
+  action             varchar2(4000),
+  client_info        varchar2(4000),
+  suite_start_time   timestamp,
+  context_start_time timestamp,
+  test_start_time    timestamp,
+  constructor function ut_session_info(self in out nocopy ut_session_info) return self as result,
+
+  member procedure before_calling_run(self in out nocopy ut_session_info, a_run in ut_run),
+  member procedure after_calling_run (self in out nocopy ut_session_info, a_run in ut_run),
+
+  member procedure before_calling_suite(self in out nocopy ut_session_info, a_suite in ut_logical_suite),
+  member procedure after_calling_suite(self in out nocopy ut_session_info, a_suite in ut_logical_suite),
+
+  member procedure before_calling_executable(self in out nocopy ut_session_info, a_executable in ut_executable),
+  member procedure after_calling_executable (self in out nocopy ut_session_info, a_executable in ut_executable),
+
+  member procedure before_calling_test(self in out nocopy ut_session_info, a_test in ut_test),
+  member procedure after_calling_test (self in out nocopy ut_session_info, a_test in ut_test),
+
+  member procedure on_finalize(self in out nocopy ut_session_info, a_run in ut_run),
+
+  /**
+  * Returns the list of events that are supported by particular implementation of the reporter
+  */
+  overriding member function get_supported_events return ut_varchar2_list,
+
+  /**
+  * Delegates execution of event into individual reporting procedures
+  */
+  overriding member procedure on_event( self in out nocopy ut_session_info, a_event_name varchar2, a_event_item ut_event_item)
+
+) final
+/

--- a/source/core/session_context/ut_session_info.tps
+++ b/source/core/session_context/ut_session_info.tps
@@ -19,9 +19,6 @@ create or replace type ut_session_info under ut_event_listener (
   module             varchar2(4000),
   action             varchar2(4000),
   client_info        varchar2(4000),
-  suite_start_time   timestamp,
-  context_start_time timestamp,
-  test_start_time    timestamp,
   constructor function ut_session_info(self in out nocopy ut_session_info) return self as result,
 
   member procedure before_calling_run(self in out nocopy ut_session_info, a_run in ut_run),

--- a/source/core/types/ut_executable.tpb
+++ b/source/core/types/ut_executable.tpb
@@ -104,9 +104,6 @@ create or replace type body ut_executable is
   begin
     l_start_transaction_id := dbms_transaction.local_transaction_id(true);
 
-    -- report to application_info
-    ut_utils.set_client_info(self.procedure_name);
-
     --listener - before call to executable
     ut_event_manager.trigger_event('before_'||self.executable_type, self);
 
@@ -173,7 +170,6 @@ create or replace type body ut_executable is
     if l_start_transaction_id != l_end_transaction_id or l_end_transaction_id is null then
       a_item.add_transaction_invalidator(self.form_name());
     end if;
-    ut_utils.set_client_info(null);
 
     return l_completed_without_errors;
     

--- a/source/core/types/ut_executable_test.tpb
+++ b/source/core/types/ut_executable_test.tpb
@@ -1,4 +1,21 @@
 create or replace type body ut_executable_test as
+  /*
+  utPLSQL - Version 3
+  Copyright 2016 - 2019 utPLSQL Project
+
+  Licensed under the Apache License, Version 2.0 (the "License"):
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  */
+
   constructor function ut_executable_test(
     self in out nocopy ut_executable_test, a_owner varchar2, a_package varchar2,
     a_procedure_name varchar2, a_executable_type varchar2

--- a/source/core/types/ut_expectation_result.tpb
+++ b/source/core/types/ut_expectation_result.tpb
@@ -24,7 +24,7 @@ create or replace type body ut_expectation_result is
     self.self_type       := $$plsql_unit;
     self.status          := a_status;
     self.description     := a_description;
-    self.message := a_message;
+    self.message         := a_message;
     if self.status = ut_utils.gc_failure and a_include_caller_info then
       self.caller_info   := ut_expectation_processor.who_called_expectation(dbms_utility.format_call_stack());
     end if;

--- a/source/core/types/ut_output_reporter_base.tpb
+++ b/source/core/types/ut_output_reporter_base.tpb
@@ -31,7 +31,14 @@ create or replace type body ut_output_reporter_base is
   overriding member procedure set_reporter_id(self in out nocopy ut_output_reporter_base, a_reporter_id raw) is
   begin
     self.id := a_reporter_id;
-    self.output_buffer.output_id := a_reporter_id;
+    self.output_buffer.init(a_reporter_id);
+  end;
+
+  member function set_reporter_id(self in ut_output_reporter_base, a_reporter_id raw) return ut_output_reporter_base is
+    l_result ut_output_reporter_base := self;
+  begin
+    l_result.set_reporter_id(a_reporter_id);
+    return l_result;
   end;
 
   overriding member procedure before_calling_run(self in out nocopy ut_output_reporter_base, a_run in ut_run) is

--- a/source/core/types/ut_output_reporter_base.tps
+++ b/source/core/types/ut_output_reporter_base.tps
@@ -19,6 +19,7 @@ create or replace type ut_output_reporter_base under ut_reporter_base(
   constructor function ut_output_reporter_base(self in out nocopy ut_output_reporter_base) return self as result,
   member procedure init(self in out nocopy ut_output_reporter_base, a_self_type varchar2, a_output_buffer ut_output_buffer_base := null),
   overriding member procedure set_reporter_id(self in out nocopy ut_output_reporter_base, a_reporter_id raw),
+  member function  set_reporter_id(self in ut_output_reporter_base, a_reporter_id raw) return ut_output_reporter_base,
   overriding member procedure before_calling_run(self in out nocopy ut_output_reporter_base, a_run in ut_run),
   
   member procedure print_text(self in out nocopy ut_output_reporter_base, a_text varchar2, a_item_type varchar2 := null),

--- a/source/core/types/ut_suite.tpb
+++ b/source/core/types/ut_suite.tpb
@@ -43,13 +43,11 @@ create or replace type body ut_suite  as
   begin
     ut_utils.debug_log('ut_suite.execute');
 
-    ut_utils.set_action(self.object_name);
-
     if self.get_disabled_flag() then
       self.mark_as_skipped();
     else
-      ut_event_manager.trigger_event(ut_event_manager.gc_before_suite, self);
       self.start_time := current_timestamp;
+      ut_event_manager.trigger_event(ut_event_manager.gc_before_suite, self);
 
       l_suite_savepoint := self.create_savepoint_if_needed();
 
@@ -82,8 +80,6 @@ create or replace type body ut_suite  as
       self.end_time := current_timestamp;
       ut_event_manager.trigger_event(ut_event_manager.gc_after_suite, self);
     end if;
-
-    ut_utils.set_action(null);
 
     return l_no_errors;
   end;

--- a/source/core/types/ut_test.tpb
+++ b/source/core/types/ut_test.tpb
@@ -56,8 +56,8 @@ create or replace type body ut_test as
     if self.get_disabled_flag() then
       mark_as_skipped();
     else
-      ut_event_manager.trigger_event(ut_event_manager.gc_before_test, self);
       self.start_time := current_timestamp;
+      ut_event_manager.trigger_event(ut_event_manager.gc_before_test, self);
 
       l_savepoint := self.create_savepoint_if_needed();
 

--- a/source/core/ut_expectation_processor.pkb
+++ b/source/core/ut_expectation_processor.pkb
@@ -78,10 +78,19 @@ create or replace package body ut_expectation_processor as
   end get_failed_expectations;
 
   procedure add_expectation_result(a_expectation_result ut_expectation_result) is
+    l_results ut_varchar2_list;
   begin
-    ut_event_manager.trigger_event(ut_event_manager.gc_debug, a_expectation_result);
-    g_expectations_called.extend;
-    g_expectations_called(g_expectations_called.last) := a_expectation_result;
+    if ut_session_context.is_ut_run then
+      ut_event_manager.trigger_event(ut_event_manager.gc_debug, a_expectation_result);
+      g_expectations_called.extend;
+      g_expectations_called(g_expectations_called.last) := a_expectation_result;
+    else
+      l_results := a_expectation_result.get_result_lines();
+      dbms_output.put_line( upper( ut_utils.test_result_to_char( a_expectation_result.status ) ) || '');
+      for i in 1 .. l_results.count loop
+        dbms_output.put_line( '  ' || l_results(i) );
+      end loop;
+    end if;
   end;
 
   procedure report_failure(a_message in varchar2) is

--- a/source/core/ut_expectation_processor.pkb
+++ b/source/core/ut_expectation_processor.pkb
@@ -90,6 +90,9 @@ create or replace package body ut_expectation_processor as
       for i in 1 .. l_results.count loop
         dbms_output.put_line( '  ' || l_results(i) );
       end loop;
+      if a_expectation_result.caller_info is not null then
+        dbms_output.put_line( ut_utils.indent_lines( a_expectation_result.caller_info, 2, true) );
+      end if;
     end if;
   end;
 
@@ -147,28 +150,55 @@ create or replace package body ut_expectation_processor as
 
   function who_called_expectation(a_call_stack varchar2) return varchar2 is
     l_caller_stack_line          varchar2(4000);
+    l_call_stack                 varchar2(4000);
     l_line_no                    integer;
     l_owner                      varchar2(1000);
     l_object_name                varchar2(1000);
-    l_object_full_name           varchar2(1000);
     l_result                     varchar2(4000);
     -- in 12.2 format_call_stack reportes not only package name, but also the procedure name
     -- when 11g and 12c reports only package name
-    c_expectation_search_pattern constant varchar2(500) :=
-    '(.*\.(UT_EXPECTATION[A-Z0-9#_$]*|UT|UTASSERT2?)(\.[A-Z0-9#_$]+)?\s+)+(.*)';
+    function cut_header_and_expectations( a_stack varchar2 ) return varchar2 is
+    begin
+      return regexp_substr( a_stack, '(.*\.(UT_EXPECTATION[A-Z0-9#_$]*|UT|UTASSERT2?)(\.[A-Z0-9#_$]+)?\s+)+((.|\s)*)', 1, 1, 'm', 4);
+    end;
+    function cut_address_columns( a_stack varchar2 ) return varchar2 is
+    begin
+      return regexp_replace( a_stack, '^(0x)?[0-9a-f]+\s+', '', 1, 0, 'm' );
+    end;
+    function cut_framework_stack( a_stack varchar2 ) return varchar2 is
+    begin
+      return regexp_replace(
+        a_stack,
+        '[0-9]+\s+anonymous\s+block\s+[0-9]+\s+package\s+body\s+sys\.dbms_sql(\.execute)?\s+[0-9]+\s+[0-9_$#a-z ]+\.ut_executable.*',
+        '',
+        1, 1, 'mni'
+        );
+    end;
+    function format_stack( a_stack varchar2 ) return varchar2 is
+    begin
+      return regexp_replace(
+        a_stack,
+        '([0-9]+)\s+(.* )?((anonymous block)|(([0-9_$#a-z]+\.[0-9_$#a-z]+(\.([0-9_$#a-z])+)?)))',
+        'at "\3", line \1', 1, 0, 'i'
+        );
+    end;
   begin
-    l_caller_stack_line    := regexp_substr( a_call_stack, c_expectation_search_pattern, 1, 1, 'm', 4);
+    l_call_stack  := cut_header_and_expectations( a_call_stack );
+    l_call_stack  := cut_address_columns( l_call_stack );
+    l_call_stack := cut_framework_stack( l_call_stack );
+    l_call_stack := format_stack( l_call_stack );
+    l_caller_stack_line    := regexp_substr(l_call_stack,'^(.*)');
     if l_caller_stack_line like '%.%' then
-      l_line_no     := to_number( regexp_substr(l_caller_stack_line,'(0x)?[0-9a-f]+\s+(\d+)',subexpression => 2) );
-      l_owner       := regexp_substr(l_caller_stack_line,'([A-Za-z0-9$#_]+)\.([A-Za-z0-9$#_]|\.)+',subexpression => 1);
-      l_object_name := regexp_substr(l_caller_stack_line,'([A-Za-z0-9$#_]+)\.([A-Za-z0-9$#_]+)',subexpression => 2);
-      l_object_full_name := regexp_substr(l_caller_stack_line,'([A-Za-z0-9$#_]+)\.(([A-Za-z0-9$#_]|\.)+)',subexpression => 2);
-      if l_owner is not null and l_object_name is not null and l_line_no is not null then
-        l_result := 'at "' || l_owner || '.' || l_object_full_name || '", line '|| l_line_no || ' '
-                    || ut_metadata.get_source_definition_line(l_owner, l_object_name, l_line_no);
-      end if;
+      l_line_no          := to_number( regexp_substr( l_caller_stack_line, ', line (\d+)', subexpression => 1 ) );
+      l_owner            := regexp_substr( l_caller_stack_line, 'at "([A-Za-z0-9$#_]+)\.(([A-Za-z0-9$#_]+)(\.([A-Za-z0-9$#_]+))?)", line (\d+)', subexpression => 1 );
+      l_object_name      := regexp_substr( l_caller_stack_line, 'at "([A-Za-z0-9$#_]+)\.(([A-Za-z0-9$#_]+)(\.([A-Za-z0-9$#_]+))?)", line (\d+)', subexpression => 3 );
+      l_result :=
+        l_caller_stack_line || ' ' || rtrim(ut_metadata.get_source_definition_line(l_owner, l_object_name, l_line_no),chr(10))
+        || replace( l_call_stack, l_caller_stack_line );
+    else
+      l_result := l_call_stack;
     end if;
-    return l_result;
+    return rtrim(l_result,chr(10));
   end;
 
   procedure add_warning(a_messsage varchar2) is

--- a/source/core/ut_suite_cache_manager.pkb
+++ b/source/core/ut_suite_cache_manager.pkb
@@ -411,7 +411,7 @@ create or replace package body ut_suite_cache_manager is
       select count( 1 ) into l_count from dual
        where exists(
                select 1
-                 from ut_suite_cache_package c
+                 from ut_suite_cache c
                 where c.object_owner = a_owner_name
                   and c.object_name = a_package_name
                );
@@ -419,7 +419,7 @@ create or replace package body ut_suite_cache_manager is
       select count( 1 ) into l_count from dual
        where exists(
                select 1
-                 from ut_suite_cache_package c
+                 from ut_suite_cache c
                 where c.object_owner = a_owner_name
                );
     end if;

--- a/source/core/ut_utils.pkb
+++ b/source/core/ut_utils.pkb
@@ -446,16 +446,6 @@ create or replace package body ut_utils is
     return l_result;
   end;
 
-  procedure set_action(a_text in varchar2) is
-  begin
-    dbms_application_info.set_module('utPLSQL', a_text);
-  end;
-
-  procedure set_client_info(a_text in varchar2) is
-  begin
-    dbms_application_info.set_client_info(a_text);
-  end;
-
   function to_xpath(a_list varchar2, a_ancestors varchar2 := '/*/') return varchar2 is
     l_xpath varchar2(32767) := a_list;
   begin

--- a/source/core/ut_utils.pks
+++ b/source/core/ut_utils.pks
@@ -295,16 +295,6 @@ create or replace package ut_utils authid definer is
 
   function convert_collection(a_collection ut_varchar2_list) return ut_varchar2_rows;
 
-  /**
-   * Set session's action and module using dbms_application_info
-   */
-  procedure set_action(a_text in varchar2);
-
-  /**
-   * Set session's client info using dbms_application_info
-   */
-  procedure set_client_info(a_text in varchar2);
-
   function to_xpath(a_list varchar2, a_ancestors varchar2 := '/*/') return varchar2;
 
   function to_xpath(a_list ut_varchar2_list, a_ancestors varchar2 := '/*/') return varchar2;

--- a/source/create_grants.sql
+++ b/source/create_grants.sql
@@ -75,6 +75,7 @@ grant execute on &&ut3_owner..ut_expectation_compound to &ut3_user;
 grant execute on &&ut3_owner..ut_expectation_json to &ut3_user;
 
 --matchers
+grant execute on &&ut3_owner..ut_matcher to &ut3_user;
 grant execute on &&ut3_owner..ut_be_between to &ut3_user;
 grant execute on &&ut3_owner..ut_be_empty to &ut3_user;
 grant execute on &&ut3_owner..ut_be_false to &ut3_user;

--- a/source/create_synonyms.sql
+++ b/source/create_synonyms.sql
@@ -91,6 +91,7 @@ create &action_type. synonym &ut3_user.ut_expectation_compound for &&ut3_owner..
 create &action_type. synonym &ut3_user.ut_expectation_json for &&ut3_owner..ut_expectation_json;
 
 --matchers
+create &action_type. synonym &ut3_user.ut_matcher for &&ut3_owner..ut_matcher;
 create &action_type. synonym &ut3_user.be_between for &&ut3_owner..be_between;
 create &action_type. synonym &ut3_user.be_empty for &&ut3_owner..be_empty;
 create &action_type. synonym &ut3_user.be_false for &&ut3_owner..be_false;

--- a/source/expectations/data_values/ut_compound_data_helper.pkb
+++ b/source/expectations/data_values/ut_compound_data_helper.pkb
@@ -608,7 +608,7 @@ create or replace package body ut_compound_data_helper is
   begin
     return 'SQL exception thrown when fetching data from cursor:'||
       ut_utils.remove_error_from_stack(sqlerrm,ut_utils.gc_xml_processing)||chr(10)||
-      ut_expectation_processor.who_called_expectation(a_error_stack)||
+      ut_expectation_processor.who_called_expectation(a_error_stack)||chr(10)||
       'Check the query and data for errors.';   
   end;
 

--- a/source/expectations/data_values/ut_compound_data_value.tpb
+++ b/source/expectations/data_values/ut_compound_data_value.tpb
@@ -16,9 +16,14 @@ create or replace type body ut_compound_data_value as
   limitations under the License.
   */
 
+  member function get_elements_count_info return varchar2 is
+  begin
+    return case when elements_count is null then ' [ null ]' else ' [ count = '||elements_count||' ]' end;
+  end;
+
   overriding member function get_object_info return varchar2 is
   begin
-    return self.data_type||' [ count = '||self.elements_count||' ]';
+    return self.data_type||get_elements_count_info();
   end;
 
   overriding member function is_null return boolean is
@@ -37,7 +42,6 @@ create or replace type body ut_compound_data_value as
   end;
 
   overriding member function to_string return varchar2 is
-    l_results       ut_utils.t_clob_tab;
     l_result        clob;
     l_result_string varchar2(32767);
   begin

--- a/source/expectations/data_values/ut_compound_data_value.tps
+++ b/source/expectations/data_values/ut_compound_data_value.tps
@@ -39,7 +39,8 @@ create or replace type ut_compound_data_value force under ut_data_value(
   * Holds name for the type of compound
   */
   compound_type varchar2(50),
-  
+
+  member function get_elements_count_info return varchar2,
   overriding member function get_object_info return varchar2,
   overriding member function is_null return boolean,
   overriding member function is_diffable return boolean,

--- a/source/expectations/data_values/ut_data_value.tpb
+++ b/source/expectations/data_values/ut_data_value.tpb
@@ -59,7 +59,7 @@ create or replace type body ut_data_value as
         l_result := l_result || chr(10);
       end if;
     else
-      l_result := self.to_string() || ' ' || l_info || ' ';
+      l_result := self.to_string() || ' ' || l_info;
     end if;
     return l_result;
   end;

--- a/source/expectations/data_values/ut_data_value_anydata.tpb
+++ b/source/expectations/data_values/ut_data_value_anydata.tpb
@@ -18,7 +18,7 @@ create or replace type body ut_data_value_anydata as
   
   overriding member function get_object_info return varchar2 is
   begin
-    return self.data_type || case when self.compound_type = 'collection' then ' [ count = '||self.elements_count||' ]' else null end;
+    return self.data_type || case when self.compound_type = 'collection' then self.get_elements_count_info() end;
   end;
     
   member function get_extract_path(a_data_value anydata) return varchar2 is

--- a/source/expectations/data_values/ut_data_value_json.tpb
+++ b/source/expectations/data_values/ut_data_value_json.tpb
@@ -113,9 +113,10 @@ create or replace type body ut_data_value_json as
       ut_utils.append_to_clob(l_result, l_results);
     
     end if;
-    
-    
-    l_result_string := ut_utils.to_string(l_result,null);
+
+    if l_result != empty_clob() then
+      l_result_string := chr(10) || 'Diff:' || ut_utils.to_string(l_result,null);
+    end if;
     dbms_lob.freetemporary(l_result);
     return l_result_string;
   end;

--- a/source/expectations/data_values/ut_data_value_refcursor.tpb
+++ b/source/expectations/data_values/ut_data_value_refcursor.tpb
@@ -220,7 +220,7 @@ create or replace type body ut_data_value_refcursor as
         a_match_options.ordered_columns()
       );
     
-      if l_column_diffs.count > 0 then
+      if l_column_diffs is not empty then
         ut_utils.append_to_clob(l_result,chr(10) || 'Columns:' || chr(10));
         l_other_cols := remove_incomparable_cols( l_other_cols, l_column_diffs );
         l_self_cols  := remove_incomparable_cols( l_self_cols, l_column_diffs );
@@ -267,8 +267,8 @@ create or replace type body ut_data_value_refcursor as
           l_results(l_results.last) := get_diff_message(l_row_diffs(i),a_match_options.unordered);
         end loop;
         ut_utils.append_to_clob(l_result,l_results);
-      else
-        l_message:= chr(10)||'Rows: [  all different ]'||chr(10)||'  All rows are different as the columns position is not matching.';
+      elsif l_column_diffs is not empty then
+        l_message:= chr(10)||'Rows: [ all different ]'||chr(10)||'  All rows are different as the columns position is not matching.';
         ut_utils.append_to_clob( l_result, l_message );
       end if;   
     else
@@ -287,8 +287,9 @@ create or replace type body ut_data_value_refcursor as
       end if;
         
     end if;
-    
-    l_result_string := ut_utils.to_string(l_result,null);
+    if l_result != empty_clob() then
+      l_result_string := chr(10) || 'Diff:' || ut_utils.to_string(l_result,null);
+    end if;
     dbms_lob.freetemporary(l_result);
     return l_result_string;
   end;

--- a/source/expectations/matchers/ut_contain.tpb
+++ b/source/expectations/matchers/ut_contain.tpb
@@ -55,8 +55,7 @@ create or replace type body ut_contain as
   begin
     if self.expected.data_type = a_actual.data_type and self.expected.is_diffable then
       l_result :=
-        'Actual: '||a_actual.get_object_info()||' '||self.description()||': '||self.expected.get_object_info()
-        ||  chr(10) || 'Diff:'
+        'Actual: '||a_actual.get_object_info()||self.description()||': '||self.expected.get_object_info()
         ||  treat(expected as ut_data_value_refcursor).diff( a_actual, self.options );
     else
       l_result := (self as ut_matcher).failure_message(a_actual) || ': '|| self.expected.to_string_report();

--- a/source/expectations/matchers/ut_equal.tpb
+++ b/source/expectations/matchers/ut_equal.tpb
@@ -244,16 +244,15 @@ create or replace type body ut_equal as
   begin
     if self.expected.data_type = a_actual.data_type and self.expected.is_diffable then
         l_result :=
-          'Actual: '||a_actual.get_object_info()||' '||self.description()||': '||self.expected.get_object_info()
-          || chr(10) || 'Diff:' ||  
-      case 
-        when  self.expected is of (ut_data_value_refcursor) then
-          treat(expected as ut_data_value_refcursor).diff( a_actual, options )
-        when self.expected is of (ut_data_value_json) then
-          treat(expected as ut_data_value_json).diff( a_actual, options )
-      else
-          expected.diff( a_actual, options )
-      end;
+          'Actual: '||a_actual.get_object_info()||self.description()||': '||self.expected.get_object_info()
+          ||case
+              when  self.expected is of (ut_data_value_refcursor) then
+                treat(expected as ut_data_value_refcursor).diff( a_actual, options )
+              when self.expected is of (ut_data_value_json) then
+                treat(expected as ut_data_value_json).diff( a_actual, options )
+            else
+                expected.diff( a_actual, options )
+            end;
     else
       l_result := (self as ut_matcher).failure_message(a_actual) || ': '|| self.expected.to_string_report();
     end if;

--- a/source/expectations/matchers/ut_matcher.tpb
+++ b/source/expectations/matchers/ut_matcher.tpb
@@ -40,12 +40,12 @@ create or replace type body ut_matcher as
 
   member function description return varchar2 is
   begin
-    return 'was expected to '||name();
+    return ' was expected to '||name();
   end;
 
   member function description_when_negated return varchar2 is
   begin
-    return 'was expected not to '||name();
+    return ' was expected not to '||name();
   end;
 
   member function error_message(a_actual ut_data_value) return varchar2 is

--- a/source/expectations/ut_expectation.tpb
+++ b/source/expectations/ut_expectation.tpb
@@ -81,6 +81,16 @@ create or replace type body ut_expectation as
     self.not_to( ut_be_false() );
   end;
 
+  member procedure to_be_empty(self in ut_expectation) is
+  begin
+    self.to_( ut_be_empty() );
+  end;
+
+  member procedure not_to_be_empty(self in ut_expectation) is
+  begin
+    self.not_to( ut_be_empty() );
+  end;
+
   member procedure to_equal(self in ut_expectation, a_expected anydata, a_nulls_are_equal boolean := null) is
   begin
     self.to_( ut_equal(a_expected, a_nulls_are_equal) );

--- a/source/expectations/ut_expectation.tps
+++ b/source/expectations/ut_expectation.tps
@@ -33,6 +33,9 @@ create or replace type ut_expectation authid current_user as object(
   member procedure not_to_be_true(self in ut_expectation),
   member procedure not_to_be_false(self in ut_expectation),
 
+  member procedure to_be_empty(self in ut_expectation),
+  member procedure not_to_be_empty(self in ut_expectation),
+
   -- this is done to provide strong type comparison. other comporators should be implemented in the type-specific classes
   member procedure to_equal(self in ut_expectation, a_expected anydata, a_nulls_are_equal boolean := null),
   member procedure to_equal(self in ut_expectation, a_expected anydata, a_exclude varchar2, a_nulls_are_equal boolean := null),

--- a/source/expectations/ut_expectation_compound.tpb
+++ b/source/expectations/ut_expectation_compound.tpb
@@ -23,16 +23,6 @@ create or replace type body ut_expectation_compound as
     return;
   end;
 
-  member procedure to_be_empty(self in ut_expectation_compound) is
-  begin
-    self.to_( ut_be_empty() );
-  end;
-
-  member procedure not_to_be_empty(self in ut_expectation_compound) is
-  begin
-    self.not_to( ut_be_empty() );
-  end;
-
   member procedure to_have_count(self in ut_expectation_compound, a_expected integer) is
   begin
     self.to_( ut_have_count(a_expected) );

--- a/source/expectations/ut_expectation_compound.tps
+++ b/source/expectations/ut_expectation_compound.tps
@@ -19,8 +19,6 @@ create or replace type ut_expectation_compound force under ut_expectation(
 
   constructor function ut_expectation_compound(self in out nocopy ut_expectation_compound, a_actual_data ut_data_value, a_description varchar2) return self as result,
 
-  member procedure to_be_empty(self in ut_expectation_compound),
-  member procedure not_to_be_empty(self in ut_expectation_compound),
   member procedure to_have_count(self in ut_expectation_compound, a_expected integer),
   member procedure not_to_have_count(self in ut_expectation_compound, a_expected integer),
 

--- a/source/expectations/ut_expectation_json.tpb
+++ b/source/expectations/ut_expectation_json.tpb
@@ -23,16 +23,6 @@ create or replace type body ut_expectation_json as
     return;
   end;
 
-  member procedure to_be_empty(self in ut_expectation_json) is
-  begin
-    self.to_( ut_be_empty() );
-  end;
-
-  member procedure not_to_be_empty(self in ut_expectation_json) is
-  begin
-    self.not_to( ut_be_empty() );
-  end;
-
   member function to_equal(a_expected json_element_t, a_nulls_are_equal boolean := null) return ut_expectation_json is
     l_result ut_expectation_json := self;
   begin

--- a/source/expectations/ut_expectation_json.tps
+++ b/source/expectations/ut_expectation_json.tps
@@ -19,8 +19,6 @@ create or replace type ut_expectation_json under ut_expectation(
 
   constructor function ut_expectation_json(self in out nocopy ut_expectation_json, a_actual_data ut_data_value, a_description varchar2) return self as result,
 
-  member procedure to_be_empty(self in ut_expectation_json),
-  member procedure not_to_be_empty(self in ut_expectation_json),
   member function  to_equal(a_expected json_element_t , a_nulls_are_equal boolean := null) return ut_expectation_json,
   member function  not_to_equal(a_expected json_element_t , a_nulls_are_equal boolean := null) return ut_expectation_json,
   member procedure to_have_count(self in ut_expectation_json, a_expected integer),

--- a/source/install.sql
+++ b/source/install.sql
@@ -31,9 +31,17 @@ prompt &&line_separator
 alter session set current_schema = &&ut3_owner;
 
 @@check_object_grants.sql
-@@check_sys_grants.sql "'CREATE TYPE','CREATE VIEW','CREATE SYNONYM','CREATE SEQUENCE','CREATE PROCEDURE','CREATE TABLE'"
+@@check_sys_grants.sql "'CREATE TYPE','CREATE VIEW','CREATE SYNONYM','CREATE SEQUENCE','CREATE PROCEDURE','CREATE TABLE', 'CREATE CONTEXT'"
 --set define off
 
+begin
+  $if $$self_testing_install $then
+    execute immediate 'create or replace context &&ut3_owner._info using &&ut3_owner..ut_session_context';
+  $else
+    execute immediate 'create or replace context ut3_info using &&ut3_owner..ut_session_context';
+  $end
+end;
+/
 
 --dbms_output buffer cache table
 @@install_component.sql 'core/ut_dbms_output_cache.sql'
@@ -98,6 +106,11 @@ alter session set current_schema = &&ut3_owner;
 @@install_component.sql 'expectations/data_values/ut_key_anyval_pairs.tps'
 @@install_component.sql 'expectations/data_values/ut_key_anyvalues.tps'
 
+--session_context
+@@install_component.sql  'core/session_context/ut_session_context.pks'
+@@install_component.sql  'core/session_context/ut_session_context.pkb'
+@@install_component.sql  'core/session_context/ut_session_info.tps'
+@@install_component.sql  'core/session_context/ut_session_info.tpb'
 
 --output buffer table
 @@install_component.sql 'core/output_buffers/ut_output_buffer_info_tmp.sql'

--- a/source/uninstall_objects.sql
+++ b/source/uninstall_objects.sql
@@ -307,6 +307,10 @@ drop table ut_output_clob_buffer_tmp purge;
 
 drop table ut_output_buffer_info_tmp purge;
 
+drop package ut_session_context;
+
+drop type ut_session_info force;
+
 drop type ut_output_data_rows force;
 
 drop type ut_output_data_row force;

--- a/test/install_ut3_user_tests.sql
+++ b/test/install_ut3_user_tests.sql
@@ -12,6 +12,8 @@ prompt Install user tests
 @@ut3_user/helpers/some_items.tps
 @@ut3_user/helpers/some_object.tps
 @@ut3_user/test_user.pks
+@@ut3_user/expectations.pks
+@@ut3_user/expectations.pkb
 @@ut3_user/expectations/unary/test_expect_not_to_be_null.pks
 @@ut3_user/expectations/unary/test_expect_to_be_null.pks
 @@ut3_user/expectations/unary/test_expect_to_be_empty.pks

--- a/test/ut3_tester/core/expectations/test_expectation_processor.pkb
+++ b/test/ut3_tester/core/expectations/test_expectation_processor.pkb
@@ -1,5 +1,7 @@
 create or replace package body test_expectation_processor is
 
+  gc_user constant varchar2(128) := sys_context('userenv','current_schema');
+
   procedure who_called_expectation is
     l_stack_trace varchar2(4000);
     l_source_line varchar2(4000);
@@ -11,7 +13,9 @@ create or replace package body test_expectation_processor is
 353dfeb2f8        26  SCH_TEST.UT_EXPECTATION_RESULT
 cba249ce0       112  SCH_TEST.UT_EXPECTATION
 3539881cf0        21  SCH_TEST.UT_EXPECTATION_NUMBER
-351a608008        28  package body SCH_TEST.TPKG_PRIOR_YEAR_GENERATION
+351a608008         7  package body ]'||gc_user||q'[.TEST_EXPECTATION_PROCESSOR
+351a608018        12  package body ]'||gc_user||q'[.TEST_EXPECTATION_PROCESSOR
+351a608018        24  package body ]'||gc_user||q'[.TEST_EXPECTATION_PROCESSOR
 351a6862b8         6  anonymous block
 351fe31010      1825  package body SYS.DBMS_SQL
 20befbe4d8       129  SCH_TEST.UT_EXECUTABLE
@@ -30,7 +34,9 @@ cba24bfd0        75  SCH_TEST.UT_LOGICAL_SUITE
 ]';
     ut.expect(
         ut3.ut_expectation_processor.who_called_expectation(l_stack_trace)
-    ).to_be_like('at "SCH_TEST.TPKG_PRIOR_YEAR_GENERATION", line 28 %');
+    ).to_equal('at "'||gc_user||'.TEST_EXPECTATION_PROCESSOR", line 7 l_source_line varchar2(4000);
+at "'||gc_user||'.TEST_EXPECTATION_PROCESSOR", line 12
+at "'||gc_user||'.TEST_EXPECTATION_PROCESSOR", line 24');
   end;
 
 
@@ -41,30 +47,24 @@ cba24bfd0        75  SCH_TEST.UT_LOGICAL_SUITE
     l_stack_trace := q'[----- PL/SQL Call Stack -----
   object      line  object
   handle    number  name
-34f88e4420       124  package body SCH_TEST.UT_EXPECTATION_PROCESSOR
-353dfeb2f8        26  SCH_TEST.UT_EXPECTATION_RESULT
-cba249ce0       112  SCH_TEST.UT_EXPECTATION
-3539881cf0        21  SCH_TEST.UT_EXPECTATION_NUMBER
-351a608008        28  package body SCH_TEST.TPKG_PRIOR_YEAR_GENERATION
-351a6862b8         6  anonymous block
-351fe31010      1825  package body SYS.DBMS_SQL
-20befbe4d8       129  SCH_TEST.UT_EXECUTABLE
-20befbe4d8        65  SCH_TEST.UT_EXECUTABLE
-34f8ab7cd8        80  SCH_TEST.UT_TEST
-34f8ab98f0        48  SCH_TEST.UT_SUITE_ITEM
-34f8ab9b10        74  SCH_TEST.UT_SUITE
-34f8ab98f0        48  SCH_TEST.UT_SUITE_ITEM
-cba24bfd0        75  SCH_TEST.UT_LOGICAL_SUITE
-353dfecf30        59  SCH_TEST.UT_RUN
-34f8ab98f0        48  SCH_TEST.UT_SUITE_ITEM
-357f5421e8        77  package body SCH_TEST.UT_RUNNER
-357f5421e8       111  package body SCH_TEST.UT_RUNNER
-20be951ab0       292  package body SCH_TEST.UT
-20be951ab0       320  package body SCH_TEST.UT
+0x80e701d8        26  UT3.UT_EXPECTATION_RESULT
+0x85e10150       112  UT3.UT_EXPECTATION
+0x8b54bad8        21  UT3.UT_EXPECTATION_NUMBER
+0x85cfd238        20  package body UT3.UT_EXAMPLETEST
+0x85def380         6  anonymous block
+0x85e93750      1825  package body SYS.DBMS_SQL
+0x80f4f608       129  UT3.UT_EXECUTABLE
+0x80f4f608        65  UT3.UT_EXECUTABLE
+0x8a116010        76  UT3.UT_TEST
+0x8a3348a0        48  UT3.UT_SUITE_ITEM
+0x887e9948        67  UT3.UT_LOGICAL_SUITE
+0x8a26de20        59  UT3.UT_RUN
+0x8a3348a0        48  UT3.UT_SUITE_ITEM
+0x838d17c0        28  anonymous block
 ]';
     ut.expect(
         ut3.ut_expectation_processor.who_called_expectation(l_stack_trace)
-    ).to_be_like('at "SCH_TEST.TPKG_PRIOR_YEAR_GENERATION", line 28 %');
+    ).to_be_like('at "UT3.UT_EXAMPLETEST", line 20 %');
   end;
 
 end;

--- a/test/ut3_tester/core/expectations/test_expectation_processor.pks
+++ b/test/ut3_tester/core/expectations/test_expectation_processor.pks
@@ -3,13 +3,16 @@ create or replace package test_expectation_processor is
   --%suite(expectation_processor)
   --%suitepath(utplsql.ut3_tester.core.expectations)
 
-  --%context(who_called_expectation)
+  --%beforeall(ut3_tester_helper.main_helper.set_ut_run_context)
+  --%afterall(ut3_tester_helper.main_helper.clear_ut_run_context)
 
-  --%test(parses stack trace and returns object and line that called expectation)
-  procedure who_called_expectation;
+  --%context(who_called_expectation_in_test)
 
-  --%test(parses stack trace containing 0x and returns object and line that called expectation)
+  --%test(parses stack trace containing 0x and returns objects and line that called expectation)
   procedure who_called_expectation_0x;
+
+  --%test(parses stack trace and returns objects and line that called expectation)
+  procedure who_called_expectation;
 
   --%endcontext
 

--- a/test/ut3_tester_helper/main_helper.pkb
+++ b/test/ut3_tester_helper/main_helper.pkb
@@ -153,6 +153,16 @@ create or replace package body main_helper is
   begin
      ut3.ut_utils.append_to_list(a_list,a_items);
   end;
-  
+
+  procedure set_ut_run_context is
+  begin
+    ut3.ut_session_context.set_context('RUN_PATHS',' ');
+  end;
+
+  procedure clear_ut_run_context is
+  begin
+    ut3.ut_session_context.clear_all_context;
+  end;
+
 end;
 /

--- a/test/ut3_tester_helper/main_helper.pks
+++ b/test/ut3_tester_helper/main_helper.pks
@@ -44,6 +44,10 @@ create or replace package main_helper is
   procedure append_to_list(a_list in out nocopy ut3.ut_varchar2_rows, a_item clob);
 
   procedure append_to_list(a_list in out nocopy ut3.ut_varchar2_rows, a_items ut3.ut_varchar2_rows);
+
+  procedure set_ut_run_context;
+
+  procedure clear_ut_run_context;
   
 end;
 /

--- a/test/ut3_user/api/test_ut_run.pkb
+++ b/test/ut3_user/api/test_ut_run.pkb
@@ -1164,7 +1164,6 @@ Failures:%
         ||'%BEFORE_SUITE:SUITE_PACKAGE='||gc_owner||'.check_context'
         ||'%BEFORE_SUITE:SUITE_PATH=some.suite.path.check_context'
         ||'%BEFORE_SUITE:SUITE_START_TIME='||to_char(current_timestamp,'yyyy-mm-dd"T"hh24:mi')
-        ||'%BEFORE_SUITE:TIME_IN_SUITE=+000000000 00:00:0'
         ||'%APPLICATION_INFO:MODULE=utPLSQL'
         ||'%APPLICATION_INFO:ACTION=check_context'
         ||'%APPLICATION_INFO:CLIENT_INFO=before_suite%'
@@ -1187,8 +1186,6 @@ Failures:%
         ||'%BEFORE_CONTEXT:SUITE_PACKAGE='||gc_owner||'.check_context'
         ||'%BEFORE_CONTEXT:SUITE_PATH=some.suite.path.check_context'
         ||'%BEFORE_CONTEXT:SUITE_START_TIME='||to_char(current_timestamp,'yyyy-mm-dd"T"hh24:mi')
-        ||'%BEFORE_CONTEXT:TIME_IN_CONTEXT=+000000000 00:00:0'
-        ||'%BEFORE_CONTEXT:TIME_IN_SUITE=+000000000 00:00:0'
         ||'%APPLICATION_INFO:MODULE=utPLSQL'
         ||'%APPLICATION_INFO:ACTION=check_context'
         ||'%APPLICATION_INFO:CLIENT_INFO=before_context%'
@@ -1213,9 +1210,6 @@ Failures:%
         ||'%BEFORE_EACH_TEST:TEST_DESCRIPTION=Some test description'
         ||'%BEFORE_EACH_TEST:TEST_NAME='||gc_owner||'.check_context.the_test'
         ||'%BEFORE_EACH_TEST:TEST_START_TIME='||to_char(current_timestamp,'yyyy-mm-dd"T"hh24:mi')
-        ||'%BEFORE_EACH_TEST:TIME_IN_CONTEXT=+000000000 00:00:0%'
-        ||'%BEFORE_EACH_TEST:TIME_IN_SUITE=+000000000 00:00:0%'
-        ||'%BEFORE_EACH_TEST:TIME_IN_TEST=+000000000 00:00:0%'
         ||'%APPLICATION_INFO:MODULE=utPLSQL'
         ||'%APPLICATION_INFO:ACTION=check_context'
         ||'%APPLICATION_INFO:CLIENT_INFO=before_each_test%'
@@ -1239,9 +1233,6 @@ Failures:%
         ||'%BEFORE_TEST:TEST_DESCRIPTION=Some test description'
         ||'%BEFORE_TEST:TEST_NAME='||gc_owner||'.check_context.the_test'
         ||'%BEFORE_TEST:TEST_START_TIME='||to_char(current_timestamp,'yyyy-mm-dd"T"hh24:mi')
-        ||'%BEFORE_TEST:TIME_IN_CONTEXT=+000000000 00:00:0%'
-        ||'%BEFORE_TEST:TIME_IN_SUITE=+000000000 00:00:0%'
-        ||'%BEFORE_TEST:TIME_IN_TEST=+000000000 00:00:0%'
         ||'%APPLICATION_INFO:MODULE=utPLSQL'
         ||'%APPLICATION_INFO:ACTION=check_context'
         ||'%APPLICATION_INFO:CLIENT_INFO=before_test%'
@@ -1265,9 +1256,6 @@ Failures:%
         ||'%THE_TEST:TEST_DESCRIPTION=Some test description'
         ||'%THE_TEST:TEST_NAME='||gc_owner||'.check_context.the_test'
         ||'%THE_TEST:TEST_START_TIME='||to_char(current_timestamp,'yyyy-mm-dd"T"hh24:mi')
-        ||'%THE_TEST:TIME_IN_CONTEXT=+000000000 00:00:0%'
-        ||'%THE_TEST:TIME_IN_SUITE=+000000000 00:00:0%'
-        ||'%THE_TEST:TIME_IN_TEST=+000000000 00:00:0%'
         ||'%APPLICATION_INFO:MODULE=utPLSQL'
         ||'%APPLICATION_INFO:ACTION=check_context'
         ||'%APPLICATION_INFO:CLIENT_INFO=the_test%'
@@ -1291,9 +1279,6 @@ Failures:%
         ||'%AFTER_TEST:TEST_DESCRIPTION=Some test description'
         ||'%AFTER_TEST:TEST_NAME='||gc_owner||'.check_context.the_test'
         ||'%AFTER_TEST:TEST_START_TIME='||to_char(current_timestamp,'yyyy-mm-dd"T"hh24:mi')
-        ||'%AFTER_TEST:TIME_IN_CONTEXT=+000000000 00:00:0%'
-        ||'%AFTER_TEST:TIME_IN_SUITE=+000000000 00:00:0%'
-        ||'%AFTER_TEST:TIME_IN_TEST=+000000000 00:00:0%'
         ||'%APPLICATION_INFO:MODULE=utPLSQL'
         ||'%APPLICATION_INFO:ACTION=check_context'
         ||'%APPLICATION_INFO:CLIENT_INFO=after_test%'
@@ -1317,9 +1302,6 @@ Failures:%
         ||'%AFTER_EACH_TEST:TEST_DESCRIPTION=Some test description'
         ||'%AFTER_EACH_TEST:TEST_NAME='||gc_owner||'.check_context.the_test'
         ||'%AFTER_EACH_TEST:TEST_START_TIME='||to_char(current_timestamp,'yyyy-mm-dd"T"hh24:mi')
-        ||'%AFTER_EACH_TEST:TIME_IN_CONTEXT=+000000000 00:00:0%'
-        ||'%AFTER_EACH_TEST:TIME_IN_SUITE=+000000000 00:00:0%'
-        ||'%AFTER_EACH_TEST:TIME_IN_TEST=+000000000 00:00:0%'
         ||'%APPLICATION_INFO:MODULE=utPLSQL'
         ||'%APPLICATION_INFO:ACTION=check_context'
         ||'%APPLICATION_INFO:CLIENT_INFO=after_each_test%'
@@ -1340,8 +1322,6 @@ Failures:%
         ||'%AFTER_CONTEXT:SUITE_PACKAGE='||gc_owner||'.check_context'
         ||'%AFTER_CONTEXT:SUITE_PATH=some.suite.path.check_context'
         ||'%AFTER_CONTEXT:SUITE_START_TIME='||to_char(current_timestamp,'yyyy-mm-dd"T"hh24:mi')
-        ||'%AFTER_CONTEXT:TIME_IN_CONTEXT=+000000000 00:00:0%'
-        ||'%AFTER_CONTEXT:TIME_IN_SUITE=+000000000 00:00:0%'
         ||'%APPLICATION_INFO:MODULE=utPLSQL'
         ||'%APPLICATION_INFO:ACTION=check_context'
         ||'%APPLICATION_INFO:CLIENT_INFO=after_context%'
@@ -1359,7 +1339,6 @@ Failures:%
         ||'%AFTER_SUITE:SUITE_PACKAGE='||gc_owner||'.check_context'
         ||'%AFTER_SUITE:SUITE_PATH=some.suite.path.check_context'
         ||'%AFTER_SUITE:SUITE_START_TIME='||to_char(current_timestamp,'yyyy-mm-dd"T"hh24:mi')
-        ||'%AFTER_SUITE:TIME_IN_SUITE=+000000000 00:00:0%'
         ||'%APPLICATION_INFO:MODULE=utPLSQL'
         ||'%APPLICATION_INFO:ACTION=check_context'
         ||'%APPLICATION_INFO:CLIENT_INFO=after_suite%'

--- a/test/ut3_user/api/test_ut_run.pkb
+++ b/test/ut3_user/api/test_ut_run.pkb
@@ -1,6 +1,11 @@
 create or replace package body test_ut_run is
 
-  g_owner varchar2(250) := sys_context('userenv', 'current_schema');
+  gc_owner               constant varchar2(250) := sys_context('userenv', 'current_schema');
+  gc_module              constant varchar2(32767) := 'test module';
+  gc_action              constant varchar2(32767) := 'test action';
+  gc_client_info         constant varchar2(32767) := 'test client info';
+
+  g_context_test_results clob;
 
   procedure clear_expectations is
   begin
@@ -746,7 +751,7 @@ Failures:%
     l_expected   clob;
   begin
     select * bulk collect into l_results
-      from table ( ut3.ut.run( g_owner||'.'||g_owner ) );
+      from table ( ut3.ut.run( gc_owner||'.'||gc_owner ) );
     l_expected := '%1 tests, 0 failed, 0 errored, 0 disabled, 0 warning(s)%';
     ut.expect(ut3_tester_helper.main_helper.table_to_clob(l_results) ).to_be_like( l_expected );
   end;
@@ -755,7 +760,7 @@ Failures:%
     pragma autonomous_transaction;
   begin
     execute immediate '
-    create or replace package '||g_owner||'.'||g_owner||' as
+    create or replace package '||gc_owner||'.'||gc_owner||' as
       --%suite
 
       --%test
@@ -763,7 +768,7 @@ Failures:%
     end;';
 
     execute immediate '
-    create or replace package body '||g_owner||'.'||g_owner||' as
+    create or replace package body '||gc_owner||'.'||gc_owner||' as
       procedure sample_test is begin ut.expect(1).to_equal(1); end;
     end;';
 
@@ -772,7 +777,7 @@ Failures:%
   procedure drop_schema_name_package is
     pragma autonomous_transaction;
   begin
-    execute immediate 'drop package '||g_owner||'.'||g_owner;
+    execute immediate 'drop package '||gc_owner||'.'||gc_owner;
   end;
 
   procedure run_with_random_order is
@@ -1015,6 +1020,378 @@ Failures:%
     ut.expect(  ut3_tester_helper.main_helper.table_to_clob(l_results) ).not_to_be_like( '%test_package_2.test2%executed%' );
     ut.expect(  ut3_tester_helper.main_helper.table_to_clob(l_results) ).not_to_be_like( '%test_package_3%' );
   end;
-  
+
+  procedure set_application_info is
+  begin
+    dbms_application_info.set_module( gc_module, gc_action );
+    dbms_application_info.set_client_info( gc_client_info );
+  end;
+
+  procedure create_context_test_suite is
+    pragma autonomous_transaction;
+  begin
+    execute immediate q'[
+      create or replace package check_context is
+        --%suite(Suite description)
+        --%suitepath(some.suite.path)
+
+        --%beforeall
+        procedure before_suite;
+
+        --%context(some_context)
+
+          --%displayname(context description)
+
+          --%beforeall
+          procedure before_context;
+
+          --%beforeeach
+          procedure before_each_test;
+
+          --%test(Some test description)
+          --%beforetest(before_test)
+          --%aftertest(after_test)
+          procedure the_test;
+          procedure before_test;
+          procedure after_test;
+
+          --%aftereach
+          procedure after_each_test;
+
+          --%afterall
+          procedure after_context;
+
+        --%endcontext
+
+
+        --%afterall
+        procedure after_suite;
+
+      end;]';
+    execute immediate q'[
+      create or replace package body check_context is
+
+        procedure print_context( a_procedure_name varchar2 ) is
+          l_results      ut_varchar2_rows;
+          l_module       varchar2(32767);
+          l_action       varchar2(32767);
+          l_client_info  varchar2(32767);
+        begin
+          select attribute||'='||value
+          bulk collect into l_results
+           from session_context where namespace = 'UT3_INFO'
+          order by attribute;
+          for i in 1 .. l_results.count loop
+            dbms_output.put_line( upper(a_procedure_name) ||':'|| l_results(i) );
+          end loop;
+          dbms_application_info.read_module( l_module, l_action );
+          dbms_application_info.read_client_info( l_client_info );
+
+          dbms_output.put_line( 'APPLICATION_INFO:MODULE=' || l_module );
+          dbms_output.put_line( 'APPLICATION_INFO:ACTION=' || l_action );
+          dbms_output.put_line( 'APPLICATION_INFO:CLIENT_INFO=' || l_client_info );
+        end;
+
+        procedure before_suite is
+        begin
+          print_context('before_suite');
+        end;
+
+        procedure before_context is
+        begin
+          print_context('before_context');
+        end;
+
+        procedure before_each_test is
+        begin
+          print_context('before_each_test');
+        end;
+
+        procedure the_test is
+        begin
+          print_context('the_test');
+        end;
+
+        procedure before_test is
+        begin
+          print_context('before_test');
+        end;
+
+        procedure after_test is
+        begin
+          print_context('after_test');
+        end;
+
+        procedure after_each_test is
+        begin
+          print_context('after_each_test');
+        end;
+
+        procedure after_context is
+        begin
+          print_context('after_context');
+        end;
+
+        procedure after_suite is
+        begin
+          print_context('after_suite');
+        end;
+
+      end;]';
+  end;
+
+  procedure drop_context_test_suite is
+    pragma autonomous_transaction;
+  begin
+    execute immediate q'[drop package check_context]';
+  end;
+
+  procedure run_context_test_suite is
+    l_lines  ut3.ut_varchar2_list;
+  begin
+    select * bulk collect into l_lines from table(ut3.ut.run('check_context'));
+    g_context_test_results := ut3_tester_helper.main_helper.table_to_clob(l_lines);
+  end;
+
+
+  procedure sys_ctx_on_suite_beforeall is
+  begin
+    ut.expect(g_context_test_results).to_be_like(
+      '%BEFORE_SUITE:CURRENT_EXECUTABLE_NAME='||gc_owner||'.check_context.before_suite'
+        ||'%BEFORE_SUITE:CURRENT_EXECUTABLE_TYPE=beforeall'
+        ||'%BEFORE_SUITE:RUN_PATHS=check_context'
+        ||'%BEFORE_SUITE:SUITE_DESCRIPTION=Suite description'
+        ||'%BEFORE_SUITE:SUITE_PACKAGE='||gc_owner||'.check_context'
+        ||'%BEFORE_SUITE:SUITE_PATH=some.suite.path.check_context'
+        ||'%BEFORE_SUITE:SUITE_START_TIME='||to_char(current_timestamp,'yyyy-mm-dd"T"hh24:mi')
+        ||'%BEFORE_SUITE:TIME_IN_SUITE=+000000000 00:00:0'
+        ||'%APPLICATION_INFO:MODULE=utPLSQL'
+        ||'%APPLICATION_INFO:ACTION=check_context'
+        ||'%APPLICATION_INFO:CLIENT_INFO=before_suite%'
+      );
+    ut.expect(g_context_test_results).not_to_be_like('%BEFORE_SUITE:CONTEXT_%');
+    ut.expect(g_context_test_results).not_to_be_like('%BEFORE_SUITE:TEST_%');
+  end;
+
+  procedure sys_ctx_on_context_beforeall is
+  begin
+    ut.expect(g_context_test_results).to_be_like(
+      '%BEFORE_CONTEXT:CONTEXT_DESCRIPTION=context description'
+        ||'%BEFORE_CONTEXT:CONTEXT_NAME=some_context'
+        ||'%BEFORE_CONTEXT:CONTEXT_PATH=some.suite.path.check_context.some_context'
+        ||'%BEFORE_CONTEXT:CONTEXT_START_TIME='||to_char(current_timestamp,'yyyy-mm-dd"T"hh24:mi')
+        ||'%BEFORE_CONTEXT:CURRENT_EXECUTABLE_NAME='||gc_owner||'.check_context.before_context'
+        ||'%BEFORE_CONTEXT:CURRENT_EXECUTABLE_TYPE=beforeall'
+        ||'%BEFORE_CONTEXT:RUN_PATHS=check_context'
+        ||'%BEFORE_CONTEXT:SUITE_DESCRIPTION=Suite description'
+        ||'%BEFORE_CONTEXT:SUITE_PACKAGE='||gc_owner||'.check_context'
+        ||'%BEFORE_CONTEXT:SUITE_PATH=some.suite.path.check_context'
+        ||'%BEFORE_CONTEXT:SUITE_START_TIME='||to_char(current_timestamp,'yyyy-mm-dd"T"hh24:mi')
+        ||'%BEFORE_CONTEXT:TIME_IN_CONTEXT=+000000000 00:00:0'
+        ||'%BEFORE_CONTEXT:TIME_IN_SUITE=+000000000 00:00:0'
+        ||'%APPLICATION_INFO:MODULE=utPLSQL'
+        ||'%APPLICATION_INFO:ACTION=check_context'
+        ||'%APPLICATION_INFO:CLIENT_INFO=before_context%'
+      );
+    ut.expect(g_context_test_results).not_to_be_like('%BEFORE_CONTEXT:TEST_%');
+  end;
+
+  procedure sys_ctx_on_beforeeach is
+  begin
+    ut.expect(g_context_test_results).to_be_like(
+      '%BEFORE_EACH_TEST:CONTEXT_DESCRIPTION=context description'
+        ||'%BEFORE_EACH_TEST:CONTEXT_NAME=some_context'
+        ||'%BEFORE_EACH_TEST:CONTEXT_PATH=some.suite.path.check_context.some_context'
+        ||'%BEFORE_EACH_TEST:CONTEXT_START_TIME='||to_char(current_timestamp,'yyyy-mm-dd"T"hh24:mi')
+        ||'%BEFORE_EACH_TEST:CURRENT_EXECUTABLE_NAME='||gc_owner||'.check_context.before_each_test'
+        ||'%BEFORE_EACH_TEST:CURRENT_EXECUTABLE_TYPE=beforeeach'
+        ||'%BEFORE_EACH_TEST:RUN_PATHS=check_context'
+        ||'%BEFORE_EACH_TEST:SUITE_DESCRIPTION=Suite description'
+        ||'%BEFORE_EACH_TEST:SUITE_PACKAGE='||gc_owner||'.check_context'
+        ||'%BEFORE_EACH_TEST:SUITE_PATH=some.suite.path.check_context'
+        ||'%BEFORE_EACH_TEST:SUITE_START_TIME='||to_char(current_timestamp,'yyyy-mm-dd"T"hh24:mi')
+        ||'%BEFORE_EACH_TEST:TEST_DESCRIPTION=Some test description'
+        ||'%BEFORE_EACH_TEST:TEST_NAME='||gc_owner||'.check_context.the_test'
+        ||'%BEFORE_EACH_TEST:TEST_START_TIME='||to_char(current_timestamp,'yyyy-mm-dd"T"hh24:mi')
+        ||'%BEFORE_EACH_TEST:TIME_IN_CONTEXT=+000000000 00:00:0%'
+        ||'%BEFORE_EACH_TEST:TIME_IN_SUITE=+000000000 00:00:0%'
+        ||'%BEFORE_EACH_TEST:TIME_IN_TEST=+000000000 00:00:0%'
+        ||'%APPLICATION_INFO:MODULE=utPLSQL'
+        ||'%APPLICATION_INFO:ACTION=check_context'
+        ||'%APPLICATION_INFO:CLIENT_INFO=before_each_test%'
+      );
+  end;
+
+  procedure sys_ctx_on_beforetest is
+  begin
+    ut.expect(g_context_test_results).to_be_like(
+      '%BEFORE_TEST:CONTEXT_DESCRIPTION=context description'
+        ||'%BEFORE_TEST:CONTEXT_NAME=some_context'
+        ||'%BEFORE_TEST:CONTEXT_PATH=some.suite.path.check_context.some_context'
+        ||'%BEFORE_TEST:CONTEXT_START_TIME='||to_char(current_timestamp,'yyyy-mm-dd"T"hh24:mi')
+        ||'%BEFORE_TEST:CURRENT_EXECUTABLE_NAME='||gc_owner||'.check_context.before_test'
+        ||'%BEFORE_TEST:CURRENT_EXECUTABLE_TYPE=beforetest'
+        ||'%BEFORE_TEST:RUN_PATHS=check_context'
+        ||'%BEFORE_TEST:SUITE_DESCRIPTION=Suite description'
+        ||'%BEFORE_TEST:SUITE_PACKAGE='||gc_owner||'.check_context'
+        ||'%BEFORE_TEST:SUITE_PATH=some.suite.path.check_context'
+        ||'%BEFORE_TEST:SUITE_START_TIME='||to_char(current_timestamp,'yyyy-mm-dd"T"hh24:mi')
+        ||'%BEFORE_TEST:TEST_DESCRIPTION=Some test description'
+        ||'%BEFORE_TEST:TEST_NAME='||gc_owner||'.check_context.the_test'
+        ||'%BEFORE_TEST:TEST_START_TIME='||to_char(current_timestamp,'yyyy-mm-dd"T"hh24:mi')
+        ||'%BEFORE_TEST:TIME_IN_CONTEXT=+000000000 00:00:0%'
+        ||'%BEFORE_TEST:TIME_IN_SUITE=+000000000 00:00:0%'
+        ||'%BEFORE_TEST:TIME_IN_TEST=+000000000 00:00:0%'
+        ||'%APPLICATION_INFO:MODULE=utPLSQL'
+        ||'%APPLICATION_INFO:ACTION=check_context'
+        ||'%APPLICATION_INFO:CLIENT_INFO=before_test%'
+      );
+  end;
+
+  procedure sys_ctx_on_test is
+  begin
+    ut.expect(g_context_test_results).to_be_like(
+      '%THE_TEST:CONTEXT_DESCRIPTION=context description'
+        ||'%THE_TEST:CONTEXT_NAME=some_context'
+        ||'%THE_TEST:CONTEXT_PATH=some.suite.path.check_context.some_context'
+        ||'%THE_TEST:CONTEXT_START_TIME='||to_char(current_timestamp,'yyyy-mm-dd"T"hh24:mi')
+        ||'%THE_TEST:CURRENT_EXECUTABLE_NAME='||gc_owner||'.check_context.the_test'
+        ||'%THE_TEST:CURRENT_EXECUTABLE_TYPE=test'
+        ||'%THE_TEST:RUN_PATHS=check_context'
+        ||'%THE_TEST:SUITE_DESCRIPTION=Suite description'
+        ||'%THE_TEST:SUITE_PACKAGE='||gc_owner||'.check_context'
+        ||'%THE_TEST:SUITE_PATH=some.suite.path.check_context'
+        ||'%THE_TEST:SUITE_START_TIME='||to_char(current_timestamp,'yyyy-mm-dd"T"hh24:mi')
+        ||'%THE_TEST:TEST_DESCRIPTION=Some test description'
+        ||'%THE_TEST:TEST_NAME='||gc_owner||'.check_context.the_test'
+        ||'%THE_TEST:TEST_START_TIME='||to_char(current_timestamp,'yyyy-mm-dd"T"hh24:mi')
+        ||'%THE_TEST:TIME_IN_CONTEXT=+000000000 00:00:0%'
+        ||'%THE_TEST:TIME_IN_SUITE=+000000000 00:00:0%'
+        ||'%THE_TEST:TIME_IN_TEST=+000000000 00:00:0%'
+        ||'%APPLICATION_INFO:MODULE=utPLSQL'
+        ||'%APPLICATION_INFO:ACTION=check_context'
+        ||'%APPLICATION_INFO:CLIENT_INFO=the_test%'
+      );
+  end;
+
+  procedure sys_ctx_on_aftertest is
+  begin
+    ut.expect(g_context_test_results).to_be_like(
+      '%AFTER_TEST:CONTEXT_DESCRIPTION=context description'
+        ||'%AFTER_TEST:CONTEXT_NAME=some_context'
+        ||'%AFTER_TEST:CONTEXT_PATH=some.suite.path.check_context.some_context'
+        ||'%AFTER_TEST:CONTEXT_START_TIME='||to_char(current_timestamp,'yyyy-mm-dd"T"hh24:mi')
+        ||'%AFTER_TEST:CURRENT_EXECUTABLE_NAME='||gc_owner||'.check_context.after_test'
+        ||'%AFTER_TEST:CURRENT_EXECUTABLE_TYPE=aftertest'
+        ||'%AFTER_TEST:RUN_PATHS=check_context'
+        ||'%AFTER_TEST:SUITE_DESCRIPTION=Suite description'
+        ||'%AFTER_TEST:SUITE_PACKAGE='||gc_owner||'.check_context'
+        ||'%AFTER_TEST:SUITE_PATH=some.suite.path.check_context'
+        ||'%AFTER_TEST:SUITE_START_TIME='||to_char(current_timestamp,'yyyy-mm-dd"T"hh24:mi')
+        ||'%AFTER_TEST:TEST_DESCRIPTION=Some test description'
+        ||'%AFTER_TEST:TEST_NAME='||gc_owner||'.check_context.the_test'
+        ||'%AFTER_TEST:TEST_START_TIME='||to_char(current_timestamp,'yyyy-mm-dd"T"hh24:mi')
+        ||'%AFTER_TEST:TIME_IN_CONTEXT=+000000000 00:00:0%'
+        ||'%AFTER_TEST:TIME_IN_SUITE=+000000000 00:00:0%'
+        ||'%AFTER_TEST:TIME_IN_TEST=+000000000 00:00:0%'
+        ||'%APPLICATION_INFO:MODULE=utPLSQL'
+        ||'%APPLICATION_INFO:ACTION=check_context'
+        ||'%APPLICATION_INFO:CLIENT_INFO=after_test%'
+      );
+  end;
+
+  procedure sys_ctx_on_aftereach is
+  begin
+    ut.expect(g_context_test_results).to_be_like(
+      '%AFTER_EACH_TEST:CONTEXT_DESCRIPTION=context description'
+        ||'%AFTER_EACH_TEST:CONTEXT_NAME=some_context'
+        ||'%AFTER_EACH_TEST:CONTEXT_PATH=some.suite.path.check_context.some_context'
+        ||'%AFTER_EACH_TEST:CONTEXT_START_TIME='||to_char(current_timestamp,'yyyy-mm-dd"T"hh24:mi')
+        ||'%AFTER_EACH_TEST:CURRENT_EXECUTABLE_NAME='||gc_owner||'.check_context.after_each_test'
+        ||'%AFTER_EACH_TEST:CURRENT_EXECUTABLE_TYPE=aftereach'
+        ||'%AFTER_EACH_TEST:RUN_PATHS=check_context'
+        ||'%AFTER_EACH_TEST:SUITE_DESCRIPTION=Suite description'
+        ||'%AFTER_EACH_TEST:SUITE_PACKAGE='||gc_owner||'.check_context'
+        ||'%AFTER_EACH_TEST:SUITE_PATH=some.suite.path.check_context'
+        ||'%AFTER_EACH_TEST:SUITE_START_TIME='||to_char(current_timestamp,'yyyy-mm-dd"T"hh24:mi')
+        ||'%AFTER_EACH_TEST:TEST_DESCRIPTION=Some test description'
+        ||'%AFTER_EACH_TEST:TEST_NAME='||gc_owner||'.check_context.the_test'
+        ||'%AFTER_EACH_TEST:TEST_START_TIME='||to_char(current_timestamp,'yyyy-mm-dd"T"hh24:mi')
+        ||'%AFTER_EACH_TEST:TIME_IN_CONTEXT=+000000000 00:00:0%'
+        ||'%AFTER_EACH_TEST:TIME_IN_SUITE=+000000000 00:00:0%'
+        ||'%AFTER_EACH_TEST:TIME_IN_TEST=+000000000 00:00:0%'
+        ||'%APPLICATION_INFO:MODULE=utPLSQL'
+        ||'%APPLICATION_INFO:ACTION=check_context'
+        ||'%APPLICATION_INFO:CLIENT_INFO=after_each_test%'
+      );
+  end;
+
+  procedure sys_ctx_on_context_afterall is
+  begin
+    ut.expect(g_context_test_results).to_be_like(
+      '%AFTER_CONTEXT:CONTEXT_DESCRIPTION=context description'
+        ||'%AFTER_CONTEXT:CONTEXT_NAME=some_context'
+        ||'%AFTER_CONTEXT:CONTEXT_PATH=some.suite.path.check_context.some_context'
+        ||'%AFTER_CONTEXT:CONTEXT_START_TIME='||to_char(current_timestamp,'yyyy-mm-dd"T"hh24:mi')
+        ||'%AFTER_CONTEXT:CURRENT_EXECUTABLE_NAME='||gc_owner||'.check_context.after_context'
+        ||'%AFTER_CONTEXT:CURRENT_EXECUTABLE_TYPE=afterall'
+        ||'%AFTER_CONTEXT:RUN_PATHS=check_context'
+        ||'%AFTER_CONTEXT:SUITE_DESCRIPTION=Suite description'
+        ||'%AFTER_CONTEXT:SUITE_PACKAGE='||gc_owner||'.check_context'
+        ||'%AFTER_CONTEXT:SUITE_PATH=some.suite.path.check_context'
+        ||'%AFTER_CONTEXT:SUITE_START_TIME='||to_char(current_timestamp,'yyyy-mm-dd"T"hh24:mi')
+        ||'%AFTER_CONTEXT:TIME_IN_CONTEXT=+000000000 00:00:0%'
+        ||'%AFTER_CONTEXT:TIME_IN_SUITE=+000000000 00:00:0%'
+        ||'%APPLICATION_INFO:MODULE=utPLSQL'
+        ||'%APPLICATION_INFO:ACTION=check_context'
+        ||'%APPLICATION_INFO:CLIENT_INFO=after_context%'
+      );
+    ut.expect(g_context_test_results).not_to_be_like('%AFTER_CONTEXT:TEST_%');
+  end;
+
+  procedure sys_ctx_on_suite_afterall is
+  begin
+    ut.expect(g_context_test_results).to_be_like(
+      '%AFTER_SUITE:CURRENT_EXECUTABLE_NAME='||gc_owner||'.check_context.after_suite'
+        ||'%AFTER_SUITE:CURRENT_EXECUTABLE_TYPE=afterall'
+        ||'%AFTER_SUITE:RUN_PATHS=check_context'
+        ||'%AFTER_SUITE:SUITE_DESCRIPTION=Suite description'
+        ||'%AFTER_SUITE:SUITE_PACKAGE='||gc_owner||'.check_context'
+        ||'%AFTER_SUITE:SUITE_PATH=some.suite.path.check_context'
+        ||'%AFTER_SUITE:SUITE_START_TIME='||to_char(current_timestamp,'yyyy-mm-dd"T"hh24:mi')
+        ||'%AFTER_SUITE:TIME_IN_SUITE=+000000000 00:00:0%'
+        ||'%APPLICATION_INFO:MODULE=utPLSQL'
+        ||'%APPLICATION_INFO:ACTION=check_context'
+        ||'%APPLICATION_INFO:CLIENT_INFO=after_suite%'
+      );
+    ut.expect(g_context_test_results).not_to_be_like('%AFTER_SUITE:CONTEXT_%');
+    ut.expect(g_context_test_results).not_to_be_like('%AFTER_SUITE:TEST_%');
+  end;
+
+  procedure sys_ctx_clear_after_run is
+    l_actual  sys_refcursor;
+  begin
+    open l_actual for
+      select attribute||'='||value
+        from session_context where namespace = 'UT3_INFO';
+
+    ut.expect(l_actual).to_be_empty();
+  end;
+
+  procedure app_info_restore_after_run is
+    l_module       varchar2(32767);
+    l_action       varchar2(32767);
+    l_client_info  varchar2(32767);
+  begin
+    dbms_application_info.read_module( l_module, l_action );
+    dbms_application_info.read_client_info( l_client_info );
+
+    ut.expect(l_module).to_equal(gc_module);
+    ut.expect(l_action).to_equal(gc_action);
+    --Disabled as it can't be tested.
+    --UT3_LATEST_RELEASE is also setting the client_info on each procedure
+    -- ut.expect(l_client_info).to_equal(gc_client_info);
+  end;
+
 end;
 /

--- a/test/ut3_user/api/test_ut_run.pks
+++ b/test/ut3_user/api/test_ut_run.pks
@@ -11,7 +11,8 @@ create or replace package test_ut_run is
   procedure ut_version;
 
   --%test(ut.fail() marks test as failed)
-  --%aftertest(clear_expectations)
+  --%beforetest(ut3_tester_helper.main_helper.set_ut_run_context)
+  --%aftertest(clear_expectations, ut3_tester_helper.main_helper.clear_ut_run_context)
   procedure ut_fail;
 
   --%context(ut_run_procedure)
@@ -227,6 +228,54 @@ create or replace package test_ut_run is
   --%test(Runs tests from given paths with paths list and a tag)
   procedure tag_run_func_path_list;
  
+  --%endcontext
+
+  --%context(ut3_info context)
+
+    --%beforeall
+    procedure set_application_info;
+    --%beforeall
+    procedure create_context_test_suite;
+
+    --%beforeall
+    procedure run_context_test_suite;
+
+    --%afterall
+    procedure drop_context_test_suite;
+
+    --%test(sets context for suite level beforeall)
+    procedure sys_ctx_on_suite_beforeall;
+
+    --%test(sets context for context level beforeall)
+    procedure sys_ctx_on_context_beforeall;
+
+    --%test(set for context level beforeeach)
+    procedure sys_ctx_on_beforeeach;
+
+    --%test(set for context level beforetest)
+    procedure sys_ctx_on_beforetest;
+
+    --%test(set for context level test)
+    procedure sys_ctx_on_test;
+
+    --%test(set for context level aftertest)
+    procedure sys_ctx_on_aftertest;
+
+    --%test(set for context level aftereach)
+    procedure sys_ctx_on_aftereach;
+
+    --%test(set for context level afterall)
+    procedure sys_ctx_on_context_afterall;
+
+    --%test(set for suite level afterall)
+    procedure sys_ctx_on_suite_afterall;
+
+    --%test(is cleared after run)
+    procedure sys_ctx_clear_after_run;
+
+    --%test(application info is restored after run)
+    procedure app_info_restore_after_run;
+
   --%endcontext
   
 end;

--- a/test/ut3_user/expectations.pkb
+++ b/test/ut3_user/expectations.pkb
@@ -1,0 +1,31 @@
+create or replace package body expectations as
+
+  --%test(Expectations return data to screen when called standalone)
+
+  procedure inline_expectation_to_dbms_out is
+    l_expected         sys_refcursor;
+    l_actual           sys_refcursor;
+    l_output           dbmsoutput_linesarray;
+    l_results          ut3.ut_varchar2_list;
+    l_lines            number := 10000;
+  begin
+    --Arrange
+    ut3_tester_helper.main_helper.clear_ut_run_context;
+    open l_expected for
+      select 'FAILURE' as out_row from dual union all
+      select 'Actual: 1 (number) was expected to equal: 0 (number)' from dual union all
+      select 'SUCCESS' from dual union all
+      select 'Actual: 0 (number) was expected to equal: 0 (number)' from dual union all
+      select '' from dual;
+    --Act
+    ut3.ut.expect(1).to_equal(0);
+    ut3.ut.expect(0).to_equal(0);
+
+    --Assert
+    dbms_output.get_lines(lines => l_output, numlines => l_lines);
+    open l_actual for select trim(column_value) as out_row from table(l_output);
+
+    ut.expect(l_actual).to_equal(l_expected);
+  end;
+end;
+/

--- a/test/ut3_user/expectations.pkb
+++ b/test/ut3_user/expectations.pkb
@@ -1,31 +1,64 @@
 create or replace package body expectations as
 
-  --%test(Expectations return data to screen when called standalone)
-
   procedure inline_expectation_to_dbms_out is
     l_expected         sys_refcursor;
     l_actual           sys_refcursor;
     l_output           dbmsoutput_linesarray;
     l_results          ut3.ut_varchar2_list;
     l_lines            number := 10000;
+    pragma autonomous_transaction;
   begin
     --Arrange
-    ut3_tester_helper.main_helper.clear_ut_run_context;
-    open l_expected for
-      select 'FAILURE' as out_row from dual union all
-      select 'Actual: 1 (number) was expected to equal: 0 (number)' from dual union all
-      select 'SUCCESS' from dual union all
-      select 'Actual: 0 (number) was expected to equal: 0 (number)' from dual union all
-      select '' from dual;
     --Act
+    execute immediate 'begin some_pkg.some_procedure; end;';
     ut3.ut.expect(1).to_equal(0);
     ut3.ut.expect(0).to_equal(0);
 
     --Assert
+    open l_expected for
+      select 'FAILURE' as out_row from dual union all
+      select 'Actual: 1 (number) was expected to equal: 0 (number)' from dual union all
+      select 'at "UT3$USER#.SOME_PKG.SOME_PROCEDURE", line 4 ut3.ut.expect(1).to_equal(0);
+  at "anonymous block", line 1
+  at "UT3$USER#.EXPECTATIONS.INLINE_EXPECTATION_TO_DBMS_OUT", line 13' from dual union all
+      select 'SUCCESS' from dual union all
+      select 'Actual: 0 (number) was expected to equal: 0 (number)' from dual union all
+      select 'FAILURE' as out_row from dual union all
+      select 'Actual: 1 (number) was expected to equal: 0 (number)' from dual union all
+      select 'at "UT3$USER#.EXPECTATIONS.INLINE_EXPECTATION_TO_DBMS_OUT", line 14 ut3.ut.expect(1).to_equal(0);' from dual union all
+      select 'SUCCESS' from dual union all
+      select 'Actual: 0 (number) was expected to equal: 0 (number)' from dual union all
+      select '' from dual;
     dbms_output.get_lines(lines => l_output, numlines => l_lines);
     open l_actual for select trim(column_value) as out_row from table(l_output);
 
     ut.expect(l_actual).to_equal(l_expected);
+    rollback;
   end;
+
+  procedure create_some_pkg is
+    pragma autonomous_transaction;
+  begin
+    execute immediate q'[
+    create or replace package some_pkg is
+      procedure some_procedure;
+    end;]';
+
+    execute immediate q'[
+    create or replace package body some_pkg is
+      procedure some_procedure is
+      begin
+        ut3.ut.expect(1).to_equal(0);
+        ut3.ut.expect(0).to_equal(0);
+      end;
+    end;]';
+  end;
+
+  procedure drop_some_pkg is
+    pragma autonomous_transaction;
+  begin
+    execute immediate 'drop package some_pkg';
+  end;
+
 end;
 /

--- a/test/ut3_user/expectations.pkb
+++ b/test/ut3_user/expectations.pkb
@@ -1,11 +1,8 @@
 create or replace package body expectations as
 
   procedure inline_expectation_to_dbms_out is
-    l_expected         sys_refcursor;
-    l_actual           sys_refcursor;
-    l_output           dbmsoutput_linesarray;
-    l_results          ut3.ut_varchar2_list;
-    l_lines            number := 10000;
+    l_expected         clob;
+    l_actual           clob;
     pragma autonomous_transaction;
   begin
     --Arrange
@@ -15,24 +12,23 @@ create or replace package body expectations as
     ut3.ut.expect(0).to_equal(0);
 
     --Assert
-    open l_expected for
-      select 'FAILURE' as out_row from dual union all
-      select 'Actual: 1 (number) was expected to equal: 0 (number)' from dual union all
-      select 'at "UT3$USER#.SOME_PKG.SOME_PROCEDURE", line 4 ut3.ut.expect(1).to_equal(0);
-  at "anonymous block", line 1
-  at "UT3$USER#.EXPECTATIONS.INLINE_EXPECTATION_TO_DBMS_OUT", line 13' from dual union all
-      select 'SUCCESS' from dual union all
-      select 'Actual: 0 (number) was expected to equal: 0 (number)' from dual union all
-      select 'FAILURE' as out_row from dual union all
-      select 'Actual: 1 (number) was expected to equal: 0 (number)' from dual union all
-      select 'at "UT3$USER#.EXPECTATIONS.INLINE_EXPECTATION_TO_DBMS_OUT", line 14 ut3.ut.expect(1).to_equal(0);' from dual union all
-      select 'SUCCESS' from dual union all
-      select 'Actual: 0 (number) was expected to equal: 0 (number)' from dual union all
-      select '' from dual;
-    dbms_output.get_lines(lines => l_output, numlines => l_lines);
-    open l_actual for select trim(column_value) as out_row from table(l_output);
+    l_actual := ut3_tester_helper.main_helper.get_dbms_output_as_clob();
 
-    ut.expect(l_actual).to_equal(l_expected);
+    l_expected := q'[FAILURE
+  Actual: 1 (number) was expected to equal: 0 (number)
+  at "UT3$USER#.SOME_PKG%", line 4 ut3.ut.expect(1).to_equal(0);
+  at "anonymous block", line 1
+  at "UT3$USER#.EXPECTATIONS%", line 10
+SUCCESS
+  Actual: 0 (number) was expected to equal: 0 (number)
+FAILURE
+  Actual: 1 (number) was expected to equal: 0 (number)
+  at "UT3$USER#.EXPECTATIONS%", line 11 ut3.ut.expect(1).to_equal(0);
+SUCCESS
+  Actual: 0 (number) was expected to equal: 0 (number)
+]';
+
+    ut.expect(l_actual).to_be_like(l_expected);
     rollback;
   end;
 

--- a/test/ut3_user/expectations.pks
+++ b/test/ut3_user/expectations.pks
@@ -7,8 +7,12 @@ create or replace package expectations as
   --%afterall(ut3_tester_helper.main_helper.clear_ut_run_context)
 
   --%test(Expectations return data to screen when called standalone)
-  --%aftertest(ut3_tester_helper.main_helper.set_ut_run_context)
+  --%beforetest( create_some_pkg, ut3_tester_helper.main_helper.clear_ut_run_context )
+  --%aftertest( drop_some_pkg, ut3_tester_helper.main_helper.set_ut_run_context )
   procedure inline_expectation_to_dbms_out;
+
+  procedure create_some_pkg;
+  procedure drop_some_pkg;
 
 end;
 /

--- a/test/ut3_user/expectations.pks
+++ b/test/ut3_user/expectations.pks
@@ -1,0 +1,14 @@
+create or replace package expectations as
+  --%suite
+  --%suitepath(utplsql.test_user)
+
+  --%beforeall(ut3_tester_helper.main_helper.set_ut_run_context)
+
+  --%afterall(ut3_tester_helper.main_helper.clear_ut_run_context)
+
+  --%test(Expectations return data to screen when called standalone)
+  --%aftertest(ut3_tester_helper.main_helper.set_ut_run_context)
+  procedure inline_expectation_to_dbms_out;
+
+end;
+/

--- a/test/ut3_user/expectations/test_expectation_anydata.pkb
+++ b/test/ut3_user/expectations/test_expectation_anydata.pkb
@@ -105,10 +105,7 @@ create or replace package body test_expectation_anydata is
     --Act
     ut3.ut.expect( g_test_actual ).to_equal( g_test_expected );
     --Assert
-    l_expected_message := q'[%Actual: ut3_tester_helper.test_dummy_object_list [ count =  ] was expected to equal: ut3_tester_helper.test_dummy_object_list [ count = 0 ]
-%Diff:
-%Rows: [  all different ]
-%All rows are different as the columns position is not matching.]';
+    l_expected_message := q'[%Actual: ut3_tester_helper.test_dummy_object_list [ null ] was expected to equal: ut3_tester_helper.test_dummy_object_list [ count = 0 ]]';
     l_actual_message := ut3_tester_helper.main_helper.get_failed_expectations(1);
     --Assert
     ut.expect(l_actual_message).to_be_like(l_expected_message);
@@ -126,7 +123,7 @@ create or replace package body test_expectation_anydata is
     --Act
     ut3.ut.expect( g_test_actual ).to_equal( g_test_expected );
     --Assert
-    l_expected_message := q'[%Actual: ut3_tester_helper.test_dummy_object_list [ count =  ] was expected to equal: ut3_tester_helper.test_dummy_object_list [ count = 1 ]
+    l_expected_message := q'[%Actual: ut3_tester_helper.test_dummy_object_list [ null ] was expected to equal: ut3_tester_helper.test_dummy_object_list [ count = 1 ]
 %Diff:
 %Rows: [ 1 differences ]
 %Row No. 1 - Missing:  <TEST_DUMMY_OBJECT><ID>1</ID><name>A</name><Value>0</Value></TEST_DUMMY_OBJECT>]';
@@ -665,7 +662,7 @@ Rows: [ 60 differences, showing first 20 ]
     g_test_actual   := anydata.convertCollection(  ut3_tester_helper.t_tab_varchar('A')  );
     --Act
     ut3.ut.expect( g_test_actual ).to_equal( g_test_expected );
-    l_expected_message := q'[%Actual: ut3_tester_helper.t_tab_varchar [ count = 1 ] was expected to equal: ut3_tester_helper.t_tab_varchar [ count =  ]
+    l_expected_message := q'[%Actual: ut3_tester_helper.t_tab_varchar [ count = 1 ] was expected to equal: ut3_tester_helper.t_tab_varchar [ null ]
 %Diff:
 %Rows: [ 1 differences ]
 %Row No. 1 - Extra:    <T_TAB_VARCHAR>A</T_TAB_VARCHAR>]';
@@ -785,7 +782,7 @@ Rows: [ 60 differences, showing first 20 ]
     g_test_actual   := anydata.convertCollection(  ut3_tester_helper.t_varray(1)  );
     --Act
     ut3.ut.expect( g_test_actual ).to_equal( g_test_expected );
-    l_expected_message := q'[%Actual: ut3_tester_helper.t_varray [ count = 1 ] was expected to equal: ut3_tester_helper.t_varray [ count =  ]
+    l_expected_message := q'[%Actual: ut3_tester_helper.t_varray [ count = 1 ] was expected to equal: ut3_tester_helper.t_varray [ null ]
 %Diff:
 %Rows: [ 1 differences ]
 %Row No. 1 - Extra:    <T_VARRAY>1</T_VARRAY>]';

--- a/test/ut3_user/expectations/test_expectations_cursor.pkb
+++ b/test/ut3_user/expectations/test_expectations_cursor.pkb
@@ -702,7 +702,7 @@ Rows: [ 1 differences ]
 Diff:
 Columns:
   Column <RN> data-type is invalid. Expected: NUMBER, actual: VARCHAR2.
-Rows: [  all different ]
+Rows: [ all different ]
   All rows are different as the columns position is not matching.]';
     l_actual_message := ut3_tester_helper.main_helper.get_failed_expectations(1);
     --Assert
@@ -749,7 +749,7 @@ Columns:
   Column <COL_4> is misplaced. Expected position: 2, actual position: 4.
   Column <COL_2> is misplaced. Expected position: 3, actual position: 2.
   Column <COL_3> is misplaced. Expected position: 4, actual position: 3.
-Rows: [  all different ]
+Rows: [ all different ]
   All rows are different as the columns position is not matching.]';
     l_actual_message := ut3_tester_helper.main_helper.get_failed_expectations(1);
     --Assert
@@ -1117,7 +1117,7 @@ Rows: [ 4 differences ]
 %Column <EXPECTED_COLUMN_NAME> [data-type: NUMBER] is missing. Expected column position: 2.
 %Column <1> [position: 1, data-type: CHAR] is not expected in results.
 %Column <2> [position: 2, data-type: CHAR] is not expected in results.
-%Rows: [  all different ]
+%Rows: [ all different ]
 %All rows are different as the columns position is not matching.]';
     l_actual_message := ut3_tester_helper.main_helper.get_failed_expectations(1);
     --Assert

--- a/test/ut3_user/expectations/unary/test_expect_to_be_empty.pkb
+++ b/test/ut3_user/expectations/unary/test_expect_to_be_empty.pkb
@@ -38,7 +38,7 @@ create or replace package body test_expect_to_be_empty is
 
     l_expected_message := q'[Actual: (refcursor [ count = 1 ])%
     <ROW><DUMMY>X</DUMMY></ROW>%
-was expected to be empty%%]';
+ was expected to be empty%]';
     l_actual_message := ut3_tester_helper.main_helper.get_failed_expectations(1);
 
     --Assert

--- a/test/ut3_user/reporters/test_realtime_reporter.pkb
+++ b/test/ut3_user/reporters/test_realtime_reporter.pkb
@@ -302,7 +302,7 @@ create or replace package body test_realtime_reporter as
 
   procedure single_failed_message is
     l_actual   varchar2(32767);
-    l_expected varchar2(80) := '<![CDATA[Actual: 1 (number) was expected to equal: 2 (number) ]]>';
+    l_expected varchar2(80) := '<![CDATA[Actual: 1 (number) was expected to equal: 2 (number)]]>';
   begin
     select t.event_doc.extract(
              '/event/test/failedExpectations/expectation[1]/message/text()'

--- a/test/ut3_user/reporters/test_teamcity_reporter.pkb
+++ b/test/ut3_user/reporters/test_teamcity_reporter.pkb
@@ -57,7 +57,7 @@ create or replace package body test_teamcity_reporter as
 <!beforeeach!>
 <!failing test!>
 <!aftereach!>
-%##teamcity[testFailed timestamp='%' details='Actual: |'number |[1|] |' (varchar2) was expected to equal: |'number |[2|] |' (varchar2) ' message='Fails as values are different' name='ut3$user#.test_reporters.failing_test']
+%##teamcity[testFailed timestamp='%' details='Actual: |'number |[1|] |' (varchar2) was expected to equal: |'number |[2|] |' (varchar2)' message='Fails as values are different' name='ut3$user#.test_reporters.failing_test']
 %##teamcity[testFinished timestamp='%' duration='%' name='ut3$user#.test_reporters.failing_test']
 %##teamcity[testStarted timestamp='%' captureStandardOutput='true' name='ut3$user#.test_reporters.erroring_test']
 <!beforeeach!>
@@ -89,7 +89,7 @@ create or replace package body test_teamcity_reporter as
   begin
     l_expected := q'{%##teamcity[testSuiteStarted timestamp='%' name='A suite with |'quote|'']
 %##teamcity[testStarted timestamp='%' captureStandardOutput='true' name='ut3$user#.check_escape_special_chars.test_do_stuff']
-%##teamcity[testFailed timestamp='%' details='Actual: (varchar2)|n    |' |[ |r|n     |] |'|nwas expected to be null' name='ut3$user#.check_escape_special_chars.test_do_stuff']
+%##teamcity[testFailed timestamp='%' details='Actual: (varchar2)|n    |' |[ |r|n     |] |'|n was expected to be null' name='ut3$user#.check_escape_special_chars.test_do_stuff']
 %##teamcity[testFinished timestamp='%' duration='%' name='ut3$user#.check_escape_special_chars.test_do_stuff']
 %##teamcity[testSuiteFinished timestamp='%' name='A suite with |'quote|'']}';
     --act


### PR DESCRIPTION
## Added ability to run expectations without tests
Expectation, when executed without test, reports results straight to dbms_output.

So it is now possible to execute:
`exec ut.expect(1).to_equal(0);`

And get result:
```
FAILURE
  Actual: 1 (number) was expected to equal: 0 (number)
```
Resolves #956


## Improvements to application_info in v$session

utPLSQL is now cleaning up the application_info after run. The `module_name`, `action`, client_info` are restored to it's original values after test run. Resolves #951

The following attributes are set in v$session when test suite is running:
- `module_name` - set to `utPLSQL`
- `action` - name of currently executing test suite package
- `client_info` name of test executable procedure (before.../after.../test) that is currently running

## Setting session context during run

It is now possible to access some of utPLSQL info within the test procedures directly. 
Resolves #781

The information is provided in `sys_context( 'UT3_INFO', attribute )`.

Following attributes are getting populated:
- Always:
    - `sys_context( 'UT3_INFO', 'RUN_PATHS' );` - list of suitepaths / suitenames used as input parameters for call to `ut.run(...)` or `ut_runner.run(...)`
    - `sys_context( 'UT3_INFO', 'SUITE_DESCRIPTION' );` - the description of test suite that is currently being executed
    - `sys_context( 'UT3_INFO', 'SUITE_PACKAGE' );` -  the owner and name of test suite package that is currently being executed
    - `sys_context( 'UT3_INFO', 'SUITE_PATH' );` - the suitepath for the test suite package that is currently being executed
    - `sys_context( 'UT3_INFO', 'SUITE_START_TIME' );` - the execution start timestamp of test suite package that is currently being executed
    - `sys_context( 'UT3_INFO', 'CURRENT_EXECUTABLE_NAME' );` - the owner.package.procedure of currently running test suite executable
    - `sys_context( 'UT3_INFO', 'CURRENT_EXECUTABLE_TYPE' );` - the type of currently running test suite executable (one of: `beforeall`, `beforeeach`, `beforetest`, `test`, `aftertest`, `aftereach`, `afterall`

- When running in suite context
    - `sys_context( 'UT3_INFO', 'CONTEXT_DESCRIPTION' );` - the description of test suite context that is currently being executed 
    - `sys_context( 'UT3_INFO', 'CONTEXT_NAME' );` - the name of test suite context that is currently being executed 
    - `sys_context( 'UT3_INFO', 'CONTEXT_PATH' );` - the suitepath for the currently executed test suite context
    - `sys_context( 'UT3_INFO', 'CONTEXT_START_TIME' );` - the execution start timestamp for the currently executed test suite context
- When running a suite executable procedure that is a `test` or `beforeeach`, `aftereach`, `beforetest`, `aftertest`
    - `sys_context( 'UT3_INFO', 'TEST_DESCRIPTION' );` - the description of test for which the current executable is being invoked
    - `sys_context( 'UT3_INFO', 'TEST_NAME' );` -  the name of test for which the current executable is being invoked
    - `sys_context( 'UT3_INFO', 'TEST_START_TIME' );` - the execution start timestamp of test that is currently being executed (the time when first `beforeeach`/`beforetest` was called for that test)

## Call stack enchancements

utPLSQL will now provide full call stack within the context of the test, not only the stack line where expectation was called.
To minimize overhead on test execution, stack is provided only when expectation fails.

Resolves #967


## Improved functionality of reporters
Reporters will now support inline calls for data-retrieval.
References #955