### PR TITLE
Feature/nested context

### DIFF
--- a/docs/userguide/annotations.md
+++ b/docs/userguide/annotations.md
@@ -1014,7 +1014,7 @@ Context have following characteristics:
 - context name must be unique within it's parent (suite or parent context)
 - if context name is not unique within it's parent, context and it's entire content is excluded from execution 
 - context name should not contain spaces or special characters
-- context name cannot contain a `.` (hard stop) character
+- context name cannot contain a `.` (full stop/period) character
 - contexts can be nested, so a context can be nested within another context
 - suite/context can have multiple nested sibling contexts in it 
 - contexts can have their own `--%beforeall`, `--%beforeeach`, `--%afterall` and `--%aftereach` procedures

--- a/docs/userguide/annotations.md
+++ b/docs/userguide/annotations.md
@@ -21,9 +21,9 @@ We strongly recommend putting package level annotations at the very top of packa
 | --- | --- | --- |
 | `--%suite(<description>)` | Package | Mandatory. Marks package as a test suite. Optional suite description can be provided (see `displayname`). |
 | `--%suitepath(<path>)` | Package | Similar to java package. The annotation allows logical grouping of suites into hierarchies. |
-| `--%displayname(<description>)` | Package/procedure | Human-readable and meaningful description of a context/suite/test. Provides description to a `context` when used within `context`. When used with `test` or `suite` annotation, overrides the `<description>` provided with `suite`/`test`. |
+| `--%displayname(<description>)` | Package/procedure | Human-readable and meaningful description of a context/suite/test. Overrides the `<description>` provided with `suite`/`test`/`context` annotation. This annotation is redundant and might be removed in future releases. |
 | `--%test(<description>)` | Procedure | Denotes that the annotated procedure is a unit test procedure.  Optional test description can by provided (see `displayname`). |
-| `--%throws(<exception>[,...])`| Procedure | Denotes that the annotated test procedure must throw one of the exceptions provided. Supported forms of exceptions are: numeric literals, numeric contant names, exception constant names, predefined Oracle exception names. |
+| `--%throws(<exception>[,...])`| Procedure | Denotes that the annotated test procedure must throw one of the exceptions provided. Supported forms of exceptions are: numeric literals, numeric constant names, exception constant names, predefined Oracle exception names. |
 | `--%beforeall` | Procedure | Denotes that the annotated procedure should be executed once before all elements of the suite. |
 | `--%beforeall([[<owner>.]<package>.]<procedure>[,...])` | Package | Denotes that the mentioned procedure(s) should be executed once before all elements of the suite. |
 | `--%afterall` | Procedure | Denotes that the annotated procedure should be executed once after all elements of the suite. |
@@ -36,7 +36,8 @@ We strongly recommend putting package level annotations at the very top of packa
 | `--%aftertest([[<owner>.]<package>.]<procedure>[,...])` | Procedure | Denotes that mentioned procedure(s) should be executed after the annotated `%test` procedure. |
 | `--%rollback(<type>)` | Package/procedure | Defines transaction control. Supported values: `auto`(default) - a savepoint is created before invocation of each "before block" is and a rollback to specific savepoint is issued after each "after" block; `manual` - rollback is never issued automatically. Property can be overridden for child element (test in suite) |
 | `--%disabled` | Package/procedure | Used to disable a suite or a test. Disabled suites/tests do not get executed, they are however marked and reported as disabled in a test run. |
-| `--%context(<name>)` | Package | Denotes start of a named context (sub-suite) in a suite package |
+| `--%context(<description>)` | Package | Denotes start of a named context (sub-suite) in a suite package an optional description for context can be provided. |
+| `--%name(<name>)` | Package | Denotes name for a context. Must be placed after the context annotation and before start of nested context. |
 | `--%endcontext` | Package | Denotes end of a nested context (sub-suite) in a suite package |
 | `--%tags` | Package/procedure | Used to label a test or a suite for purpose of identification |
 
@@ -1008,14 +1009,15 @@ Contexts allow for creating sub-suites within a suite package and they allow for
 In essence, context behaves like a suite within a suite. 
 
 Context have following characteristics:
-- context starts with the `--%context` annotation and ends with `--%endcontext`
-- can have a name provided as parameter for example `--%context(remove_rooms_by_name)`. This is different than with `suite` and `test` annotations, where name is taken from test `package/procedure`
-- when no name is provided for context, the context is named `context_N` where `N` is the number of the context in suite or parent context
-- context name must be unique within it's parent (suite or parent context)
+- context starts with the `--%context` annotation and ends with `--%endcontext`. Everything placed between those two annotations belongs to that context
+- can have a description provided as parameter for example `--%context(Some interesting stuff)`. 
+- can have a name provided with `--%name` annotation. This is different than with `suite` and `test` annotations, where name is taken from `package/procedure` name.
+- contexts can be nested, you can place a context inside another context
+- when no name is provided for context, the context is named `context_N` where `N` is the number of the context in suite or parent context.
+- context name must be unique within it's parent (suite / parent context)
 - if context name is not unique within it's parent, context and it's entire content is excluded from execution 
 - context name should not contain spaces or special characters
 - context name cannot contain a `.` (full stop/period) character
-- contexts can be nested, so a context can be nested within another context
 - suite/context can have multiple nested sibling contexts in it 
 - contexts can have their own `--%beforeall`, `--%beforeeach`, `--%afterall` and `--%aftereach` procedures
 - `--%beforeall`, `--%beforeeach`, `--%afterall` and `--%aftereach` procedures defined at ancestor level, propagate to context
@@ -1231,8 +1233,7 @@ Example of nested contexts test suite specification.
 create or replace package queue_spec as
   --%suite(Queue specification)
 
-  --%context(a_new_queue)
-  --%displayname(A new queue)
+  --%context(A new queue)
 
     --%test(Is empty)
     procedure is_empty;
@@ -1241,8 +1242,7 @@ create or replace package queue_spec as
     --%test(Cannot be created with non positive bounding capacity)
     procedure non_positive_bounding_cap;
   --%endcontext
-  --%context(an_empty_queue)
-  --%displayname(An empty queue)
+  --%context(An empty queue)
 
     --%test(Dequeues an empty value)
     procedure deq_empty_value;
@@ -1251,19 +1251,16 @@ create or replace package queue_spec as
     --%test(Becomes non empty when non null value enqueued)
     procedure non_empty_after_enq;
   --%endcontext
-  --%context(a_non_empty_queue)
-  --%displayname(A non empty queue)
+  --%context(A non empty queue)
 
-    --%context(that_is_not_full)
-    --%displayname(that is not full)
+    --%context(that is not full)
 
       --%test(Becomes longer when non null value enqueued)
       procedure grow_on_enq_non_null;
       --%test(Becomes full when enqueued up to capacity)
       procedure full_on_enq_to_cap;
     --%endcontext
-    --%context(that_is_full)
-    --%displayname(That is full)
+    --%context(that is full)
 
       --%test(Ignores further enqueued values)
       procedure full_ignore_enq;
@@ -1312,6 +1309,122 @@ Finished in .088573 seconds
 
 Suite nesting allows for organizing tests into human-readable specification of behavior.
 
+### Name
+The `--%name` annotation is currently only used only for naming a context.
+If a context doesn't have explicit name specified, then the name is given automatically by framework.
+
+The automatic name will be `context_#n` where `n` is a context number within a suite/parent context.
+
+The `--%name` can be useful when you would like to run only a specific context or its items by `suitepath`.
+
+Consider the below example.
+
+```sql
+create or replace package queue_spec as
+  --%suite(Queue specification)
+
+  --%context(A new queue)
+
+    --%test(Cannot be created with non positive bounding capacity)
+    procedure non_positive_bounding_cap;
+  --%endcontext
+  --%context(An empty queue)
+
+    --%test(Becomes non empty when non null value enqueued)
+    procedure non_empty_after_enq;
+  --%endcontext
+  --%context(A non empty queue)
+
+    --%context(that is not full)
+
+      --%test(Becomes full when enqueued up to capacity)
+      procedure full_on_enq_to_cap;
+    --%endcontext
+    --%context(that is full)
+
+      --%test(Becomes non full when dequeued)
+      procedure non_full_on_deq;
+    --%endcontext
+
+  --%endcontext
+end;
+```
+
+In the above code, suitepaths, context names and context descriptions will be as follows.
+
+| suitepath | description | name |
+|-----------|------------|------|
+| queue_spec | Queue specification | queue_spec |
+| queue_spec.context_#1 | A new queue | context_#1 |
+| queue_spec.context_#2 | An empty queue | context_#2 |
+| queue_spec.context_#3 | A non empty queue | context_#3 |
+| queue_spec.context_#3.context_#1 | that is not full | context_#1 |
+| queue_spec.context_#3.context_#2 | that is full | context_#2 |
+
+In order to run only the tests for the context `A non empty queue that is not full` you will need to call utPLSQL as below:
+```sql 
+  exec ut.run(':queue_spec.context_#3.context_#1');
+```
+
+You can use `--%name` annotation to explicitly name contexts on suitepath.  
+```sql
+create or replace package queue_spec as
+  --%suite(Queue specification)
+
+  --%context(A new queue)
+  --%name(a_new_queue)
+
+    --%test(Cannot be created with non positive bounding capacity)
+    procedure non_positive_bounding_cap;
+  --%endcontext
+  --%context(An empty queue)
+  --%name(an_empty_queue)
+
+    --%test(Becomes non empty when non null value enqueued)
+    procedure non_empty_after_enq;
+  --%endcontext
+  --%context(A non empty queue)
+  --%name(a_non_empty_queue)
+
+    --%context(that is not full)
+    --%name(that_is_not_full)
+
+      --%test(Becomes full when enqueued up to capacity)
+      procedure full_on_enq_to_cap;
+    --%endcontext
+    --%context(that is full)
+    --%name(that_is_full)
+
+      --%test(Becomes non full when dequeued)
+      procedure non_full_on_deq;
+    --%endcontext
+
+  --%endcontext
+end;
+```
+
+In the above code, suitepaths, context names and context descriptions will be as follows.
+
+| suitepath | description | name |
+|-----------|------------|------|
+| queue_spec | Queue specification | queue_spec |
+| queue_spec.a_new_queue | A new queue | a_new_queue |
+| queue_spec.an_empty_queue | An empty queue | an_empty_queue |
+| queue_spec.a_non_empty_queue | A non empty queue | a_non_empty_queue |
+| queue_spec.a_non_empty_queue.that_is_not_full | that is not full | that_is_not_full |
+| queue_spec.a_non_empty_queue.that_is_full | that is full | that_is_full |
+
+
+The `--%name` annotation is only relevant for:
+- running subsets of tests by given context suitepath
+- some of test reports, like `ut_junit_reporter` that use suitepath or test-suite element names (not descriptions) for reporting   
+
+#### Name naming convention
+
+The value of `--%name` annotation must follow the following naming rules:
+- cannot contain spaces
+- cannot contain a `.` (full stop/dot)
+- is case-insensitive  
 
 ### Tags
 
