### PR TITLE
ignore cobertura.xml which is created by a test run

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ tfs_test_results.xml
 junit_test_results.xml
 test_results.xml
 *debug*.xml
+cobertura.xml


### PR DESCRIPTION
Avoid deleting this file after each full test run. 
Ignoring this file is simpler.