### PR TITLE
Changed `dbms_plssqlcode` tables to be permanent.

### DIFF
--- a/source/core/coverage/dbms_plssqlcode.sql
+++ b/source/core/coverage/dbms_plssqlcode.sql
@@ -7,7 +7,7 @@ begin
      select synonym_name from all_synonyms where synonym_name = 'DBMSPCC_BLOCKS' and owner = sys_context('USERENV','CURRENT_SCHEMA'));
   if l_tab_exist = 0 then
     execute immediate q'[
-      create global temporary table dbmspcc_blocks (
+      create table dbmspcc_blocks (
         run_id         number(38, 0),
         object_id      number(38, 0),
         block          number(38, 0),
@@ -21,7 +21,7 @@ begin
         constraint dbmspcc_blocks_covered_ck check ( covered in ( 0, 1 ) ) enable,
         constraint dbmspcc_blocks_not_feasible_ck check ( not_feasible in ( 0, 1 ) ) enable,
         constraint dbmspcc_blocks_pk primary key ( run_id, object_id, block ) using index
-      ) on commit preserve rows]';
+      )]';
   end if;
 end;
 /
@@ -34,13 +34,13 @@ begin
      select synonym_name from all_synonyms where synonym_name = 'DBMSPCC_RUNS' and owner = sys_context('USERENV','CURRENT_SCHEMA'));
   if l_tab_exist = 0 then
     execute immediate q'[
-      create global temporary table dbmspcc_runs (
+      create table dbmspcc_runs (
         run_id          number(38, 0),
         run_comment     varchar2(4000 byte),
         run_owner       varchar2(128 byte) constraint dbmspcc_runs_run_owner_nn not null enable,
         run_timestamp   date constraint dbmspcc_runs_run_timestamp_nn not null enable,
         constraint dbmspcc_runs_pk primary key ( run_id ) using index enable
-      ) on commit preserve rows]';
+      )]';
     end if;
 end;
 /
@@ -53,7 +53,7 @@ begin
      select synonym_name from all_synonyms where synonym_name = 'DBMSPCC_UNITS' and owner = sys_context('USERENV','CURRENT_SCHEMA'));
   if l_tab_exist = 0 then
     execute immediate q'[
-      create global temporary table dbmspcc_units (
+      create table dbmspcc_units (
         run_id          number(38, 0),
         object_id       number(38, 0),
         owner           varchar2(128 byte) constraint dbmspcc_units_owner_nn not null enable,
@@ -61,7 +61,7 @@ begin
         type            varchar2(12 byte) constraint dbmspcc_units_type_nn not null enable,
         last_ddl_time   date constraint dbmspcc_units_last_ddl_time_nn not null enable,
         constraint dbmspcc_units_pk primary key ( run_id, object_id ) using index enable
-      ) on commit preserve rows]';
+      )]';
   end if;
 end;
 /


### PR DESCRIPTION
This is prerequisite for multi-session coverage.
Also it's needed for our self-testing to run properly.