@@ -1440,8 +1553,9 @@ If you want to create tests for your application it is recommended to structure 
     * Payments recognition
     * Payments set off
 
-The `%suitepath` annotation is used for such grouping. Even though test packages are defined in a flat structure the `%suitepath` is used by the framework to form them into a hierarchical structure. Your payments recognition test package might look like:
+The `--%suitepath` annotation is used for such grouping. Even though test packages are defined in a flat structure the `--%suitepath` is used by the framework to form them into a hierarchical structure. 
 
+Your payments recognition test package might look like:
 ```sql
 create or replace package test_payment_recognition as
 
@@ -1476,8 +1590,8 @@ create or replace package test_payment_set_off as
 end test_payment_set_off;
 ```
 
-When you execute tests for your application, the framework constructs a test suite for each test package. Then it combines suites into grouping suites by the `%suitepath` annotation value so that the fully qualified path to the `recognize_by_num` procedure is `USER:payments.test_payment_recognition.test_recognize_by_num`. If any of its expectations fails then the test is marked as failed, also the `test_payment_recognition` suite, the parent suite `payments` and the whole run is marked as failed.
-The test report indicates which expectation has failed on the payments module. The payments recognition submodule is causing the failure as `recognize_by_num` has not met the expectations of the test. Grouping tests into modules and submodules using the `%suitepath` annotation allows you to logically organize your project's flat structure of packages into functional groups.
+When you execute tests for your application, the framework constructs a test suite for each test package. Then it combines suites into grouping suites by the `--%suitepath` annotation value so that the fully qualified path to the `recognize_by_num` procedure is `USER:payments.test_payment_recognition.test_recognize_by_num`. If any of its expectations fails then the test is marked as failed, also the `test_payment_recognition` suite, the parent suite `payments` and the whole run is marked as failed.
+The test report indicates which expectation has failed on the payments module. The payments recognition submodule is causing the failure as `recognize_by_num` has not met the expectations of the test. Grouping tests into modules and submodules using the `--%suitepath` annotation allows you to logically organize your project's flat structure of packages into functional groups.
 
 An additional advantage of such grouping is the fact that every element level of the grouping can be an actual unit test package containing a common module level setup for all of the submodules. So in addition to the packages mentioned above you could have the following package.
 ```sql
@@ -1493,9 +1607,10 @@ create or replace package payments as
 
 end payments;
 ```
-A `%suitepath` can be provided in three ways:
+
+When executing tests, `path` for executing tests can be provided in three ways:
 * schema - execute all tests in the schema
-* [schema]:suite1[.suite2][.suite3]...[.procedure] - execute all tests in all suites from suite1[.suite2][.suite3]...[.procedure] path. If schema is not provided, then the current schema is used. Example: `:all.rooms_tests`
+* [schema]:suite1[.suite2][.suite3]...[.procedure] - execute all tests by `suitepath` in all suites on path suite1[.suite2][.suite3]...[.procedure]. If schema is not provided, then the current schema is used. Example: `:all.rooms_tests`
 * [schema.]package[.procedure] - execute all tests in the specified test package. The whole hierarchy of suites in the schema is built before all before/after hooks or part suites for the provided suite package are executed as well. Example: `tests.test_contact.test_last_name_validator` or simply `test_contact.test_last_name_validator` if `tests` is the current schema.
 
 

--- a/source/core/ut_suite_builder.pkb
+++ b/source/core/ut_suite_builder.pkb
@@ -777,7 +777,7 @@ create or replace package body ut_suite_builder is
       if regexp_like( l_context_name, '\.' ) or l_context_name is null then
         if regexp_like( l_context_name, '\.' ) then
           a_suite.put_warning(
-            'Invalid value "'||l_context_name||'" for context name. The name cannot contain "." (hard stop) character.' ||
+            'Invalid value "'||l_context_name||'" for context name. The name cannot contain "." (full stop/period) character.' ||
             ' Context name ignored and fallback to auto-name "'||gc_context||'_'||l_context_no||'" ' ||
             get_object_reference( a_suite, null, l_context_pos )
             );

--- a/source/core/ut_suite_builder.pkb
+++ b/source/core/ut_suite_builder.pkb
@@ -774,6 +774,16 @@ create or replace package body ut_suite_builder is
       l_end_context_pos := get_endcontext_position(l_context_pos, a_annotations.by_name );
       
       l_context_name := coalesce( a_annotations.by_line( l_context_pos ).text, gc_context||'_'||l_context_no );
+      if regexp_like( l_context_name, '\.' ) or l_context_name is null then
+        if regexp_like( l_context_name, '\.' ) then
+          a_suite.put_warning(
+            'Invalid value "'||l_context_name||'" for context name. The name cannot contain "." (hard stop) character.' ||
+            ' Context name ignored and fallback to auto-name "'||gc_context||'_'||l_context_no||'" ' ||
+            get_object_reference( a_suite, null, l_context_pos )
+            );
+        end if;
+        l_context_name := gc_context||'_'||l_context_no;
+      end if;
       l_context := ut_suite_context(a_suite.object_owner, a_suite.object_name, l_context_name, l_context_pos );
       l_context.path := a_suite.path||'.'||l_context_name;
       l_context.description := a_annotations.by_line( l_context_pos ).text;

--- a/source/core/ut_suite_builder.pkb
+++ b/source/core/ut_suite_builder.pkb
@@ -829,7 +829,7 @@ create or replace package body ut_suite_builder is
     end loop;
   end;
 
