### PR TITLE
Moved validation of `--%throws` annotation values.

### DIFF
--- a/source/core/types/ut_executable_test.tpb
+++ b/source/core/types/ut_executable_test.tpb
@@ -31,7 +31,7 @@ create or replace type body ut_executable_test as
 
   member procedure do_execute(
     self in out nocopy ut_executable_test, a_item in out nocopy ut_suite_item,
-    a_expected_error_codes in ut_integer_list
+    a_expected_error_codes in ut_varchar2_rows
   ) is
     l_completed_without_errors  boolean;
   begin
@@ -40,10 +40,114 @@ create or replace type body ut_executable_test as
 
   member function do_execute(
     self in out nocopy ut_executable_test, a_item in out nocopy ut_suite_item,
-    a_expected_error_codes in ut_integer_list
+    a_expected_error_codes in ut_varchar2_rows
   ) return boolean is
     l_expected_except_message  varchar2(4000);
+    l_expected_error_numbers   ut_integer_list;
 
+    function build_exception_numbers_list(
+      a_item                 in out nocopy ut_suite_item,
+      a_expected_error_codes in ut_varchar2_rows
+    ) return ut_integer_list is
+      l_exception_number        integer;
+      l_exception_number_list   ut_integer_list := ut_integer_list();
+      c_regexp_for_exception_no constant varchar2(30) := '^-?[[:digit:]]{1,5}$';
+
+      c_integer_exception       constant varchar2(1) := 'I';
+      c_named_exception         constant varchar2(1) := 'N';
+
+      function is_valid_qualified_name (a_name varchar2) return boolean is
+        l_name varchar2(500);
+      begin
+        l_name := dbms_assert.qualified_sql_name(a_name);
+        return true;
+      exception when others then
+        return false;
+      end;
+
+      function check_exception_type(a_exception_name in varchar2) return varchar2 is
+        l_exception_type varchar2(50);
+      begin
+        --check if it is a predefined exception
+        begin
+          execute immediate 'begin null; exception when '||a_exception_name||' then null; end;';
+          l_exception_type := c_named_exception;
+        exception
+          when others then
+            if dbms_utility.format_error_stack() like '%PLS-00485%' then
+              declare
+                e_invalid_number exception;
+                pragma exception_init ( e_invalid_number, -6502 );
+              begin
+                execute immediate 'declare x integer := '||a_exception_name||'; begin null; end;';
+                l_exception_type := c_integer_exception;
+              exception
+                when others then
+                  null;
+              end;
+              end if;
+        end;
+        return l_exception_type;
+      end;
+
+      function get_exception_number (a_exception_var in varchar2) return integer is
+        l_exc_no   integer;
+        l_exc_type varchar2(50);
+        function remap_no_data_found (a_number integer) return integer is
+        begin
+          return case a_number when 100 then -1403 else a_number end;
+        end;
+      begin
+        l_exc_type := check_exception_type(a_exception_var);
+
+        execute immediate
+          case l_exc_type
+          when c_integer_exception then
+            'declare l_exception number; begin :l_exception := '||a_exception_var||'; end;'
+          when c_named_exception then
+            'begin raise '||a_exception_var||'; exception when others then :l_exception := sqlcode; end;'
+          else
+            'begin :l_exception := null; end;'
+          end
+          using out l_exc_no;
+
+        return remap_no_data_found(l_exc_no);
+      end;
+
+    begin
+      if a_expected_error_codes is not empty then
+        for i in 1 .. a_expected_error_codes.count loop
+          /**
+          * Check if its a valid qualified name and if so try to resolve name to an exception number
+          */
+          if is_valid_qualified_name(a_expected_error_codes(i)) then
+            l_exception_number := get_exception_number(a_expected_error_codes(i));
+          elsif regexp_like(a_expected_error_codes(i), c_regexp_for_exception_no) then
+            l_exception_number := a_expected_error_codes(i);
+          end if;
+
+          if l_exception_number is null then
+            a_item.put_warning(
+              'Invalid parameter value "'||a_expected_error_codes(i)||'" for "--%throws" annotation. Parameter ignored.',
+              self.procedure_name,
+              a_item.line_no
+            );
+          elsif l_exception_number >= 0 then
+            a_item.put_warning(
+              'Invalid parameter value "'||a_expected_error_codes(i)||'" for "--%throws" annotation. Exception value must be a negative integer. Parameter ignored.',
+              self.procedure_name,
+              a_item.line_no
+              );
+          else
+            l_exception_number_list.extend;
+            l_exception_number_list(l_exception_number_list.last) := l_exception_number;
+          end if;
+          l_exception_number := null;
+        end loop;
+      end if;
+
+      return l_exception_number_list;
+    end;
     function failed_expec_errnum_message(a_expected_error_codes in ut_integer_list) return varchar is
       l_actual_error_no      integer;
       l_expected_error_codes varchar2(4000);
