### PR TITLE
Feature/fix coverage uk violation on dup obj name

### DIFF
--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -147,7 +147,7 @@ PROMPT Grants for testing coverage outside of main $UT3_DEVELOP_SCHEMA schema.
 grant create any procedure, drop any procedure, execute any procedure, create any type, drop any type, execute any type, under any type,
   select any table, update any table, insert any table, delete any table, create any table, drop any table, alter any table,
   select any dictionary, create any synonym, drop any synonym,
-  grant any object privilege, grant any privilege, create public synonym, drop public synonym
+  grant any object privilege, grant any privilege, create public synonym, drop public synonym, create any trigger
   to $UT3_TESTER_HELPER;
 
 grant create job to $UT3_TESTER_HELPER;

--- a/source/core/coverage/ut_coverage.pkb
+++ b/source/core/coverage/ut_coverage.pkb
@@ -93,7 +93,7 @@ create or replace package body ut_coverage is
              and s.type  = f.object_type
              and s.owner = f.object_owner';
     else
-      l_full_name := q'[lower(s.owner||'.'||s.name)]';
+      l_full_name := q'[lower(s.type||' '||s.owner||'.'||s.name)]';
       l_filters := case
         when a_coverage_options.include_objects is not empty then '
            and (s.owner, s.name) in (

--- a/source/core/coverage/ut_coverage.pkb
+++ b/source/core/coverage/ut_coverage.pkb
@@ -48,7 +48,7 @@ create or replace package body ut_coverage is
       ),
       sources as (
         select /*+ cardinality(f {mappings_cardinality}) */
-               {l_full_name} as full_name, s.owner, s.name,
+               {l_full_name} as full_name, s.owner, s.name, s.type,
                s.line - case when s.type = 'TRIGGER' then o.offset else 0 end as line,
                s.text
           from {sources_view} s {join_file_mappings}
@@ -58,7 +58,7 @@ create or replace package body ut_coverage is
            {filters}
       ),
       coverage_sources as (
-        select full_name, owner, name, line, text,
+        select full_name, owner, name, type, line, text,
                case
                  when
                    -- to avoid execution of regexp_like on every line
@@ -77,7 +77,7 @@ create or replace package body ut_coverage is
                end as to_be_skipped
           from sources s
       )
-    select full_name, owner, name, line, to_be_skipped, text
+    select full_name, owner, name, type, line, to_be_skipped, text
       from coverage_sources s
            -- Exclude calls to utPLSQL framework, Unit Test packages and objects from a_exclude_list parameter of coverage reporter
      where (s.owner, s.name) not in ( select /*+ cardinality(el {skipped_objects_cardinality})*/el.owner, el.name from table(:l_skipped_objects) el )

--- a/source/core/coverage/ut_coverage_block.pkb
+++ b/source/core/coverage/ut_coverage_block.pkb
@@ -40,11 +40,7 @@ create or replace package body ut_coverage_block is
       exit when l_source_objects_crsr%notfound;
     
       --get coverage data
-      l_line_calls := ut_coverage_helper_block.get_raw_coverage_data(
-        l_source_object.owner,
-        l_source_object.name,
-        a_coverage_options.coverage_run_id
-        );
+      l_line_calls := ut_coverage_helper_block.get_raw_coverage_data(l_source_object, a_coverage_options.coverage_run_id);
       --if there is coverage, we need to filter out the garbage (badly indicated data)
       if l_line_calls.count > 0 then
         --remove lines that should not be indicted as meaningful

--- a/source/core/coverage/ut_coverage_helper.pkb
+++ b/source/core/coverage/ut_coverage_helper.pkb
@@ -36,8 +36,8 @@ create or replace package body ut_coverage_helper is
   begin
     forall i in 1 .. a_data.count
       insert into ut_coverage_sources_tmp