-  procedure warning_on_floating_endcontext(
+  procedure warning_on_extra_endcontext(
     a_suite              in out nocopy ut_suite,
     a_package_ann_index  tt_annotations_by_name
   ) is
@@ -915,7 +915,7 @@ create or replace package body ut_suite_builder is
       add_tests_to_items( l_suite, l_annotations, a_suite_items );
 
       --by this time all contexts were consumed and l_annotations should not have any context/endcontext annotation in it.
-      warning_on_floating_endcontext( l_suite, l_annotations.by_name );
+      warning_on_extra_endcontext( l_suite, l_annotations.by_name );
 
       a_suite_items.extend;
       a_suite_items( a_suite_items.last) := l_suite;

--- a/source/core/ut_suite_builder.pkb
+++ b/source/core/ut_suite_builder.pkb
@@ -777,7 +777,7 @@ create or replace package body ut_suite_builder is
 
       if l_end_context_pos is null then
         a_suite.put_warning(
-          'Missing "--%endcontext" annotation for a "--%context" annotation. The end of package specification is effective end of context.'|| get_object_reference( a_suite, null, l_context_pos )
+          'Missing "--%endcontext" annotation for a "--%context" annotation. The end of package is considered end of context.'|| get_object_reference( a_suite, null, l_context_pos )
           );
         l_end_context_pos := a_annotations.by_line.last;
       end if;

--- a/test/ut3_tester/core/test_suite_builder.pkb
+++ b/test/ut3_tester/core/test_suite_builder.pkb
@@ -1038,7 +1038,7 @@ create or replace package body test_suite_builder is
     l_actual := invoke_builder_for_annotations(l_annotations, 'SOME_PACKAGE');
     --Assert
     ut.expect(l_actual).to_be_like(
-      '%Invalid value &quot;'||l_bad_name||'&quot; for context name. The name cannot contain &quot;.&quot; (hard stop) character. Context name ignored and fallback to auto-name &quot;context_1&quot;%'
+      '%Invalid value &quot;'||l_bad_name||'&quot; for context name. The name cannot contain &quot;.&quot; (full stop/period) character. Context name ignored and fallback to auto-name &quot;context_1&quot;%'
     );
     ut.expect(l_actual).to_be_like(
       '<ROWSET><ROW>'||

--- a/test/ut3_tester/core/test_suite_builder.pkb
+++ b/test/ut3_tester/core/test_suite_builder.pkb
@@ -884,7 +884,7 @@ create or replace package body test_suite_builder is
     l_actual := invoke_builder_for_annotations(l_annotations, 'SOME_PACKAGE');
     --Assert
     ut.expect(l_actual).to_be_like(
-        '%<WARNINGS><VARCHAR2>Missing &quot;--\%endcontext&quot; annotation for a &quot;--\%context&quot; annotation. The end of context considered be end of package.%at package &quot;UT3_TESTER.SOME_PACKAGE&quot;, line 4</VARCHAR2></WARNINGS>%'
+        '%<WARNINGS><VARCHAR2>Missing &quot;--\%endcontext&quot; annotation for a &quot;--\%context&quot; annotation. The end of package is considered end of context.%at package &quot;UT3_TESTER.SOME_PACKAGE&quot;, line 4</VARCHAR2></WARNINGS>%'
         ,'\'
     );
     ut.expect(l_actual).to_be_like(

--- a/test/ut3_tester/core/test_suite_builder.pkb
+++ b/test/ut3_tester/core/test_suite_builder.pkb
@@ -635,8 +635,8 @@ create or replace package body test_suite_builder is
         ut3.ut_annotation(1, 'suite','Cool', null),
         ut3.ut_annotation(2, 'beforeall',null, 'suite_level_beforeall'),
         ut3.ut_annotation(3, 'test','In suite', 'suite_level_test'),
-        ut3.ut_annotation(4, 'context','a_context', null),
-        ut3.ut_annotation(5, 'displayname','A context', null),
+        ut3.ut_annotation(4, 'context','A context', null),
+        ut3.ut_annotation(5, 'name','a_context', null),
         ut3.ut_annotation(6, 'beforeall',null, 'context_setup'),
         ut3.ut_annotation(7, 'test', 'In context', 'test_in_a_context'),
         ut3.ut_annotation(8, 'endcontext',null, null)
@@ -683,23 +683,24 @@ create or replace package body test_suite_builder is
       ut3.ut_annotation( 1, 'suite','Cool', null),
       ut3.ut_annotation( 2, 'beforeall',null, 'suite_level_beforeall'),
       ut3.ut_annotation( 3, 'test','In suite', 'suite_level_test'),
-      ut3.ut_annotation( 4, 'context','a_context', null),
-      ut3.ut_annotation( 5,   'displayname','A context', null),
+      ut3.ut_annotation( 4, 'context','A context', null),
+      ut3.ut_annotation( 5,   'name','a_context', null),
       ut3.ut_annotation( 6,   'beforeall',null, 'context_setup'),
       ut3.ut_annotation( 7,   'test', 'First test in context', 'first_test_in_a_context'),
-      ut3.ut_annotation( 8,   'context','a_nested_context', null),
-      ut3.ut_annotation( 9,     'displayname','A nested context', null),
+      ut3.ut_annotation( 8,   'context','A nested context', null),
+      ut3.ut_annotation( 9,     'name','a_nested_context', null),
       ut3.ut_annotation(10,     'beforeall',null, 'nested_context_setup'),
       ut3.ut_annotation(11,     'test', 'Test in nested context', 'test_in_nested_context'),
       ut3.ut_annotation(12,   'endcontext',null, null),
-      ut3.ut_annotation(13,   'context','nested_context_2', null),
-      ut3.ut_annotation(14,     'test', 'Test in nested context', 'test_in_nested_context_2'),
-      ut3.ut_annotation(15,     'context','a_nested_context_3', null),
-      ut3.ut_annotation(16,       'test', 'Test in nested context', 'test_in_nested_context_3'),
-      ut3.ut_annotation(17,     'endcontext',null, null),
-      ut3.ut_annotation(18,   'endcontext',null, null),
-      ut3.ut_annotation(19,   'test', 'Second test in context', 'second_test_in_a_context'),
-      ut3.ut_annotation(20, 'endcontext',null, null)
+      ut3.ut_annotation(13,   'context',null, null),
+      ut3.ut_annotation(14,     'name','nested_context_2', null),
+      ut3.ut_annotation(15,     'test', 'Test in nested context', 'test_in_nested_context_2'),
+      ut3.ut_annotation(16,     'context','a_nested_context_3', null),
+      ut3.ut_annotation(17,       'test', 'Test in nested context', 'test_in_nested_context_3'),
+      ut3.ut_annotation(18,     'endcontext',null, null),
+      ut3.ut_annotation(19,   'endcontext',null, null),
+      ut3.ut_annotation(20,   'test', 'Second test in context', 'second_test_in_a_context'),
+      ut3.ut_annotation(21, 'endcontext',null, null)
       );
     --Act
     l_actual := invoke_builder_for_annotations(l_annotations, 'SOME_PACKAGE');
@@ -716,10 +717,10 @@ create or replace package body test_suite_builder is
                   '%<NAME>nested_context_2</NAME><DESCRIPTION>nested_context_2</DESCRIPTION><PATH>some_package.a_context.nested_context_2</PATH>' ||
                   '%<ITEMS>' ||
                     '<UT_SUITE_ITEM>' ||
-                      '%<NAME>a_nested_context_3</NAME><DESCRIPTION>a_nested_context_3</DESCRIPTION><PATH>some_package.a_context.nested_context_2.a_nested_context_3</PATH>' ||
+                      '%<NAME>nested_context_#1</NAME><DESCRIPTION>a_nested_context_3</DESCRIPTION><PATH>some_package.a_context.nested_context_2.nested_context_#1</PATH>' ||
                       '%<ITEMS>' ||
                         '<UT_SUITE_ITEM>' ||
-                          '%<NAME>test_in_nested_context_3</NAME><DESCRIPTION>Test in nested context</DESCRIPTION><PATH>some_package.a_context.nested_context_2.a_nested_context_3.test_in_nested_context_3</PATH>' ||
+                          '%<NAME>test_in_nested_context_3</NAME><DESCRIPTION>Test in nested context</DESCRIPTION><PATH>some_package.a_context.nested_context_2.nested_context_#1.test_in_nested_context_3</PATH>' ||
                         '%</UT_SUITE_ITEM>' ||
                       '</ITEMS>' ||
                       '<BEFORE_ALL_LIST/>' ||
@@ -775,7 +776,7 @@ create or replace package body test_suite_builder is
     l_annotations := ut3.ut_annotations(
         ut3.ut_annotation(1, 'suite', 'Cool', null),
         ut3.ut_annotation(2, 'test', 'In suite', 'suite_level_test'),
-        ut3.ut_annotation(3, 'context', 'a_context', null),
+        ut3.ut_annotation(3, 'context', 'A context', null),
         ut3.ut_annotation(4, 'beforeall', 'context_beforeall', null),
         ut3.ut_annotation(5, 'beforeeach', null, 'context_beforeeach'),
         ut3.ut_annotation(6, 'test', 'In context', 'test_in_a_context'),
@@ -791,7 +792,7 @@ create or replace package body test_suite_builder is
       '<UT_LOGICAL_SUITE>' ||
         '%<ITEMS>' ||
           '%<UT_SUITE_ITEM>' ||
-            '%<NAME>a_context</NAME>' ||
+            '%<NAME>nested_context_#1</NAME><DESCRIPTION>A context</DESCRIPTION><PATH>some_package.nested_context_#1</PATH>' ||
             '%<ITEMS>' ||
               '%<UT_SUITE_ITEM>' ||
                 '%<NAME>test_in_a_context</NAME>' ||
@@ -827,7 +828,7 @@ create or replace package body test_suite_builder is
         ut3.ut_annotation(2, 'beforeall',null, 'suite_level_beforeall'),
         ut3.ut_annotation(3, 'beforeeach',null, 'suite_level_beforeeach'),
         ut3.ut_annotation(4, 'test','In suite', 'suite_level_test'),
-        ut3.ut_annotation(5, 'context','a_context', null),
+        ut3.ut_annotation(5, 'context',null, null),
         ut3.ut_annotation(6, 'test', 'In context', 'test_in_a_context'),
         ut3.ut_annotation(7, 'endcontext',null, null),
         ut3.ut_annotation(8, 'aftereach',null, 'suite_level_aftereach'),
@@ -841,7 +842,7 @@ create or replace package body test_suite_builder is
       '<UT_LOGICAL_SUITE>' ||
         '%<ITEMS>' ||
           '%<UT_SUITE_ITEM>' ||
-            '%<NAME>a_context</NAME>' ||
+            '%<NAME>nested_context_#1</NAME><DESCRIPTION>nested_context_#1</DESCRIPTION><PATH>some_package.nested_context_#1</PATH>' ||
             '%<ITEMS>' ||
               '%<UT_SUITE_ITEM>' ||
                 '%<NAME>test_in_a_context</NAME>' ||
@@ -876,8 +877,9 @@ create or replace package body test_suite_builder is
         ut3.ut_annotation(1, 'suite','Cool', null),
         ut3.ut_annotation(2, 'beforeall',null, 'suite_level_beforeall'),
         ut3.ut_annotation(3, 'test','In suite', 'suite_level_test'),
-        ut3.ut_annotation(4, 'context','a_context', null),
-        ut3.ut_annotation(5, 'beforeall',null, 'context_setup'),
+        ut3.ut_annotation(4, 'context','Some context', null),
+        ut3.ut_annotation(5, 'name','a_context', null),
+        ut3.ut_annotation(6, 'beforeall',null, 'context_setup'),
         ut3.ut_annotation(7, 'test', 'In context', 'test_in_a_context')
     );
     --Act
@@ -891,7 +893,7 @@ create or replace package body test_suite_builder is
         '<ROWSET><ROW>'||
         '<UT_LOGICAL_SUITE>' ||
           '%<ITEMS>' ||
-            '%<NAME>a_context</NAME><DESCRIPTION>a_context</DESCRIPTION><PATH>some_package.a_context</PATH>' ||
+            '%<NAME>a_context</NAME><DESCRIPTION>Some context</DESCRIPTION><PATH>some_package.a_context</PATH>' ||
             '%<ITEMS>' ||
               '<UT_SUITE_ITEM>' ||
                 '%<NAME>test_in_a_context</NAME><DESCRIPTION>In context</DESCRIPTION><PATH>some_package.a_context.test_in_a_context</PATH>' ||
@@ -922,8 +924,8 @@ create or replace package body test_suite_builder is
         ut3.ut_annotation(1, 'suite','Cool', null),
         ut3.ut_annotation(2, 'beforeall',null, 'suite_level_beforeall'),
         ut3.ut_annotation(3, 'test','In suite', 'suite_level_test'),
-        ut3.ut_annotation(4, 'context','a_context', null),
-        ut3.ut_annotation(5, 'displayname','A context', null),
+        ut3.ut_annotation(4, 'context','A context', null),
+        ut3.ut_annotation(5, 'name','a_context', null),
         ut3.ut_annotation(6, 'beforeall',null, 'context_setup'),
         ut3.ut_annotation(7, 'test', 'In context', 'test_in_a_context'),
         ut3.ut_annotation(8, 'endcontext',null, null),
@@ -974,13 +976,13 @@ create or replace package body test_suite_builder is
           ut3.ut_annotation(1, 'suite','Cool', null),
           ut3.ut_annotation(2, 'beforeall',null, 'suite_level_beforeall'),
           ut3.ut_annotation(3, 'test','In suite', 'suite_level_test'),
-          ut3.ut_annotation(4, 'context','a_context', null),
-          ut3.ut_annotation(5, 'displayname','A context', null),
+          ut3.ut_annotation(4, 'context','A context', null),
+          ut3.ut_annotation(5, 'name','a_context', null),
           ut3.ut_annotation(6, 'beforeall',null, 'context_setup'),
           ut3.ut_annotation(7, 'test', 'In context', 'test_in_a_context'),
           ut3.ut_annotation(8, 'endcontext',null, null),
-          ut3.ut_annotation(9, 'context','a_context', null),
-          ut3.ut_annotation(10, 'displayname','A context', null),
+          ut3.ut_annotation(9, 'context','A context', null),
+          ut3.ut_annotation(10, 'name','a_context', null),
           ut3.ut_annotation(11, 'beforeall',null, 'setup_in_duplicated_context'),
           ut3.ut_annotation(12, 'test', 'In duplicated context', 'test_in_duplicated_context'),
           ut3.ut_annotation(13, 'endcontext',null, null)
@@ -989,31 +991,43 @@ create or replace package body test_suite_builder is
       l_actual := invoke_builder_for_annotations(l_annotations, 'SOME_PACKAGE');
       --Assert
       ut.expect(l_actual).to_be_like(
-          '%<WARNINGS><VARCHAR2>Context name must be unique in a suite. Context and all of it&apos;s content ignored.%at package &quot;UT3_TESTER.SOME_PACKAGE&quot;, line 9</VARCHAR2></WARNINGS>%'
+          '%<WARNINGS><VARCHAR2>Context name &quot;a_context&quot; already used in this scope. Name must be unique. Using fallback name nested_context_#2.%</VARCHAR2></WARNINGS>%'
           ,'\'
       );
       ut.expect(l_actual).to_be_like(
           '<ROWSET><ROW>'||
           '<UT_LOGICAL_SUITE>' ||
           '%<ITEMS>' ||
-          '<UT_SUITE_ITEM>' ||
-          '%<NAME>a_context</NAME><DESCRIPTION>A context</DESCRIPTION><PATH>some_package.a_context</PATH>' ||
-          '%<ITEMS>' ||
-          '<UT_SUITE_ITEM>' ||
-          '%<NAME>test_in_a_context</NAME><DESCRIPTION>In context</DESCRIPTION><PATH>some_package.a_context.test_in_a_context</PATH>' ||
-          '%</UT_SUITE_ITEM>' ||
+            '<UT_SUITE_ITEM>' ||
+              '%<NAME>nested_context_#2</NAME><DESCRIPTION>A context</DESCRIPTION><PATH>some_package.nested_context_#2</PATH>' ||
+              '%<ITEMS>' ||
+                '<UT_SUITE_ITEM>' ||
+                  '%<NAME>test_in_duplicated_context</NAME><DESCRIPTION>In duplicated context</DESCRIPTION><PATH>some_package.nested_context_#2.test_in_duplicated_context</PATH>' ||
+                '%</UT_SUITE_ITEM>' ||
+              '</ITEMS>' ||
+              '<BEFORE_ALL_LIST>' ||
+                '%<OBJECT_NAME>some_package</OBJECT_NAME><PROCEDURE_NAME>setup_in_duplicated_context</PROCEDURE_NAME>' ||
+              '%</BEFORE_ALL_LIST>' ||
+              '<AFTER_ALL_LIST/>' ||
+            '</UT_SUITE_ITEM>' ||
+            '<UT_SUITE_ITEM>' ||
+              '%<NAME>a_context</NAME><DESCRIPTION>A context</DESCRIPTION><PATH>some_package.a_context</PATH>' ||
+              '%<ITEMS>' ||
+                '<UT_SUITE_ITEM>' ||
+                  '%<NAME>test_in_a_context</NAME><DESCRIPTION>In context</DESCRIPTION><PATH>some_package.a_context.test_in_a_context</PATH>' ||
+                '%</UT_SUITE_ITEM>' ||
+              '</ITEMS>' ||
+              '<BEFORE_ALL_LIST>' ||
+                '%<OBJECT_NAME>some_package</OBJECT_NAME><PROCEDURE_NAME>context_setup</PROCEDURE_NAME>' ||
+              '%</BEFORE_ALL_LIST>' ||
+              '<AFTER_ALL_LIST/>' ||
+            '</UT_SUITE_ITEM>' ||
+            '<UT_SUITE_ITEM>' ||
+                '%<NAME>suite_level_test</NAME><DESCRIPTION>In suite</DESCRIPTION><PATH>some_package.suite_level_test</PATH>' ||
+            '%</UT_SUITE_ITEM>' ||
           '</ITEMS>' ||
           '<BEFORE_ALL_LIST>' ||
-          '%<OBJECT_NAME>some_package</OBJECT_NAME><PROCEDURE_NAME>context_setup</PROCEDURE_NAME>' ||
-          '%</BEFORE_ALL_LIST>' ||
-          '<AFTER_ALL_LIST/>' ||
-          '</UT_SUITE_ITEM>' ||
-          '<UT_SUITE_ITEM>' ||
-          '%<NAME>suite_level_test</NAME><DESCRIPTION>In suite</DESCRIPTION><PATH>some_package.suite_level_test</PATH>' ||
-          '%</UT_SUITE_ITEM>' ||
-          '</ITEMS>' ||
-          '<BEFORE_ALL_LIST>' ||
-          '%<OBJECT_NAME>some_package</OBJECT_NAME><PROCEDURE_NAME>suite_level_beforeall</PROCEDURE_NAME>' ||
+            '%<OBJECT_NAME>some_package</OBJECT_NAME><PROCEDURE_NAME>suite_level_beforeall</PROCEDURE_NAME>' ||
           '%</BEFORE_ALL_LIST>' ||
           '<AFTER_ALL_LIST/>' ||
           '</UT_LOGICAL_SUITE>'||
@@ -1027,10 +1041,11 @@ create or replace package body test_suite_builder is
     l_bad_name    varchar2(100);
   begin
     --Arrange
-    l_bad_name := 'Context with invalid name. Should fail';
+    l_bad_name := 'ctx_with_dot.in_it';
     l_annotations := ut3.ut_annotations(
       ut3.ut_annotation(1, 'suite','Cool', null),
-      ut3.ut_annotation(4, 'context','Context with invalid name. Should fail', null),
+      ut3.ut_annotation(4, 'context',null, null),
+      ut3.ut_annotation(5, 'name',l_bad_name, null),
       ut3.ut_annotation(7, 'test', 'In context', 'test_in_a_context'),
       ut3.ut_annotation(13, 'endcontext',null, null)
       );
@@ -1038,21 +1053,195 @@ create or replace package body test_suite_builder is
     l_actual := invoke_builder_for_annotations(l_annotations, 'SOME_PACKAGE');
     --Assert
     ut.expect(l_actual).to_be_like(
-      '%Invalid value &quot;'||l_bad_name||'&quot; for context name. The name cannot contain &quot;.&quot; (full stop/period) character. Context name ignored and fallback to auto-name &quot;context_1&quot;%'
+      '%Invalid value &quot;'||l_bad_name||'&quot; for context name. Context name ignored and fallback to auto-name &quot;nested_context_#1&quot;%'
     );
     ut.expect(l_actual).to_be_like(
       '<ROWSET><ROW>'||
         '<UT_LOGICAL_SUITE>' ||
         '%<ITEMS>' ||
         '<UT_SUITE_ITEM>' ||
-          '%<NAME>context_1</NAME><DESCRIPTION>Context with invalid name. Should fail</DESCRIPTION><PATH>some_package.context_1</PATH>' ||
+          '%<NAME>nested_context_#1</NAME><DESCRIPTION>nested_context_#1</DESCRIPTION><PATH>some_package.nested_context_#1</PATH>' ||
           '%<ITEMS>' ||
             '<UT_SUITE_ITEM>' ||
-              '%<NAME>test_in_a_context</NAME><DESCRIPTION>In context</DESCRIPTION><PATH>some_package.context_1.test_in_a_context</PATH>' ||
+              '%<NAME>test_in_a_context</NAME><DESCRIPTION>In context</DESCRIPTION><PATH>some_package.nested_context_#1.test_in_a_context</PATH>' ||
             '%</UT_SUITE_ITEM>' ||
           '</ITEMS>%' ||
         '</UT_SUITE_ITEM>%' ||
         '</ITEMS>%' ||
+        '</UT_LOGICAL_SUITE>'||
+        '</ROW></ROWSET>'
+      );
+  end;
+
+  procedure name_with_spaces_invalid is
+    l_actual      clob;
+    l_annotations ut3.ut_annotations;
+    l_bad_name    varchar2(100);
+  begin
+    --Arrange
+    l_bad_name := 'context name with spaces';
+    l_annotations := ut3.ut_annotations(
+      ut3.ut_annotation(1, 'suite','Cool', null),
+      ut3.ut_annotation(4, 'context',null, null),
+      ut3.ut_annotation(5, 'name',l_bad_name, null),
+      ut3.ut_annotation(7, 'test', 'In context', 'test_in_a_context'),
+      ut3.ut_annotation(13, 'endcontext',null, null)
+      );
+    --Act
+    l_actual := invoke_builder_for_annotations(l_annotations, 'SOME_PACKAGE');
+    --Assert
+    ut.expect(l_actual).to_be_like(
+      '%Invalid value &quot;'||l_bad_name||'&quot; for context name. Context name ignored and fallback to auto-name &quot;nested_context_#1&quot;%'
+      );
+    ut.expect(l_actual).to_be_like(
+      '<ROWSET><ROW>'||
+        '<UT_LOGICAL_SUITE>' ||
+        '%<ITEMS>' ||
+        '<UT_SUITE_ITEM>' ||
+        '%<NAME>nested_context_#1</NAME><DESCRIPTION>nested_context_#1</DESCRIPTION><PATH>some_package.nested_context_#1</PATH>' ||
+        '%<ITEMS>' ||
+        '<UT_SUITE_ITEM>' ||
+        '%<NAME>test_in_a_context</NAME><DESCRIPTION>In context</DESCRIPTION><PATH>some_package.nested_context_#1.test_in_a_context</PATH>' ||
+        '%</UT_SUITE_ITEM>' ||
+        '</ITEMS>%' ||
+        '</UT_SUITE_ITEM>%' ||
+        '</ITEMS>%' ||
+        '</UT_LOGICAL_SUITE>'||
+        '</ROW></ROWSET>'
+      );
+  end;
+
+  procedure duplicate_name_annotation is
+    l_actual      clob;
+    l_annotations ut3.ut_annotations;
+  begin
+    --Arrange
+    l_annotations := ut3.ut_annotations(
+      ut3.ut_annotation(1, 'suite','Cool', null),
+      ut3.ut_annotation(4, 'context','A context', null),
+      ut3.ut_annotation(5, 'name','a_context_name', null),
+      ut3.ut_annotation(6, 'name','a_newer_context_name', null),
+      ut3.ut_annotation(7, 'test', 'In context', 'test_in_a_context'),
+      ut3.ut_annotation(8, 'endcontext',null, null),
+      ut3.ut_annotation(12, 'test', 'In suite', 'suite_level_test')
+      );
+    --Act
+    l_actual := invoke_builder_for_annotations(l_annotations, 'SOME_PACKAGE');
+    --Assert
+    ut.expect(l_actual).to_be_like(
+      '%<WARNINGS><VARCHAR2>Duplicate annotation &quot;--%name&quot;. Annotation ignored.%</VARCHAR2></WARNINGS>%'
+      ,'\'
+      );
+    ut.expect(l_actual).to_be_like(
+      '<ROWSET><ROW>'||
+        '<UT_LOGICAL_SUITE>' ||
+          '%<ITEMS>' ||
+            '<UT_SUITE_ITEM>' ||
+              '%<NAME>a_context_name</NAME><DESCRIPTION>A context</DESCRIPTION><PATH>some_package.a_context_name</PATH>' ||
+              '%<ITEMS>' ||
+                '<UT_SUITE_ITEM>' ||
+                  '%<NAME>test_in_a_context</NAME><DESCRIPTION>In context</DESCRIPTION><PATH>some_package.a_context_name.test_in_a_context</PATH>' ||
+                '%</UT_SUITE_ITEM>' ||
+              '</ITEMS>' ||
+              '<BEFORE_ALL_LIST/>' ||
+              '<AFTER_ALL_LIST/>'  ||
+            '</UT_SUITE_ITEM>' ||
+            '<UT_SUITE_ITEM>' ||
+              '%<NAME>suite_level_test</NAME><DESCRIPTION>In suite</DESCRIPTION><PATH>some_package.suite_level_test</PATH>' ||
+            '%</UT_SUITE_ITEM>' ||
+          '</ITEMS>' ||
+          '<BEFORE_ALL_LIST/>' ||
+          '<AFTER_ALL_LIST/>'  ||
+        '</UT_LOGICAL_SUITE>'||
+        '</ROW></ROWSET>'
+      );
+  end;
+
+  procedure name_outside_of_context is
+    l_actual      clob;
+    l_annotations ut3.ut_annotations;
+  begin
+    --Arrange
+    l_annotations := ut3.ut_annotations(
+      ut3.ut_annotation(1, 'suite','Cool', null),
+      ut3.ut_annotation(3, 'name','a_context_name', null),
+      ut3.ut_annotation(4, 'context','A context', null),
+      ut3.ut_annotation(7, 'test', 'In context', 'test_in_a_context'),
+      ut3.ut_annotation(8, 'endcontext',null, null),
+      ut3.ut_annotation(12, 'test', 'In suite', 'suite_level_test')
+      );
+    --Act
+    l_actual := invoke_builder_for_annotations(l_annotations, 'SOME_PACKAGE');
+    --Assert
+    ut.expect(l_actual).to_be_like(
+      '%<WARNINGS/>%'
+      ,'\'
+      );
+    ut.expect(l_actual).to_be_like(
+      '<ROWSET><ROW>'||
+        '<UT_LOGICAL_SUITE>' ||
+          '%<ITEMS>' ||
+            '<UT_SUITE_ITEM>' ||
+              '%<NAME>nested_context_#1</NAME><DESCRIPTION>A context</DESCRIPTION><PATH>some_package.nested_context_#1</PATH>' ||
+              '%<ITEMS>' ||
+                '<UT_SUITE_ITEM>' ||
+                  '%<NAME>test_in_a_context</NAME><DESCRIPTION>In context</DESCRIPTION><PATH>some_package.nested_context_#1.test_in_a_context</PATH>' ||
+                '%</UT_SUITE_ITEM>' ||
+              '</ITEMS>' ||
+              '<BEFORE_ALL_LIST/>' ||
+              '<AFTER_ALL_LIST/>'  ||
+            '</UT_SUITE_ITEM>' ||
+            '<UT_SUITE_ITEM>' ||
+              '%<NAME>suite_level_test</NAME><DESCRIPTION>In suite</DESCRIPTION><PATH>some_package.suite_level_test</PATH>' ||
+            '%</UT_SUITE_ITEM>' ||
+          '</ITEMS>' ||
+          '<BEFORE_ALL_LIST/>' ||
+          '<AFTER_ALL_LIST/>'  ||
+        '</UT_LOGICAL_SUITE>'||
+        '</ROW></ROWSET>'
+      );
+  end;
+
+  procedure name_empty_value is
+    l_actual      clob;
+    l_annotations ut3.ut_annotations;
+  begin
+    --Arrange
+    l_annotations := ut3.ut_annotations(
+      ut3.ut_annotation(1, 'suite','Cool', null),
+      ut3.ut_annotation(4, 'context','A context', null),
+      ut3.ut_annotation(5, 'name',null, null),
+      ut3.ut_annotation(7, 'test', 'In context', 'test_in_a_context'),
+      ut3.ut_annotation(8, 'endcontext',null, null),
+      ut3.ut_annotation(12, 'test', 'In suite', 'suite_level_test')
+      );
+    --Act
+    l_actual := invoke_builder_for_annotations(l_annotations, 'SOME_PACKAGE');
+    --Assert
+    ut.expect(l_actual).to_be_like(
+      '%<WARNINGS/>%'
+      ,'\'
+      );
+    ut.expect(l_actual).to_be_like(
+      '<ROWSET><ROW>'||
+        '<UT_LOGICAL_SUITE>' ||
+          '%<ITEMS>' ||
+            '<UT_SUITE_ITEM>' ||
+              '%<NAME>nested_context_#1</NAME><DESCRIPTION>A context</DESCRIPTION><PATH>some_package.nested_context_#1</PATH>' ||
+              '%<ITEMS>' ||
+                '<UT_SUITE_ITEM>' ||
+                  '%<NAME>test_in_a_context</NAME><DESCRIPTION>In context</DESCRIPTION><PATH>some_package.nested_context_#1.test_in_a_context</PATH>' ||
+                '%</UT_SUITE_ITEM>' ||
+              '</ITEMS>' ||
+              '<BEFORE_ALL_LIST/>' ||
+              '<AFTER_ALL_LIST/>'  ||
+            '</UT_SUITE_ITEM>' ||
+            '<UT_SUITE_ITEM>' ||
+              '%<NAME>suite_level_test</NAME><DESCRIPTION>In suite</DESCRIPTION><PATH>some_package.suite_level_test</PATH>' ||
+            '%</UT_SUITE_ITEM>' ||
+          '</ITEMS>' ||
+          '<BEFORE_ALL_LIST/>' ||
+          '<AFTER_ALL_LIST/>'  ||
         '</UT_LOGICAL_SUITE>'||
         '</ROW></ROWSET>'
       );

--- a/test/ut3_tester/core/test_suite_builder.pkb
+++ b/test/ut3_tester/core/test_suite_builder.pkb
@@ -674,6 +674,99 @@ create or replace package body test_suite_builder is
     );
   end;
 
+  procedure nested_contexts is
+    l_actual      clob;
+    l_annotations ut3.ut_annotations;
+  begin
+    --Arrange
+    l_annotations := ut3.ut_annotations(
+      ut3.ut_annotation( 1, 'suite','Cool', null),
+      ut3.ut_annotation( 2, 'beforeall',null, 'suite_level_beforeall'),
+      ut3.ut_annotation( 3, 'test','In suite', 'suite_level_test'),
+      ut3.ut_annotation( 4, 'context','a_context', null),
+      ut3.ut_annotation( 5,   'displayname','A context', null),
+      ut3.ut_annotation( 6,   'beforeall',null, 'context_setup'),
+      ut3.ut_annotation( 7,   'test', 'First test in context', 'first_test_in_a_context'),
+      ut3.ut_annotation( 8,   'context','a_nested_context', null),
+      ut3.ut_annotation( 9,     'displayname','A nested context', null),
+      ut3.ut_annotation(10,     'beforeall',null, 'nested_context_setup'),
+      ut3.ut_annotation(11,     'test', 'Test in nested context', 'test_in_nested_context'),
+      ut3.ut_annotation(12,   'endcontext',null, null),
+      ut3.ut_annotation(13,   'context','nested_context_2', null),
+      ut3.ut_annotation(14,     'test', 'Test in nested context', 'test_in_nested_context_2'),
+      ut3.ut_annotation(15,     'context','a_nested_context_3', null),
+      ut3.ut_annotation(16,       'test', 'Test in nested context', 'test_in_nested_context_3'),
+      ut3.ut_annotation(17,     'endcontext',null, null),
+      ut3.ut_annotation(18,   'endcontext',null, null),
+      ut3.ut_annotation(19,   'test', 'Second test in context', 'second_test_in_a_context'),
+      ut3.ut_annotation(20, 'endcontext',null, null)
+      );
+    --Act
+    l_actual := invoke_builder_for_annotations(l_annotations, 'SOME_PACKAGE');
+    --Assert
+    ut.expect(l_actual).to_be_like(
+      '<ROWSET><ROW>'||
+        '<UT_LOGICAL_SUITE>' ||
+          '%<WARNINGS/>' ||
+          '%<ITEMS>' ||
+            '<UT_SUITE_ITEM>' ||
+              '%<NAME>a_context</NAME><DESCRIPTION>A context</DESCRIPTION><PATH>some_package.a_context</PATH>' ||
+              '%<ITEMS>' ||
+                '<UT_SUITE_ITEM>' ||
+                  '%<NAME>nested_context_2</NAME><DESCRIPTION>nested_context_2</DESCRIPTION><PATH>some_package.a_context.nested_context_2</PATH>' ||
+                  '%<ITEMS>' ||
+                    '<UT_SUITE_ITEM>' ||
+                      '%<NAME>a_nested_context_3</NAME><DESCRIPTION>a_nested_context_3</DESCRIPTION><PATH>some_package.a_context.nested_context_2.a_nested_context_3</PATH>' ||
+                      '%<ITEMS>' ||
+                        '<UT_SUITE_ITEM>' ||
+                          '%<NAME>test_in_nested_context_3</NAME><DESCRIPTION>Test in nested context</DESCRIPTION><PATH>some_package.a_context.nested_context_2.a_nested_context_3.test_in_nested_context_3</PATH>' ||
+                        '%</UT_SUITE_ITEM>' ||
+                      '</ITEMS>' ||
+                      '<BEFORE_ALL_LIST/>' ||
+                    '%</UT_SUITE_ITEM>' ||
+                    '<UT_SUITE_ITEM>' ||
+                      '%<NAME>test_in_nested_context_2</NAME><DESCRIPTION>Test in nested context</DESCRIPTION><PATH>some_package.a_context.nested_context_2.test_in_nested_context_2</PATH>' ||
+                    '%</UT_SUITE_ITEM>' ||
+                  '</ITEMS>' ||
+                  '<BEFORE_ALL_LIST/>' ||
+                '%</UT_SUITE_ITEM>' ||
+                '<UT_SUITE_ITEM>' ||
+                  '%<NAME>a_nested_context</NAME><DESCRIPTION>A nested context</DESCRIPTION><PATH>some_package.a_context.a_nested_context</PATH>' ||
+                  '%<ITEMS>' ||
+                    '<UT_SUITE_ITEM>' ||
+                      '%<NAME>test_in_nested_context</NAME><DESCRIPTION>Test in nested context</DESCRIPTION><PATH>some_package.a_context.a_nested_context.test_in_nested_context</PATH>' ||
+                    '%</UT_SUITE_ITEM>' ||
+                  '</ITEMS>' ||
+                  '<BEFORE_ALL_LIST>' ||
+                    '%<OBJECT_NAME>some_package</OBJECT_NAME><PROCEDURE_NAME>nested_context_setup</PROCEDURE_NAME>' ||
+                  '%</BEFORE_ALL_LIST>' ||
+                '%</UT_SUITE_ITEM>' ||
+                '<UT_SUITE_ITEM>' ||
+                  '%<NAME>first_test_in_a_context</NAME><DESCRIPTION>First test in context</DESCRIPTION><PATH>some_package.a_context.first_test_in_a_context</PATH>' ||
+                '%</UT_SUITE_ITEM>' ||
+                '<UT_SUITE_ITEM>' ||
+                  '%<NAME>second_test_in_a_context</NAME><DESCRIPTION>Second test in context</DESCRIPTION><PATH>some_package.a_context.second_test_in_a_context</PATH>' ||
+                '%</UT_SUITE_ITEM>' ||
+              '</ITEMS>' ||
+              '<BEFORE_ALL_LIST>' ||
+                '%<OBJECT_NAME>some_package</OBJECT_NAME><PROCEDURE_NAME>context_setup</PROCEDURE_NAME>' ||
+              '%</BEFORE_ALL_LIST>' ||
+              '<AFTER_ALL_LIST/>' ||
+            '</UT_SUITE_ITEM>' ||
+            '<UT_SUITE_ITEM>' ||
+            '%<NAME>suite_level_test</NAME><DESCRIPTION>In suite</DESCRIPTION><PATH>some_package.suite_level_test</PATH>' ||
+            '%</UT_SUITE_ITEM>' ||
+          '</ITEMS>' ||
+          '<BEFORE_ALL_LIST>' ||
+          '%<OBJECT_NAME>some_package</OBJECT_NAME><PROCEDURE_NAME>suite_level_beforeall</PROCEDURE_NAME>' ||
+          '%</BEFORE_ALL_LIST>' ||
+          '<AFTER_ALL_LIST/>' ||
+        '</UT_LOGICAL_SUITE>'||
+        '</ROW></ROWSET>'
+      );
+  end;
+
+
   procedure before_after_in_context is
     l_actual      clob;
     l_annotations ut3.ut_annotations;
@@ -783,7 +876,7 @@ create or replace package body test_suite_builder is
         ut3.ut_annotation(1, 'suite','Cool', null),
         ut3.ut_annotation(2, 'beforeall',null, 'suite_level_beforeall'),
         ut3.ut_annotation(3, 'test','In suite', 'suite_level_test'),
-        ut3.ut_annotation(4, 'context','A context', null),
+        ut3.ut_annotation(4, 'context','a_context', null),
         ut3.ut_annotation(5, 'beforeall',null, 'context_setup'),
         ut3.ut_annotation(7, 'test', 'In context', 'test_in_a_context')
     );
@@ -791,25 +884,30 @@ create or replace package body test_suite_builder is
     l_actual := invoke_builder_for_annotations(l_annotations, 'SOME_PACKAGE');
     --Assert
     ut.expect(l_actual).to_be_like(
-        '%<WARNINGS><VARCHAR2>Invalid annotation &quot;--\%context&quot;. Cannot find following &quot;--\%endcontext&quot;. Annotation ignored.%at package &quot;UT3_TESTER.SOME_PACKAGE&quot;, line 4</VARCHAR2></WARNINGS>%'
+        '%<WARNINGS><VARCHAR2>Missing &quot;--\%endcontext&quot; annotation for a &quot;--\%context&quot; annotation. The end of context considered be end of package.%at package &quot;UT3_TESTER.SOME_PACKAGE&quot;, line 4</VARCHAR2></WARNINGS>%'
         ,'\'
     );
     ut.expect(l_actual).to_be_like(
         '<ROWSET><ROW>'||
         '<UT_LOGICAL_SUITE>' ||
-        '%<ITEMS>' ||
-        '<UT_SUITE_ITEM>' ||
-        '%<NAME>suite_level_test</NAME><DESCRIPTION>In suite</DESCRIPTION><PATH>some_package.suite_level_test</PATH>' ||
-        '%</UT_SUITE_ITEM>' ||
-        '<UT_SUITE_ITEM>' ||
-        '%<NAME>test_in_a_context</NAME><DESCRIPTION>In context</DESCRIPTION><PATH>some_package.test_in_a_context</PATH>' ||
-        '%</UT_SUITE_ITEM>' ||
-        '</ITEMS>' ||
-        '<BEFORE_ALL_LIST>' ||
-        '%<OBJECT_NAME>some_package</OBJECT_NAME><PROCEDURE_NAME>suite_level_beforeall</PROCEDURE_NAME>' ||
-        '%<OBJECT_NAME>some_package</OBJECT_NAME><PROCEDURE_NAME>context_setup</PROCEDURE_NAME>' ||
-        '%</BEFORE_ALL_LIST>' ||
-        '<AFTER_ALL_LIST/>' ||
+          '%<ITEMS>' ||
+            '%<NAME>a_context</NAME><DESCRIPTION>a_context</DESCRIPTION><PATH>some_package.a_context</PATH>' ||
+            '%<ITEMS>' ||
+              '<UT_SUITE_ITEM>' ||
+                '%<NAME>test_in_a_context</NAME><DESCRIPTION>In context</DESCRIPTION><PATH>some_package.a_context.test_in_a_context</PATH>' ||
+              '%</UT_SUITE_ITEM>' ||
+            '</ITEMS>' ||
+            '<BEFORE_ALL_LIST>' ||
+              '%<OBJECT_NAME>some_package</OBJECT_NAME><PROCEDURE_NAME>context_setup</PROCEDURE_NAME>' ||
+            '%</BEFORE_ALL_LIST>' ||
+            '%<UT_SUITE_ITEM>' ||
+              '%<NAME>suite_level_test</NAME><DESCRIPTION>In suite</DESCRIPTION><PATH>some_package.suite_level_test</PATH>' ||
+            '%</UT_SUITE_ITEM>' ||
+          '</ITEMS>' ||
+          '<BEFORE_ALL_LIST>' ||
+            '%<OBJECT_NAME>some_package</OBJECT_NAME><PROCEDURE_NAME>suite_level_beforeall</PROCEDURE_NAME>' ||
+          '%</BEFORE_ALL_LIST>' ||
+          '<AFTER_ALL_LIST/>' ||
         '</UT_LOGICAL_SUITE>'||
         '</ROW></ROWSET>'
     );
@@ -835,7 +933,7 @@ create or replace package body test_suite_builder is
     l_actual := invoke_builder_for_annotations(l_annotations, 'SOME_PACKAGE');
     --Assert
     ut.expect(l_actual).to_be_like(
-        '%<WARNINGS><VARCHAR2>Invalid annotation &quot;--\%endcontext&quot;. Cannot find preceding &quot;--\%context&quot;. Annotation ignored.%at package &quot;UT3_TESTER.SOME_PACKAGE&quot;, line 9</VARCHAR2></WARNINGS>%'
+        '%<WARNINGS><VARCHAR2>Extra &quot;--\%endcontext&quot; annotation found. Cannot find corresponding &quot;--\%context&quot;. Annotation ignored.%at package &quot;UT3_TESTER.SOME_PACKAGE&quot;, line 9</VARCHAR2></WARNINGS>%'
         ,'\'
     );
     ut.expect(l_actual).to_be_like(
@@ -850,7 +948,7 @@ create or replace package body test_suite_builder is
               '%</UT_SUITE_ITEM>' ||
             '</ITEMS>' ||
             '<BEFORE_ALL_LIST>' ||
-            '%<OBJECT_NAME>some_package</OBJECT_NAME><PROCEDURE_NAME>context_setup</PROCEDURE_NAME>' ||
+              '%<OBJECT_NAME>some_package</OBJECT_NAME><PROCEDURE_NAME>context_setup</PROCEDURE_NAME>' ||
             '%</BEFORE_ALL_LIST>' ||
             '<AFTER_ALL_LIST/>' ||
           '</UT_SUITE_ITEM>' ||
@@ -859,7 +957,7 @@ create or replace package body test_suite_builder is
           '%</UT_SUITE_ITEM>' ||
         '</ITEMS>' ||
         '<BEFORE_ALL_LIST>' ||
-        '%<OBJECT_NAME>some_package</OBJECT_NAME><PROCEDURE_NAME>suite_level_beforeall</PROCEDURE_NAME>' ||
+          '%<OBJECT_NAME>some_package</OBJECT_NAME><PROCEDURE_NAME>suite_level_beforeall</PROCEDURE_NAME>' ||
         '%</BEFORE_ALL_LIST>' ||
         '<AFTER_ALL_LIST/>' ||
       '</UT_LOGICAL_SUITE>'||
@@ -1152,7 +1250,7 @@ create or replace package body test_suite_builder is
         '%<TAGS><VARCHAR2>testtag</VARCHAR2></TAGS>%'||
         '%</UT_SUITE_ITEM>%'
     );
- 
+
   end;
 
   procedure suite_tag_annotation is
@@ -1173,9 +1271,9 @@ create or replace package body test_suite_builder is
         '%<TAGS><VARCHAR2>suitetag</VARCHAR2></TAGS>%'||
         '%</UT_LOGICAL_SUITE>%'
     );