@@ -72,9 +176,9 @@ create or replace type body ut_executable_test as
   begin
     --Create a ut_executable object and call do_execute after that get the data to know the test's execution result
     self.do_execute(a_item);
-
-    if a_expected_error_codes is not null and a_expected_error_codes is not empty then
-      l_expected_except_message := failed_expec_errnum_message(a_expected_error_codes);
+    l_expected_error_numbers := build_exception_numbers_list(a_item, a_expected_error_codes);
+    if l_expected_error_numbers is not null and l_expected_error_numbers is not empty then
+      l_expected_except_message := failed_expec_errnum_message( l_expected_error_numbers );
 
       if l_expected_except_message is not null then
         ut_expectation_processor.add_expectation_result(

--- a/source/core/types/ut_executable_test.tps
+++ b/source/core/types/ut_executable_test.tps
@@ -22,12 +22,12 @@ create or replace type ut_executable_test authid current_user under ut_executabl
   
   member procedure do_execute(
     self in out nocopy ut_executable_test, a_item in out nocopy ut_suite_item, 
-    a_expected_error_codes in ut_integer_list
+    a_expected_error_codes in ut_varchar2_rows
   ),
   
   member function do_execute(
     self in out nocopy ut_executable_test, a_item in out nocopy ut_suite_item, 
-    a_expected_error_codes in ut_integer_list
+    a_expected_error_codes in ut_varchar2_rows
   ) return boolean
   
 ) final;

--- a/source/core/types/ut_suite_cache_row.tps
+++ b/source/core/types/ut_suite_cache_row.tps
@@ -33,7 +33,7 @@ create type ut_suite_cache_row as object (
   before_test_list ut_executables,
   after_each_list ut_executables,
   after_test_list ut_executables,
-  expected_error_codes ut_integer_list,
+  expected_error_codes ut_varchar2_rows,
   tags ut_varchar2_rows,
   item ut_executable_test
 )

--- a/source/core/types/ut_suite_item.tpb
+++ b/source/core/types/ut_suite_item.tpb
@@ -97,6 +97,16 @@ create or replace type body ut_suite_item as
     self.results_count.increase_warning_count;
   end;
 
+  member procedure put_warning(self in out nocopy ut_suite_item, a_message varchar2, a_procedure_name varchar2, a_line_no integer) is
+    l_result varchar2(1000);
+  begin
+    l_result := self.object_owner || '.' || self.object_name ;
+    if a_procedure_name is not null then
+      l_result := l_result || '.' || a_procedure_name ;
+    end if;
+    put_warning( a_message || chr( 10 ) || 'at package "' || upper(l_result) || '", line ' || a_line_no );
+  end;
+
   member function get_transaction_invalidators return ut_varchar2_list is
   begin
     return transaction_invalidators;

--- a/source/core/types/ut_suite_item.tps
+++ b/source/core/types/ut_suite_item.tps
@@ -84,7 +84,8 @@ create or replace type ut_suite_item force under ut_event_item (
   not instantiable member procedure mark_as_errored(self in out nocopy ut_suite_item, a_error_stack_trace varchar2),
   not instantiable member function get_error_stack_traces return ut_varchar2_list,
   not instantiable member function get_serveroutputs return clob,
-  member procedure put_warning(self in out nocopy ut_suite_item, a_message varchar2)
+  member procedure put_warning(self in out nocopy ut_suite_item, a_message varchar2),
+  member procedure put_warning(self in out nocopy ut_suite_item, a_message varchar2, a_procedure_name varchar2, a_line_no integer)
 )
 not final not instantiable
 /