-             (full_name,owner,name,line,text, to_be_skipped)
-       values(a_data(i).full_name,a_data(i).owner,a_data(i).name,a_data(i).line,a_data(i).text,a_data(i).to_be_skipped);
+             (full_name,owner,name,type,line,text,to_be_skipped)
+       values(a_data(i).full_name,a_data(i).owner,a_data(i).name,a_data(i).type,a_data(i).line,a_data(i).text,a_data(i).to_be_skipped);
   end;
 
   procedure cleanup_tmp_table is
@@ -60,12 +60,12 @@ create or replace package body ut_coverage_helper is
     l_result t_tmp_table_objects_crsr;
   begin
     open l_result for
-      select o.owner, o.name, o.full_name, max(o.line) as lines_count,
+      select o.owner, o.name, o.type, o.full_name, max(o.line) as lines_count,
              cast(
                collect(decode(to_be_skipped, 'Y', to_char(line))) as ut_varchar2_list
              ) as to_be_skipped_list
         from ut_coverage_sources_tmp o
-       group by o.owner, o.name, o.full_name;
+       group by o.owner, o.name, o.type, o.full_name;
 
     return l_result;
   end;

--- a/source/core/coverage/ut_coverage_helper.pks
+++ b/source/core/coverage/ut_coverage_helper.pks
@@ -32,6 +32,7 @@ create or replace package ut_coverage_helper authid definer is
     full_name      ut_coverage_sources_tmp.full_name%type,
     owner          ut_coverage_sources_tmp.owner%type,
     name           ut_coverage_sources_tmp.name%type,
+    type           ut_coverage_sources_tmp.type%type,
     line           ut_coverage_sources_tmp.line%type,
     to_be_skipped  ut_coverage_sources_tmp.to_be_skipped%type,
     text           ut_coverage_sources_tmp.text%type
@@ -42,6 +43,7 @@ create or replace package ut_coverage_helper authid definer is
   type t_tmp_table_object is record(
     owner              ut_coverage_sources_tmp.owner%type,
     name               ut_coverage_sources_tmp.name%type,
+    type               ut_coverage_sources_tmp.type%type,
     full_name          ut_coverage_sources_tmp.full_name%type,
     lines_count        integer,
     to_be_skipped_list ut_varchar2_list

--- a/source/core/coverage/ut_coverage_helper_block.pkb
+++ b/source/core/coverage/ut_coverage_helper_block.pkb
@@ -65,6 +65,7 @@ create or replace package body ut_coverage_helper_block is
            group by ccb.line, ccb.block
          )
      group by line
+     having count(block) > 1
      order by line]'
     bulk collect into l_coverage_rows
     using

--- a/source/core/coverage/ut_coverage_helper_block.pks
+++ b/source/core/coverage/ut_coverage_helper_block.pks
@@ -20,9 +20,7 @@ create or replace package ut_coverage_helper_block authid current_user is
 
   procedure coverage_stop;
 
-  function get_raw_coverage_data(
-    a_object_owner varchar2, a_object_name varchar2, a_coverage_run_id raw
-  ) return ut_coverage_helper.t_unit_line_calls;
+  function get_raw_coverage_data(a_object ut_coverage_helper.t_tmp_table_object, a_coverage_run_id raw) return ut_coverage_helper.t_unit_line_calls;
 
 end;
 /

--- a/source/core/coverage/ut_coverage_helper_profiler.pkb
+++ b/source/core/coverage/ut_coverage_helper_profiler.pkb
@@ -55,7 +55,7 @@ create or replace package body ut_coverage_helper_profiler is
    dbms_profiler.stop_profiler();
   end;
 
-  function proftab_results(a_object_owner varchar2, a_object_name varchar2, a_coverage_run_id raw) return t_proftab_rows is
+  function proftab_results(a_object ut_coverage_helper.t_tmp_table_object, a_coverage_run_id raw) return t_proftab_rows is
     l_coverage_rows t_proftab_rows;
   begin
     select
@@ -69,21 +69,19 @@ create or replace package body ut_coverage_helper_profiler is
       join ut_coverage_runs r
         on r.line_coverage_id = u.runid
      where r.coverage_run_id = a_coverage_run_id