- 
+
   end;
-  
+
   procedure test_tags_annotation is
     l_actual      clob;
     l_annotations ut3.ut_annotations;
@@ -1195,7 +1293,7 @@ create or replace package body test_suite_builder is
         '%<TAGS><VARCHAR2>testtag</VARCHAR2><VARCHAR2>testtag2</VARCHAR2><VARCHAR2>testtag3</VARCHAR2></TAGS>%'||
         '%</UT_SUITE_ITEM>%'
     );
- 
+
   end;
 
   procedure suite_tags_annotation is
@@ -1216,7 +1314,7 @@ create or replace package body test_suite_builder is
         '%<TAGS><VARCHAR2>suitetag</VARCHAR2><VARCHAR2>suitetag1</VARCHAR2><VARCHAR2>suitetag2</VARCHAR2></TAGS>%'||
         '%</UT_LOGICAL_SUITE>%'
     );
- 
+
   end;
 
   procedure test_2line_tags_annotation is
@@ -1239,7 +1337,7 @@ create or replace package body test_suite_builder is
         '%<TAGS><VARCHAR2>testtag</VARCHAR2><VARCHAR2>testtag2</VARCHAR2></TAGS>%'||
         '%</UT_SUITE_ITEM>%'
     );
- 
+
   end;
 
   procedure suite_2line_tags_annotation is
