### PR TITLE
Changed names on internal columns in cursor & object compare.

### DIFF
--- a/test/ut3_user/expectations/test_expectations_cursor.pks
+++ b/test/ut3_user/expectations/test_expectations_cursor.pks
@@ -462,8 +462,14 @@ create or replace package test_expectations_cursor is
   --%test( Mixed column order exclusion  )
   procedure uc_columns_exclude;
 
-  --%test(Compares cursors with long column names - Issue #952 )
+  --%test( Compares cursors with long column names - Issue #952 )
   procedure compare_long_column_names;
+
+  --%test( Compares cursors with specific column names - Issue #997 )
+  procedure compare_specific_column_names;
+
+  --%test( Multiple failures reported correctly - Issue #998 )
+  procedure multiple_cursor_expectations;
 
 end;
 /


### PR DESCRIPTION
Columns:
 - ITEM_DATA
 - DATA_ID
 - ITEM_NO
 - DUP_NO
 - POSITION
Can now be safely used in cursors.
Resolves #997

Added delete on DIFF temp tables after cursor / object compare.
Resolves #998