-       and u.unit_owner = a_object_owner
-       and u.unit_name = a_object_name
-       and u.unit_type in ('PACKAGE BODY', 'TYPE BODY', 'PROCEDURE', 'FUNCTION', 'TRIGGER')
+       and u.unit_owner = a_object.owner
+       and u.unit_name = a_object.name
+       and u.unit_type = a_object.type
      group by d.line#;
 
     return l_coverage_rows;
   end;
   
-  function get_raw_coverage_data(
-    a_object_owner varchar2, a_object_name varchar2, a_coverage_run_id raw
-  ) return ut_coverage_helper.t_unit_line_calls is
+  function get_raw_coverage_data(a_object ut_coverage_helper.t_tmp_table_object, a_coverage_run_id raw) return ut_coverage_helper.t_unit_line_calls is
     l_tmp_data t_proftab_rows;
     l_results  ut_coverage_helper.t_unit_line_calls;  
   begin
-    l_tmp_data := proftab_results(a_object_owner, a_object_name, a_coverage_run_id);
+    l_tmp_data := proftab_results(a_object, a_coverage_run_id);
        
     for i in 1 .. l_tmp_data.count loop
       l_results(l_tmp_data(i).line).calls := l_tmp_data(i).calls;

--- a/source/core/coverage/ut_coverage_helper_profiler.pks
+++ b/source/core/coverage/ut_coverage_helper_profiler.pks
@@ -24,9 +24,7 @@ create or replace package ut_coverage_helper_profiler authid definer is
 
   procedure coverage_resume;
 
-  function get_raw_coverage_data(
-    a_object_owner varchar2, a_object_name varchar2, a_coverage_run_id raw
-  ) return ut_coverage_helper.t_unit_line_calls;
+  function get_raw_coverage_data(a_object ut_coverage_helper.t_tmp_table_object, a_coverage_run_id raw) return ut_coverage_helper.t_unit_line_calls;
 
 end;
 /

--- a/source/core/coverage/ut_coverage_profiler.pkb
+++ b/source/core/coverage/ut_coverage_profiler.pkb
@@ -34,11 +34,7 @@ create or replace package body ut_coverage_profiler is
       exit when l_source_objects_crsr%notfound;
 
       --get coverage data
-      l_line_calls := ut_coverage_helper_profiler.get_raw_coverage_data(
-        l_source_object.owner,
-        l_source_object.name,
-        a_coverage_options.coverage_run_id
-        );
+      l_line_calls := ut_coverage_helper_profiler.get_raw_coverage_data( l_source_object, a_coverage_options.coverage_run_id);
 
       --if there is coverage, we need to filter out the garbage (badly indicated data from dbms_profiler)
       if l_line_calls.count > 0 then

--- a/source/core/coverage/ut_coverage_sources_tmp.sql
+++ b/source/core/coverage/ut_coverage_sources_tmp.sql
@@ -15,10 +15,11 @@ create global temporary table ut_coverage_sources_tmp(
   full_name varchar2(4000),
   owner varchar2(250),
   name  varchar2(250),
+  type  varchar2(250),
   line  number(38,0),
   to_be_skipped varchar2(1),
   text varchar2(4000),
-  constraint ut_coverage_sources_tmp_pk primary key (owner,name,line)
+  constraint ut_coverage_sources_tmp_pk primary key (owner,name,type,line)
 ) on commit preserve rows;
 
 --is this needed?

--- a/test/ut3_tester_helper/coverage_helper.pks
+++ b/test/ut3_tester_helper/coverage_helper.pks
@@ -22,5 +22,8 @@ create or replace package coverage_helper is
   procedure create_test_results_table;
   procedure drop_test_results_table;
 
+  procedure drop_dup_object_name;
+  procedure create_dup_object_name;
+
 end;
 /

--- a/test/ut3_user/reporters/test_coverage/test_coverage_standalone.pkb
+++ b/test/ut3_user/reporters/test_coverage/test_coverage_standalone.pkb
@@ -5,7 +5,7 @@ create or replace package body test_coverage_standalone is
     l_block_cov       clob;
     l_file_path       varchar2(250);
   begin