@@ -1261,7 +1359,7 @@ create or replace package body test_suite_builder is
         '%<TAGS><VARCHAR2>suitetag</VARCHAR2><VARCHAR2>suitetag1</VARCHAR2></TAGS>%'||
         '%</UT_LOGICAL_SUITE>%'
     );
- 
+
   end;
 
   procedure test_empty_tag is
@@ -1280,9 +1378,9 @@ create or replace package body test_suite_builder is
         '%<WARNINGS>%&quot;--%tags&quot; annotation requires a tag value populated. Annotation ignored.%</WARNINGS>%'||
         '%<TAGS/>%'
     );
- 
+
   end;
-  
+
   procedure suite_empty_tag is
     l_actual      clob;
     l_annotations ut3.ut_annotations;
@@ -1299,7 +1397,7 @@ create or replace package body test_suite_builder is
         '%<WARNINGS><VARCHAR2>&quot;--%tags&quot; annotation requires a tag value populated. Annotation ignored.%</VARCHAR2></WARNINGS>%'||
         '%<TAGS/>%'
     );
- 
+
   end;
 
   procedure test_duplicate_tag is
@@ -1322,9 +1420,9 @@ create or replace package body test_suite_builder is
         '%<TAGS><VARCHAR2>testtag</VARCHAR2><VARCHAR2>testtag1</VARCHAR2><VARCHAR2>testtag2</VARCHAR2></TAGS>%'||
         '%</UT_SUITE_ITEM>%'
     );