--- a/source/core/types/ut_test.tpb
+++ b/source/core/types/ut_test.tpb
@@ -18,7 +18,7 @@ create or replace type body ut_test as
 
   constructor function ut_test(
     self in out nocopy ut_test, a_object_owner varchar2 := null, a_object_name varchar2, a_name varchar2,
-    a_line_no integer, a_expected_error_codes ut_integer_list := null, a_tags ut_varchar2_rows := null
+    a_line_no integer, a_expected_error_codes ut_varchar2_rows := null, a_tags ut_varchar2_rows := null
   ) return self as result is
   begin
     self.self_type := $$plsql_unit;

--- a/source/core/types/ut_test.tps
+++ b/source/core/types/ut_test.tps
@@ -54,10 +54,10 @@ create or replace type ut_test force under ut_suite_item (
   /**
   *Holds the expected error codes list when the user use the annotation throws
   */
-  expected_error_codes  ut_integer_list,
+  expected_error_codes  ut_varchar2_rows,
   constructor function ut_test(
     self in out nocopy ut_test, a_object_owner varchar2 := null, a_object_name varchar2, a_name varchar2,
-    a_line_no integer, a_expected_error_codes ut_integer_list := null, a_tags ut_varchar2_rows := null
+    a_line_no integer, a_expected_error_codes ut_varchar2_rows := null, a_tags ut_varchar2_rows := null
   ) return self as result,
   overriding member procedure mark_as_skipped(self in out nocopy ut_test),
   overriding member function do_execute(self in out nocopy ut_test) return boolean,

--- a/source/core/ut_suite_cache_manager.pkb
+++ b/source/core/ut_suite_cache_manager.pkb
@@ -57,7 +57,7 @@ create or replace package body ut_suite_cache_manager is
         select 'UT_LOGICAL_SUITE' as self_type, p.path, p.object_owner,
                upper( substr(p.path, instr( p.path, '.', -1 ) + 1 ) ) as object_name,
                cast(null as ut_executables) as x,
-               cast(null as ut_integer_list) as y,
+               cast(null as ut_varchar2_rows) as y,
                cast(null as ut_executable_test) as z
           from suitepath_part p
          where p.path

--- a/test/ut3_tester/core/annotations/test_annot_throws_exception.pkb
+++ b/test/ut3_tester/core/annotations/test_annot_throws_exception.pkb
@@ -20,212 +20,230 @@ is
           c_e_diff_exc   constant number := -20204;
           c_e_mix_list   constant number := -20205;
           c_e_mix_missin constant number := -20206;
-          
+          c_e_positive   constant number :=  20207;
+
           e_some_exception exception;
           pragma exception_init(e_some_exception, -20207);
           
        end;]';
     
     l_package_spec := '
-        create package annotated_package_with_throws is
-            --%suite(Dummy package to test annotation throws)
+      create package annotated_package_with_throws is
+        --%suite(Dummy package to test annotation throws)
 
-            --%test(Throws same annotated exception)
-            --%throws(-20145)
-            procedure raised_same_exception;
+        --%test(Throws same annotated exception)
+        --%throws(-20145)
+        procedure raised_same_exception;
 
-            --%test(Throws one of the listed exceptions)
-            --%throws(-20145,-20146, -20189 ,-20563)
-            procedure raised_one_listed_exception;
+        --%test(Throws one of the listed exceptions)
+        --%throws(-20145,-20146, -20189 ,-20563)
+        procedure raised_one_listed_exception;
 
-            --%test(Leading zero is ignored in exception list)
-            --%throws(-01476)
-            procedure leading_0_exception_no;
+        --%test(Leading zero is ignored in exception list)
+        --%throws(-01476)
+        procedure leading_0_exception_no;
 
-            --%test(Throws diff exception)
-            --%throws(-20144)
-            procedure raised_diff_exception;
+        --%test(Throws diff exception)
+        --%throws(-20144)
+        procedure raised_diff_exception;
 
-            --%test(Throws empty)
-            --%throws()
-            procedure empty_throws;
+        --%test(Throws empty)
+        --%throws()
+        procedure empty_throws;
 