-    l_file_path := 'ut3_develop.'||a_object_name;
+    l_file_path := 'package body ut3_develop.'||a_object_name;
     --Arrange
     if ut3_tester_helper.coverage_helper.block_coverage_available then
       l_block_cov := '<line number="4" hits="5" branch="true" condition-coverage="67% (2/3)"/>';

--- a/test/ut3_user/reporters/test_coverage/test_coveralls_reporter.pkb
+++ b/test/ut3_user/reporters/test_coverage/test_coveralls_reporter.pkb
@@ -41,7 +41,7 @@ null,
   begin
     --Arrange
     l_expected := q'[{"source_files":[
-{ "name": "ut3_develop.]'||ut3_tester_helper.coverage_helper.covered_package_name||q'[",
+{ "name": "package body ut3_develop.]'||ut3_tester_helper.coverage_helper.covered_package_name||q'[",
 "coverage": [
 0,
 0,

--- a/test/ut3_user/reporters/test_coverage/test_extended_coverage.pkb
+++ b/test/ut3_user/reporters/test_coverage/test_extended_coverage.pkb
@@ -15,7 +15,7 @@ create or replace package body test_extended_coverage is
     l_actual    clob;
   begin
     --Arrange
-    l_expected := '%<file path="ut3_develop.'||ut3_tester_helper.coverage_helper.covered_package_name||'">' ||
+    l_expected := '%<file path="package body ut3_develop.'||ut3_tester_helper.coverage_helper.covered_package_name||'">' ||
       get_block_coverage_line||
       '%<lineToCover lineNumber="6" covered="false"/>%';
     --Act
@@ -38,7 +38,7 @@ create or replace package body test_extended_coverage is
     l_actual    clob;
   begin
     --Arrange
-    l_expected := '%<file path="ut3_develop.'||ut3_tester_helper.coverage_helper.covered_package_name||'">' ||
+    l_expected := '%<file path="package body ut3_develop.'||ut3_tester_helper.coverage_helper.covered_package_name||'">' ||
       get_block_coverage_line ||
       '%<lineToCover lineNumber="6" covered="false"/>%';
     --Act
@@ -54,7 +54,7 @@ create or replace package body test_extended_coverage is
         );
     --Assert
     ut.expect(l_actual).to_be_like(l_expected);
-    ut.expect(l_actual).to_be_like('%<file path="ut3_develop.%">%<file path="ut3_develop.%">%');
+    ut.expect(l_actual).to_be_like('%<file path="package body ut3_develop.%">%<file path="package body ut3_develop.%">%');
   end;
 
   procedure coverage_for_file is

--- a/test/ut3_user/reporters/test_coverage/test_proftab_coverage.pkb
+++ b/test/ut3_user/reporters/test_coverage/test_proftab_coverage.pkb
@@ -92,6 +92,27 @@ create or replace package body test_proftab_coverage is
     ut.expect(l_actual).to_be_like(l_expected);
   end;
 
+  procedure dup_object_name_coverage is
+    l_actual clob;
+    l_expected clob;
+  begin
+    l_expected := '%<file path="ut3_develop.duplicate_name"><lineToCover lineNumber="6" covered="false"/>';
+    --Act
+    l_actual :=
+      ut3_tester_helper.coverage_helper.run_tests_as_job(
+      q'[
+            ut3_develop.ut.run(
+              a_path => 'ut3_develop.test_duplicate_name',
+              a_reporter=> ut3_develop.ut_coverage_sonar_reporter( ),
+              a_include_objects => ut3_develop.ut_varchar2_list( 'ut3_develop.duplicate_name' )
+            )
+          ]'
+      );
+    --Assert
+    --TODO - need to fix coverage reporting so that coverage is grouped by object type not only object name
+    ut.expect(l_actual).to_be_like(l_expected);
+  end;
+
   procedure coverage_tmp_data_refresh is
     l_actual    clob;
     l_test_code varchar2(32767);

--- a/test/ut3_user/reporters/test_coverage/test_proftab_coverage.pkb
+++ b/test/ut3_user/reporters/test_coverage/test_proftab_coverage.pkb
@@ -5,7 +5,7 @@ create or replace package body test_proftab_coverage is
     l_actual    clob;
   begin
     --Arrange
-    l_expected := coverage_helper.substitute_covered_package('%<file path="ut3_develop.{p}">%');
+    l_expected := coverage_helper.substitute_covered_package('%<file path="package body ut3_develop.{p}">%');
     --Act
     l_actual :=
       ut3_tester_helper.coverage_helper.run_tests_as_job(
@@ -28,7 +28,7 @@ create or replace package body test_proftab_coverage is
     l_actual    clob;
   begin
     --Arrange
-    l_expected := coverage_helper.substitute_covered_package('%<file path="ut3_develop.{p}">%');
+    l_expected := coverage_helper.substitute_covered_package('%<file path="package body ut3_develop.{p}">%');
     --Act
     l_actual :=
       ut3_tester_helper.coverage_helper.run_tests_as_job(
@@ -51,7 +51,7 @@ create or replace package body test_proftab_coverage is
     l_actual    clob;
   begin
     --Arrange
-    l_expected := '<file path="ut3_develop.%">';
+    l_expected := '<file path="package body ut3_develop.%">';
     l_expected := '%'||l_expected||'%'||l_expected||'%';
     --Act
     l_actual :=
@@ -96,7 +96,9 @@ create or replace package body test_proftab_coverage is
     l_actual clob;
     l_expected clob;
   begin
-    l_expected := '%<file path="ut3_develop.duplicate_name"><lineToCover lineNumber="6" covered="false"/>';
+    l_expected :=
+      '%<file path="package body ut3_develop.duplicate_name">%<lineToCover lineNumber="4" covered="true"/>' ||
+           '%<file path="trigger ut3_develop.duplicate_name">%<lineToCover lineNumber="3" covered="true"/>%';
     --Act
     l_actual :=
       ut3_tester_helper.coverage_helper.run_tests_as_job(
@@ -164,11 +166,11 @@ create or replace package body test_proftab_coverage is
 <!DOCTYPE coverage SYSTEM "http://cobertura.sourceforge.net/xml/coverage-04.dtd">
 <coverage line-rate="0" branch-rate="0.0" lines-covered="0" lines-valid="9" branches-covered="0" branches-valid="0" complexity="0" version="1" timestamp="%">
 <sources>
-<source>ut3_develop.{p}</source>
+<source>package body ut3_develop.{p}</source>
 </sources>
 <packages>
 <package name="{P}" line-rate="0.0" branch-rate="0.0" complexity="0.0">
-<class name="{P}" filename="ut3_develop.{p}" line-rate="0.0" branch-rate="0.0" complexity="0.0">
+<class name="{P}" filename="package body ut3_develop.{p}" line-rate="0.0" branch-rate="0.0" complexity="0.0">
 <lines>
 <line number="1" hits="0" branch="false"/>
 <line number="2" hits="0" branch="false"/>

--- a/test/ut3_user/reporters/test_coverage/test_proftab_coverage.pks
+++ b/test/ut3_user/reporters/test_coverage/test_proftab_coverage.pks
@@ -14,6 +14,11 @@ create or replace package test_proftab_coverage is
 
   --%test(Coverage is gathered for specified file - default coverage type)
   procedure coverage_for_file;
+
+  --%beforetest(ut3_tester_helper.coverage_helper.create_dup_object_name)
+  --%aftertest(ut3_tester_helper.coverage_helper.drop_dup_object_name)
+  --%test(Coverage on duplicate object name)
+  procedure dup_object_name_coverage;
   
   --%test(Coverage data is not cached between runs - issue #562 )
   --%aftertest(ut3_tester_helper.coverage_helper.drop_dummy_coverage_1)


### PR DESCRIPTION
Extended UK on ut_coverage_sources_tmp table.
Added object type to name in coverage reports.
Fixed issue with reporting non-block coverage as block coverage.
Resolves #1086