- 
+
   end;
-  
+
   procedure suite_duplicate_tag is
     l_actual      clob;
     l_annotations ut3.ut_annotations;
@@ -1344,7 +1442,7 @@ create or replace package body test_suite_builder is
         '%<TAGS><VARCHAR2>suitetag</VARCHAR2><VARCHAR2>suitetag1</VARCHAR2><VARCHAR2>suitetag2</VARCHAR2></TAGS>%'||
         '%</UT_LOGICAL_SUITE>%'
     );
- 
+
   end;
 
   procedure test_empty_tag_between is
@@ -1366,9 +1464,9 @@ create or replace package body test_suite_builder is
         '%<TAGS><VARCHAR2>testtag</VARCHAR2><VARCHAR2>testtag1</VARCHAR2></TAGS>%'||
         '%</UT_SUITE_ITEM>%'
     );
- 
+
   end;
-  
+
   procedure suite_empty_tag_between is
     l_actual      clob;
     l_annotations ut3.ut_annotations;
@@ -1387,8 +1485,8 @@ create or replace package body test_suite_builder is
         '%<TAGS><VARCHAR2>suitetag</VARCHAR2><VARCHAR2>suitetag1</VARCHAR2></TAGS>%'||
         '%</UT_LOGICAL_SUITE>%'
     );
