### PR TITLE
Fix check of sys grants with ANY (issue #992)

### DIFF
--- a/source/check_sys_grants.sql
+++ b/source/check_sys_grants.sql
@@ -21,7 +21,7 @@ begin
     (select privilege
     from user_sys_privs
     union all
-    select replace(privilege,' ANY ') privilege
+    select replace(privilege,' ANY') privilege
     from user_sys_privs)
   );
   if l_missing_grants is not null then


### PR DESCRIPTION
This commit fixes an issue in the installation when the CREATE ANY CONTEXT right is granted instead of CREATE CONTEXT. 