-            --%test(Ignores annotation and fails when exception was thrown)
-            --%throws(hello,784#,0-=234,,u1234)
-            procedure bad_paramters_with_except;
+        --%test(Ignores annotation and fails when exception was thrown)
+        --%throws(hello,784#,0-=234,,u1234)
+        procedure bad_paramters_with_except;
 
-            --%test(Ignores annotation and succeeds when no exception thrown)
-            --%throws(hello,784#,0-=234,,u1234)
-            procedure bad_paramters_without_except;
+        --%test(Ignores annotation and succeeds when no exception thrown)
+        --%throws(hello,784#,0-=234,,u1234)
+        procedure bad_paramters_without_except;
 
-            --%test(Detects a valid exception number within many invalid ones)
-            --%throws(7894562, operaqk, -=1, -1, pow74d, posdfk3)
-            procedure one_valid_exception_number;
+        --%test(Ignores annotation for positive exception number value)
+        --%throws(20001)
+        procedure positive_exception_number;
 
-            --%test(Gives failure when a exception is expected and nothing is thrown)
-            --%throws(-20459, -20136, -20145)
-            procedure nothing_thrown;
-            
-           --%test(Single exception defined as a constant number in package)
-           --%throws(exc_pkg.c_e_single_exc)
-           procedure single_exc_const_pkg;
-           
-           --%test(Gives success when one of annotated exception using constant is thrown)
-           --%throws(exc_pkg.c_e_list_1,exc_pkg.c_e_list_2)
-           procedure list_of_exc_constant;
-            
-            --%test(Gives failure when the raised exception is different that the annotated one using variable)
-            --%throws(exc_pkg.c_e_diff_exc)
-            procedure fail_not_match_exc;
-            
-            --%test(Success when one of exception from mixed list of number and constant is thrown) 
-            --%throws(exc_pkg.c_e_mix_list,-20105)
-            procedure mixed_exc_list; 
-            
-            --%test(Success when match exception even if other variable on list dont exists)  
-            --%throws(exc_pkg.c_e_mix_missin,utter_rubbish)
-            procedure mixed_list_notexi;
-            
-            --%test(Success resolve and match named exception defined in pragma exception init)  
-            --%throws(exc_pkg.e_some_exception)
-            procedure named_exc_pragma;
-  
-           --%test(Success resolve and match oracle named exception)
-           --%throws(NO_DATA_FOUND)
-           procedure named_exc_ora;
-           
-           --%test(Success resolve and match oracle named exception dup val index)  
-           --%throws(DUP_VAL_ON_INDEX)
-           procedure named_exc_ora_dup_ind;
-            
-           --%test(Success map no data 100 to -1403)  
-           --%throws(-1403)
-           procedure nodata_exc_ora;   
-           
-           --%test(Success for exception defined as varchar)  
-           --%throws(exc_pkg.c_e_varch_exc)
-           procedure defined_varchar_exc; 
-           
-           --%test(Non existing constant exception)  
-           --%throws(dummy.c_dummy);
-           procedure non_existing_const;  
-           
-           --%test(Bad exception constant) 
-           --%throws(exc_pkg.c_e_dummy);
-           procedure bad_exc_const;  
-           
-        end;
+        --%test(Ignores annotation for positive exception number variable)
+        --%throws(exc_pkg.c_e_positive)
+        procedure positive_exception_number_var;
+
+        --%test(Detects a valid exception number within many invalid ones)
+        --%throws(7894562, operaqk, -=1, -1, pow74d, posdfk3)
+        procedure one_valid_exception_number;
+
+        --%test(Gives failure when a exception is expected and nothing is thrown)
+        --%throws(-20459, -20136, -20145)
+        procedure nothing_thrown;
+
+        --%test(Single exception defined as a constant number in package)
+        --%throws(exc_pkg.c_e_single_exc)
+        procedure single_exc_const_pkg;
+
+        --%test(Gives success when one of annotated exception using constant is thrown)
+        --%throws(exc_pkg.c_e_list_1,exc_pkg.c_e_list_2)
+        procedure list_of_exc_constant;
+
+        --%test(Gives failure when the raised exception is different that the annotated one using variable)
+        --%throws(exc_pkg.c_e_diff_exc)
+        procedure fail_not_match_exc;
+
+        --%test(Success when one of exception from mixed list of number and constant is thrown)
+        --%throws(exc_pkg.c_e_mix_list,-20105)
+        procedure mixed_exc_list;
+
+        --%test(Success when match exception even if other variable on list dont exists)
+        --%throws(exc_pkg.c_e_mix_missin,utter_rubbish)
+        procedure mixed_list_notexi;
+
+        --%test(Success resolve and match named exception defined in pragma exception init)
+        --%throws(exc_pkg.e_some_exception)
+        procedure named_exc_pragma;
+
+        --%test(Success resolve and match oracle named exception)
+        --%throws(NO_DATA_FOUND)
+        procedure named_exc_ora;
+
+        --%test(Success resolve and match oracle named exception dup val index)
+        --%throws(DUP_VAL_ON_INDEX)
+        procedure named_exc_ora_dup_ind;
+
+        --%test(Success map no data 100 to -1403)
+        --%throws(-1403)
+        procedure nodata_exc_ora;
+
+        --%test(Success for exception defined as varchar)
+        --%throws(exc_pkg.c_e_varch_exc)
+        procedure defined_varchar_exc;
+
+        --%test(Non existing constant exception)
+        --%throws(dummy.c_dummy);
+        procedure non_existing_const;
+
+        --%test(Bad exception constant)
+        --%throws(exc_pkg.c_e_dummy);
+        procedure bad_exc_const;
+      end;
     ';
 
     l_package_body := '
-        create package body annotated_package_with_throws is
-            procedure raised_same_exception is
-            begin
-                raise_application_error(-20145, ''Test error'');
-            end;
-
-            procedure raised_one_listed_exception is
-            begin
-                raise_application_error(-20189, ''Test error'');
-            end;
-
-            procedure leading_0_exception_no is
-                x integer;
-            begin
-                x := 1 / 0;
-            end;
-
-            procedure raised_diff_exception is
-            begin
-                raise_application_error(-20143, ''Test error'');
-            end;
-
-            procedure empty_throws is
-            begin
-                raise_application_error(-20143, ''Test error'');
-            end;
-
-            procedure bad_paramters_with_except is
-            begin
-                raise_application_error(-20143, ''Test error'');
-            end;
-
-            procedure bad_paramters_without_except is
-            begin
-                null;
-            end;
-
-            procedure one_valid_exception_number is
-            begin
-              raise dup_val_on_index;
-            end;
-
-            procedure nothing_thrown is
-            begin
-                null;
-            end;
-            
-           procedure single_exc_const_pkg is
-           begin
-             raise_application_error(exc_pkg.c_e_single_exc,''Test'');
-           end;
-           
-           procedure list_of_exc_constant is
-           begin
-             raise_application_error(exc_pkg.c_e_list_1,''Test'');
-           end;
-           
-           procedure fail_not_match_exc is
-           begin
-             raise NO_DATA_FOUND;
-           end;
-           
-           procedure mixed_exc_list is
-           begin
-             raise_application_error(exc_pkg.c_e_mix_list,''Test'');
-           end;
-           
-           procedure mixed_list_notexi is
-           begin
-             raise_application_error(exc_pkg.c_e_mix_missin,''Test'');
-           end;
- 
-           procedure named_exc_pragma is
-           begin
-             raise exc_pkg.e_some_exception;
-           end;
-  
-           procedure named_exc_ora is
-           begin
-             raise NO_DATA_FOUND;
-           end;
-           
-           procedure named_exc_ora_dup_ind is
-           begin
-             raise DUP_VAL_ON_INDEX;
-           end;
-  
-           procedure nodata_exc_ora is
-           begin
-             raise NO_DATA_FOUND;
-           end;
-           
-           procedure defined_varchar_exc is
-           begin
-             raise_application_error(exc_pkg.c_e_varch_exc,''Test'');
-           end;
-           
-           procedure non_existing_const is
-           begin
-             raise_application_error(-20143, ''Test error'');
-           end;
-           
-           procedure bad_exc_const is
-           begin
-             raise_application_error(-20143, ''Test error'');
-           end;
-           
+      create package body annotated_package_with_throws is
+        procedure raised_same_exception is
+        begin
+          raise_application_error(-20145, ''Test error'');
         end;
+
+        procedure raised_one_listed_exception is
+        begin
+          raise_application_error(-20189, ''Test error'');
+        end;
+
+        procedure leading_0_exception_no is
+          x integer;
+        begin
+          x := 1 / 0;
+        end;
+
+        procedure raised_diff_exception is
+        begin
+          raise_application_error(-20143, ''Test error'');
+        end;
+
+        procedure empty_throws is
+        begin
+          raise_application_error(-20143, ''Test error'');
+        end;
+
+        procedure bad_paramters_with_except is
+        begin
+          raise_application_error(-20143, ''Test error'');
+        end;
+
+        procedure bad_paramters_without_except is
+        begin
+          null;
+        end;
+
+        procedure positive_exception_number is
+        begin
+          null;
+        end;
+
+        procedure positive_exception_number_var is
+        begin
+          null;
+        end;
+
+        procedure one_valid_exception_number is
+        begin
+          raise dup_val_on_index;
+        end;
+
+        procedure nothing_thrown is
+        begin
+          null;
+        end;
+
+        procedure single_exc_const_pkg is
+        begin
+          raise_application_error(exc_pkg.c_e_single_exc,''Test'');
+        end;
+
+        procedure list_of_exc_constant is
+        begin
+          raise_application_error(exc_pkg.c_e_list_1,''Test'');
+        end;
+
+        procedure fail_not_match_exc is
+        begin
+          raise NO_DATA_FOUND;
+        end;
+
+        procedure mixed_exc_list is
+        begin
+          raise_application_error(exc_pkg.c_e_mix_list,''Test'');
+        end;
+
+        procedure mixed_list_notexi is
+        begin
+          raise_application_error(exc_pkg.c_e_mix_missin,''Test'');
+        end;
+
+        procedure named_exc_pragma is
+        begin
+          raise exc_pkg.e_some_exception;
+        end;
+
+        procedure named_exc_ora is
+        begin
+          raise NO_DATA_FOUND;
+        end;
+
+        procedure named_exc_ora_dup_ind is
+        begin
+          raise DUP_VAL_ON_INDEX;
+        end;
+
+        procedure nodata_exc_ora is
+        begin
+          raise NO_DATA_FOUND;
+        end;
+
+        procedure defined_varchar_exc is
+        begin
+          raise_application_error(exc_pkg.c_e_varch_exc,''Test'');
+        end;
+
+        procedure non_existing_const is
+        begin
+          raise_application_error(-20143, ''Test error'');
+        end;
+
+        procedure bad_exc_const is
+        begin
+          raise_application_error(-20143, ''Test error'');
+        end;
+           
+      end;
     ';
 
     execute immediate l_exception_spec;
@@ -277,13 +295,25 @@ is
   procedure bad_paramters_without_except is
   begin
     ut.expect(g_tests_results).to_match('^\s*Ignores annotation and succeeds when no exception thrown \[[,\.0-9]+ sec\]\s*$','m');
-    ut.expect(g_tests_results).not_to_match('bad_paramters_without_except');
+    ut.expect(g_tests_results).to_match('bad_paramters_without_except\s*Invalid parameter value ".*" for "--%throws" annotation. Parameter ignored.','m');
+  end;
+
+  procedure positive_exception_number is
+  begin
+    ut.expect(g_tests_results).to_match('^\s*Ignores annotation for positive exception number value \[[,\.0-9]+ sec\]\s*$','m');
+    ut.expect(g_tests_results).to_match('positive_exception_number\s*Invalid parameter value "20001" for "--%throws" annotation. Exception value must be a negative integer. Parameter ignored.','m');
+  end;
+
+  procedure positive_exception_number_var is
+  begin
+    ut.expect(g_tests_results).to_match('^\s*Ignores annotation for positive exception number variable \[[,\.0-9]+ sec\]\s*$','m');
+    ut.expect(g_tests_results).to_match('positive_exception_number_var\s*Invalid parameter value ".*" for "--%throws" annotation. Exception value must be a negative integer. Parameter ignored.','m');
   end;
 
   procedure one_valid_exception_number is
   begin
     ut.expect(g_tests_results).to_match('^\s*Detects a valid exception number within many invalid ones \[[\.0-9]+ sec\]\s*$','m');
-    ut.expect(g_tests_results).not_to_match('one_valid_exception_number');
+    ut.expect(g_tests_results).to_match('one_valid_exception_number\s*Invalid parameter value ".*" for "--%throws" annotation. Parameter ignored.','m');
   end;
 
   procedure nothing_thrown is
@@ -319,13 +349,13 @@ is
   procedure mixed_list_notexi is
   begin
     ut.expect(g_tests_results).to_match('^\s*Success when match exception even if other variable on list dont exists \[[,\.0-9]+ sec\]\s*$','m');
-    ut.expect(g_tests_results).not_to_match('mixed_list_notexi');
+    ut.expect(g_tests_results).to_match('mixed_list_notexi\s*Invalid parameter value "utter_rubbish" for "--%throws" annotation. Parameter ignored.','m');
   end;
 
   procedure named_exc_pragma is
   begin
     ut.expect(g_tests_results).to_match('^\s*Success resolve and match named exception defined in pragma exception init \[[,\.0-9]+ sec\]\s*$','m');
-    ut.expect(g_tests_results).not_to_match('mixed_list_notexi');  
+    ut.expect(g_tests_results).not_to_match('named_exc_pragma');
   end;
   
   procedure named_exc_ora is

--- a/test/ut3_tester/core/annotations/test_annot_throws_exception.pks
+++ b/test/ut3_tester/core/annotations/test_annot_throws_exception.pks
@@ -26,7 +26,13 @@ is
   
   --%test(Ignores when only bad parameters are passed, the test does not raise a exception and it shows successful test)
   procedure bad_paramters_without_except;
-  
+
+  --%test(Ignores annotation for positive exception number value)
+  procedure positive_exception_number;
+
+  --%test(Ignores annotation for positive exception number variable)
+  procedure positive_exception_number_var;
+
   --%test(Detects a valid exception number within many invalid ones)
   procedure one_valid_exception_number;
   

--- a/test/ut3_tester/core/test_suite_builder.pkb
+++ b/test/ut3_tester/core/test_suite_builder.pkb
@@ -1386,24 +1386,6 @@ create or replace package body test_suite_builder is
     );
   end;
 
-  procedure throws_value_invalid is
-    l_actual      clob;
-    l_annotations ut3.ut_annotations;
-  begin
-    --Arrange
-    l_annotations := ut3.ut_annotations(
-        ut3.ut_annotation(1, 'suite','Cool', null),
-        ut3.ut_annotation(3, 'test','A test with invalid throws annotation', 'A_TEST_PROCEDURE'),
-        ut3.ut_annotation(3, 'throws',' -20145 , bad_variable_name ', 'A_TEST_PROCEDURE')
-    );
-    --Act
-    l_actual := invoke_builder_for_annotations(l_annotations, 'SOME_PACKAGE');
-    --Assert
-    ut.expect(l_actual).to_be_like(
-        '%<WARNINGS>%Invalid parameter value &quot;bad_variable_name&quot; for &quot;--%throws&quot; annotation. Parameter ignored.%</WARNINGS>%'
-    );
-  end;
-
 
   procedure before_aftertest_multi is
     l_actual      clob;

--- a/test/ut3_tester/core/test_suite_builder.pks
+++ b/test/ut3_tester/core/test_suite_builder.pks
@@ -161,9 +161,6 @@ create or replace package test_suite_builder is
       --%test(Gives warning if --%throws annotation has no value)
       procedure throws_value_empty;
 
-      --%test(Gives warning if --%throws annotation has invalid value)
-      procedure throws_value_invalid;
-
   --%endcontext
 
   --%context(--%beforetest/aftertest annotation)


### PR DESCRIPTION
Now the validation is executed at runtime, when the tests is executed.

This resolves issues related to the fact that some package constants may not exist or be valid at suite parse time.
In such scenario, the annotations continued to be ignored despite the fact that package constants were valid at test runtime.

With this change, tests can now have `--throws` annotations referencing constants that are undefined at compile time.
Resolves #1033
Resolves #721