- 
-  end; 
+
+  end;
 
   procedure test_special_char_tag is
     l_actual      clob;
@@ -1409,9 +1507,9 @@ create or replace package body test_suite_builder is
         '%<TAGS><VARCHAR2>#?$%^&amp;*!|\/@][</VARCHAR2></TAGS>%'||
         '%</UT_SUITE_ITEM>%'
     );
- 
+
   end;
-  
+
   procedure suite_special_char_tag is
     l_actual      clob;
     l_annotations ut3.ut_annotations;
@@ -1430,8 +1528,8 @@ create or replace package body test_suite_builder is
         '%<TAGS><VARCHAR2>#?$%^&amp;*!|\/@][</VARCHAR2></TAGS>%'||
         '%</UT_LOGICAL_SUITE>%'
     );
- 
-  end; 
+
+  end;
 
 end test_suite_builder;
 /

--- a/test/ut3_tester/core/test_suite_builder.pks
+++ b/test/ut3_tester/core/test_suite_builder.pks
@@ -116,6 +116,9 @@ create or replace package test_suite_builder is
   --%test(Creates nested suite for content between context/endcontext annotations)
   procedure suite_from_context;
 
+  --%test(Creates nested contexts inside a context)
+  procedure nested_contexts;
+
   --%test(Associates before/after all/each to tests in context only)
   procedure before_after_in_context;
 

--- a/test/ut3_tester/core/test_suite_builder.pks
+++ b/test/ut3_tester/core/test_suite_builder.pks
@@ -125,7 +125,7 @@ create or replace package test_suite_builder is
   --%test(Propagates beforeeach/aftereach to context)
   procedure before_after_out_of_context;
 
-  --%test(Does not create context and gives warning when endcontext is missing)
+  --%test(Gives warning when endcontext is missing)
   procedure context_without_endcontext;
 
   --%test(Gives warning if --%endcontext is missing a preceding --%context)

--- a/test/ut3_tester/core/test_suite_builder.pks
+++ b/test/ut3_tester/core/test_suite_builder.pks
@@ -134,6 +134,9 @@ create or replace package test_suite_builder is
     --%test(Gives warning when two contexts have the same name and ignores duplicated context)
     procedure duplicate_context_name;
 
+    --%test(Fallback to default naming and gives warning when context name contains "." character)
+    procedure hard_stop_in_ctx_name;
+
   --%endcontext
 
   --%context(throws)

--- a/test/ut3_tester/core/test_suite_builder.pks
+++ b/test/ut3_tester/core/test_suite_builder.pks
@@ -2,8 +2,7 @@ create or replace package test_suite_builder is
   --%suite(suite_builder)
   --%suitepath(utplsql.ut3_tester.core)
 
-  --%context(suite)
-  --%displayname(--%suite annotation)
+  --%context(--%suite annotation)
 
       --%test(Sets suite name from package name and leaves description empty)
       procedure no_suite_description;
@@ -16,8 +15,7 @@ create or replace package test_suite_builder is
 
   --%endcontext
 
-  --%context(displayname)
-  --%displayname(--%displayname annotation)
+  --%context(--%displayname annotation)
 
       --%test(Overrides suite description using first --%displayname annotation)
       procedure suite_descr_from_displayname;
@@ -30,8 +28,7 @@ create or replace package test_suite_builder is
 
   --%endcontext
 
-  --%context(test)
-  --%displayname(--%test annotation)
+  --%context(--%test annotation)
 
       --%test(Creates a test item for procedure annotated with --%test annotation)
       procedure test_annotation;
@@ -44,8 +41,7 @@ create or replace package test_suite_builder is
 
   --%endcontext
 
-  --%context(suitepath)
-  --%displayname(--%suitepath annotation)
+  --%context(--%suitepath annotation)
 
       --%test(Sets suite path using first --%suitepath annotation)
       procedure suitepath_from_non_empty_path;
@@ -61,8 +57,7 @@ create or replace package test_suite_builder is
 
   --%endcontext
 
-  --%context(rollback)
-  --%displayname(--%rollback annotation)
+  --%context--%rollback annotation)
 
       --%test(Sets rollback type using first --%rollback annotation)
       procedure rollback_type_valid;
@@ -78,8 +73,7 @@ create or replace package test_suite_builder is
 
   --%endcontext
 
-  --%context(before_after_all_each)
-  --%displayname(--%before/after all/each annotations)
+  --%context(--%before/after all/each annotations)
 
       --%test(Supports multiple before/after all/each procedure level definitions)
       procedure multiple_before_after;
@@ -110,11 +104,10 @@ create or replace package test_suite_builder is
 
   --%endcontext
 
-  --%context(context)
-  --%displayname(--%context annotation)
+  --%context(--%context annotation)
 
-      --%test(Creates nested suite for content between context/endcontext annotations)
-      procedure suite_from_context;
+    --%test(Creates nested suite for content between context/endcontext annotations)
+    procedure suite_from_context;
 
     --%test(Creates nested contexts inside a context)
     procedure nested_contexts;
@@ -131,16 +124,31 @@ create or replace package test_suite_builder is
     --%test(Gives warning if --%endcontext is missing a preceding --%context)
     procedure endcontext_without_context;
 
-    --%test(Gives warning when two contexts have the same name and ignores duplicated context)
+    --%test(Gives warning when two contexts have the same name and falls back to default context name)
     procedure duplicate_context_name;
-
-    --%test(Fallback to default naming and gives warning when context name contains "." character)
-    procedure hard_stop_in_ctx_name;
 
   --%endcontext
 
-  --%context(throws)
-  --%displayname(--%throws annotation)
+  --%context(--%name annotation)
+
+    --%test(Falls back to default context name and gives warning when context name contains "." character)
+    procedure hard_stop_in_ctx_name;
+
+    --%test(Falls back to default context name and gives warning when name contains spaces)
+    procedure name_with_spaces_invalid;
+
+    --%test(Raises warning when more than one name annotation used )
+    procedure duplicate_name_annotation;
+
+    --%test(Is ignored when used outside of context - no warning given)
+    procedure name_outside_of_context;
+
+    --%test(Is ignored when name value is empty)
+    procedure name_empty_value;
+
+  --%endcontext
+
+  --%context(--%throws annotation)
 
       --%test(Gives warning if --%throws annotation has no value)
       procedure throws_value_empty;
@@ -150,8 +158,7 @@ create or replace package test_suite_builder is
 
   --%endcontext
 
-  --%context(beforetest_aftertest)
-  --%displayname(--%beforetest/aftertest annotation)
+  --%context(--%beforetest/aftertest annotation)
 
       --%test(Supports multiple occurrences of beforetest/aftertest for a test)
       procedure before_aftertest_multi;
@@ -167,8 +174,7 @@ create or replace package test_suite_builder is
 
   --%endcontext
 
-  --%context(unknown_annotation)
-  --%displayname(--%bad_annotation)
+  --%context(--%bad_annotation)
 
       --%test(Gives warning when unknown procedure level annotation passed)
       procedure test_bad_procedure_annotation;
@@ -178,8 +184,7 @@ create or replace package test_suite_builder is
 
   --%endcontext
 
-  --%context(tags_annotation)
-  --%displayname(--%tag_annotation)
+  --%context(--%tag_annotation)
   
       --%test(Build suite test with tag)
       procedure test_tag_annotation;

--- a/test/ut3_tester/core/test_suite_manager.pkb
+++ b/test/ut3_tester/core/test_suite_manager.pkb
@@ -259,8 +259,8 @@ end test_package_3;]';
 
   gv_glob_val number;
 
-  --%context(some_context)
-  --%displayname(Some context description)
+  --%context(Some context description)
+  --%name(some_context)
 
   --%test
   --%displayname(Test1 from test package 1)

--- a/test/ut3_user/api/test_ut_run.pkb
+++ b/test/ut3_user/api/test_ut_run.pkb
@@ -688,7 +688,7 @@ Failures:%
     select * bulk collect into l_results from table(ut3.ut.run('bad_annotations'));
     l_actual :=  ut3_tester_helper.main_helper.table_to_clob(l_results);
 
-    ut.expect(l_actual).to_be_like('%Invalid annotation "--%context". Cannot find following "--%endcontext". Annotation ignored.%
+    ut.expect(l_actual).to_be_like('%Missing "--%endcontext" annotation for a "--%context" annotation. The end of context considered be end of package.%
 %1 tests, 0 failed, 0 errored, 0 disabled, 1 warning(s)%');
 
   end;

--- a/test/ut3_user/api/test_ut_run.pkb
+++ b/test/ut3_user/api/test_ut_run.pkb
@@ -688,7 +688,7 @@ Failures:%
     select * bulk collect into l_results from table(ut3.ut.run('bad_annotations'));
     l_actual :=  ut3_tester_helper.main_helper.table_to_clob(l_results);
 
-    ut.expect(l_actual).to_be_like('%Missing "--%endcontext" annotation for a "--%context" annotation. The end of context considered be end of package.%
+    ut.expect(l_actual).to_be_like('%Missing "--%endcontext" annotation for a "--%context" annotation. The end of package is considered end of context.%
 %1 tests, 0 failed, 0 errored, 0 disabled, 1 warning(s)%');
 
   end;

--- a/test/ut3_user/api/test_ut_run.pkb
+++ b/test/ut3_user/api/test_ut_run.pkb
@@ -1080,9 +1080,8 @@ Failures:%
         --%beforeall
         procedure before_suite;
 
-        --%context(some_context)
-
-          --%displayname(context description)
+        --%context(context description)
+        --%name(some_context)
 
           --%beforeall
           procedure before_context;

--- a/test/ut3_user/reporters.pkb
+++ b/test/ut3_user/reporters.pkb
@@ -14,8 +14,8 @@ as
   --%beforeeach
   procedure beforeeach;
 
-  --%context(some_context)
-  --%displayname(A description of some context)
+  --%context(A description of some context)
+  --%name(some_context)
 
   --%test
   --%beforetest(beforetest)

--- a/test/ut3_user/reporters/test_realtime_reporter.pkb
+++ b/test/ut3_user/reporters/test_realtime_reporter.pkb
@@ -9,7 +9,8 @@ create or replace package body test_realtime_reporter as
       --%suite(suite <A>)
       --%suitepath(realtime_reporting)
 
-      --%context(test context)
+      --%context
+      --%name(test_context)
 
       --%test(test 1 - OK) 
       procedure test_1_ok;
@@ -164,12 +165,12 @@ create or replace package body test_realtime_reporter as
       select 'post-test'  as event_type, 'realtime_reporting.check_realtime_reporting2.test_5'                    as item_id from dual union all
       select 'post-suite' as event_type, 'realtime_reporting.check_realtime_reporting2'                           as item_id from dual union all
       select 'pre-suite'  as event_type, 'realtime_reporting.check_realtime_reporting1'                           as item_id from dual union all
-      select 'pre-suite'  as event_type, 'realtime_reporting.check_realtime_reporting1.test context'              as item_id from dual union all
-      select 'pre-test'   as event_type, 'realtime_reporting.check_realtime_reporting1.test context.test_1_ok'    as item_id from dual union all
-      select 'post-test'  as event_type, 'realtime_reporting.check_realtime_reporting1.test context.test_1_ok'    as item_id from dual union all
-      select 'pre-test'   as event_type, 'realtime_reporting.check_realtime_reporting1.test context.test_2_nok'   as item_id from dual union all
-      select 'post-test'  as event_type, 'realtime_reporting.check_realtime_reporting1.test context.test_2_nok'   as item_id from dual union all
-      select 'post-suite' as event_type, 'realtime_reporting.check_realtime_reporting1.test context'              as item_id from dual union all
+      select 'pre-suite'  as event_type, 'realtime_reporting.check_realtime_reporting1.test_context'              as item_id from dual union all
+      select 'pre-test'   as event_type, 'realtime_reporting.check_realtime_reporting1.test_context.test_1_ok'    as item_id from dual union all
+      select 'post-test'  as event_type, 'realtime_reporting.check_realtime_reporting1.test_context.test_1_ok'    as item_id from dual union all
+      select 'pre-test'   as event_type, 'realtime_reporting.check_realtime_reporting1.test_context.test_2_nok'   as item_id from dual union all
+      select 'post-test'  as event_type, 'realtime_reporting.check_realtime_reporting1.test_context.test_2_nok'   as item_id from dual union all
+      select 'post-suite' as event_type, 'realtime_reporting.check_realtime_reporting1.test_context'              as item_id from dual union all
       select 'post-suite' as event_type, 'realtime_reporting.check_realtime_reporting1'                           as item_id from dual union all
       select 'post-suite' as event_type, 'realtime_reporting'                                                     as item_id from dual union all
       select 'post-run'   as event_type, null                                                                     as item_id from dual;
@@ -310,7 +311,7 @@ create or replace package body test_realtime_reporter as
       into l_actual
       from table(g_events) t
      where t.event_doc.extract('/event[@type="post-test"]/test/@id').getstringval() 
-           = 'realtime_reporting.check_realtime_reporting1.test context.test_2_nok';
+           = 'realtime_reporting.check_realtime_reporting1.test_context.test_2_nok';
     ut.expect(l_actual).to_equal(l_expected);
   end single_failed_message;
   


### PR DESCRIPTION
Added ability to nest contexts in suites - Resolves #938 
Added fix for invalid context name - Resolves #966

Changed approach for context naming - Resolves #1016 

So now you can write tests like a Pro (see [talk](https://www.youtube.com/watch?v=tWn8RA_DEic) by Kevlin Henney)
```sql
create or replace package queue_spec as
  -- %suite(Queue Spec)
  
  -- %context(a_not_empty_queue)
    
    -- %context(that_is_not_full)
      -- %test
      procedure becomes_longer_when_non_null_value_enqueued;
      -- %test
      procedure becomes_full_when_enqueued_up_to_capacity;
    -- %endcontext
    
    -- %context(that_is_full)
      -- %test
      procedure ignores_further_enqueued_values;
      -- %test
      procedure becomes_non_full_when_dequeued;
    -- %endcontext

    -- %test
    procedure dequeues_values_in_order_enqueued;

  -- %endcontext
end;
```
Leading to
```
Queue Spec
  a_not_empty_queue
    that_is_not_full
      becomes_longer_when_non_null_value_enqueued [SUCCESS]
      becomes_full_when_enqueued_up_to_capacity [SUCCESS]
    that_is_full
      ignores_further_enqueued_values [SUCCESS]
      becomes_non_full_when_dequeued [SUCCESS]
    dequeues_values_in_order_enqueued [SUCCESS]
```
