### PR TITLE
Replaced hard coded 0 in total test coverage

### DIFF
--- a/source/reporters/ut_coverage_cobertura_reporter.tpb
+++ b/source/reporters/ut_coverage_cobertura_reporter.tpb
@@ -90,7 +90,9 @@ create or replace type body ut_coverage_cobertura_reporter is
       --write header
       ut_utils.append_to_list(
         l_result,
-        '<coverage line-rate="0" branch-rate="0.0" lines-covered="'
+        '<coverage line-rate="'
+          ||to_char(round(a_coverage_data.covered_lines/(a_coverage_data.covered_lines + a_coverage_data.uncovered_lines), 17), rpad('FM0.',21,'9')) 
+          ||'" branch-rate="0.0" lines-covered="'
           ||a_coverage_data.covered_lines||'" lines-valid="'
           ||TO_CHAR(a_coverage_data.covered_lines + a_coverage_data.uncovered_lines)
           ||'" branches-covered="0" branches-valid="0" complexity="0" version="1" timestamp="'||l_epoch||'">'

--- a/source/reporters/ut_coverage_cobertura_reporter.tpb
+++ b/source/reporters/ut_coverage_cobertura_reporter.tpb
@@ -79,9 +79,10 @@ create or replace type body ut_coverage_cobertura_reporter is
       c_packages_footer constant varchar2(30) := '</packages>';
       c_package_footer  constant varchar2(30) := '</package>';
       c_class_footer    constant varchar2(30) := '</class>';
-      c_classes_footer    constant varchar2(30) := '</classes>';
+      c_classes_footer  constant varchar2(30) := '</classes>';
       c_lines_footer    constant varchar2(30) := '</lines>';
       l_epoch           varchar2(50) := (sysdate - to_date('01-01-1970 00:00:00', 'dd-mm-yyyy hh24:mi:ss')) * 24 * 60 * 60;
+      l_lines_valid     number := a_coverage_data.covered_lines + a_coverage_data.uncovered_lines;
       begin
    
       ut_utils.append_to_list( l_result, ut_utils.get_xml_header(a_run.client_character_set) );
@@ -91,10 +92,10 @@ create or replace type body ut_coverage_cobertura_reporter is
       ut_utils.append_to_list(
         l_result,
         '<coverage line-rate="'
-          ||to_char(round(a_coverage_data.covered_lines/(a_coverage_data.covered_lines + a_coverage_data.uncovered_lines), 17), rpad('FM0.',21,'9')) 
+          ||to_char(round((case l_lines_valid when 0 then 0 else a_coverage_data.covered_lines/(l_lines_valid) end), 17), rpad('FM0.',21,'9')) 
           ||'" branch-rate="0.0" lines-covered="'
           ||a_coverage_data.covered_lines||'" lines-valid="'
-          ||TO_CHAR(a_coverage_data.covered_lines + a_coverage_data.uncovered_lines)
+          ||TO_CHAR(l_lines_valid)
           ||'" branches-covered="0" branches-valid="0" complexity="0" version="1" timestamp="'||l_epoch||'">'
       );
       

--- a/source/reporters/ut_coverage_cobertura_reporter.tpb
+++ b/source/reporters/ut_coverage_cobertura_reporter.tpb
@@ -82,7 +82,7 @@ create or replace type body ut_coverage_cobertura_reporter is
       c_classes_footer  constant varchar2(30) := '</classes>';
       c_lines_footer    constant varchar2(30) := '</lines>';
       l_epoch           varchar2(50) := (sysdate - to_date('01-01-1970 00:00:00', 'dd-mm-yyyy hh24:mi:ss')) * 24 * 60 * 60;
-      l_lines_valid     number := a_coverage_data.covered_lines + a_coverage_data.uncovered_lines;
+      l_lines_valid     integer := a_coverage_data.covered_lines + a_coverage_data.uncovered_lines;
       begin
    
       ut_utils.append_to_list( l_result, ut_utils.get_xml_header(a_run.client_character_set) );
@@ -92,10 +92,10 @@ create or replace type body ut_coverage_cobertura_reporter is
       ut_utils.append_to_list(
         l_result,
         '<coverage line-rate="'
-          ||to_char(round((case l_lines_valid when 0 then 0 else a_coverage_data.covered_lines/(l_lines_valid) end), 17), rpad('FM0.',21,'9')) 
+          ||to_char(round((case l_lines_valid when 0 then 0 else a_coverage_data.covered_lines/(l_lines_valid) end), 17), rpad('FM0.0',20,'9') , 'NLS_NUMERIC_CHARACTERS=''. ''')
           ||'" branch-rate="0.0" lines-covered="'
           ||a_coverage_data.covered_lines||'" lines-valid="'
-          ||TO_CHAR(l_lines_valid)
+          ||to_char(l_lines_valid)
           ||'" branches-covered="0" branches-valid="0" complexity="0" version="1" timestamp="'||l_epoch||'">'
       );
       

--- a/test/ut3_user/reporters/test_coverage/test_cov_cobertura_reporter.pkb
+++ b/test/ut3_user/reporters/test_coverage/test_cov_cobertura_reporter.pkb
@@ -20,7 +20,7 @@ create or replace package body test_cov_cobertura_reporter is
     l_expected :=
     q'[<?xml version="1.0"?>
 <!DOCTYPE coverage SYSTEM "http://cobertura.sourceforge.net/xml/coverage-04.dtd">
-<coverage line-rate="0" branch-rate="0.0" lines-covered="1" lines-valid="2" branches-covered="0" branches-valid="0" complexity="0" version="1" timestamp="%">
+<coverage line-rate="0.5" branch-rate="0.0" lines-covered="1" lines-valid="2" branches-covered="0" branches-valid="0" complexity="0" version="1" timestamp="%">
 <sources>
 <source>]'||l_file_path||q'[</source>
 </sources>

--- a/test/ut3_user/reporters/test_coverage/test_coverage_standalone.pkb
+++ b/test/ut3_user/reporters/test_coverage/test_coverage_standalone.pkb
@@ -15,7 +15,7 @@ create or replace package body test_coverage_standalone is
     l_expected :=
       q'[<?xml version="1.0" encoding="]'||upper(a_charset)||q'["?>
 <!DOCTYPE coverage SYSTEM "http://cobertura.sourceforge.net/xml/coverage-04.dtd">
-<coverage line-rate="0" branch-rate="0.0" lines-covered="2" lines-valid="2" branches-covered="0" branches-valid="0" complexity="0" version="1" timestamp="%">
+<coverage line-rate="1.0" branch-rate="0.0" lines-covered="2" lines-valid="2" branches-covered="0" branches-valid="0" complexity="0" version="1" timestamp="%">
 <sources>
 <source>]'||l_file_path||q'[</source>
 </sources>

--- a/test/ut3_user/reporters/test_coverage/test_proftab_coverage.pkb
+++ b/test/ut3_user/reporters/test_coverage/test_proftab_coverage.pkb
@@ -164,7 +164,7 @@ create or replace package body test_proftab_coverage is
     l_expected :=
       q'[<?xml version="1.0"?>
 <!DOCTYPE coverage SYSTEM "http://cobertura.sourceforge.net/xml/coverage-04.dtd">
-<coverage line-rate="0" branch-rate="0.0" lines-covered="0" lines-valid="9" branches-covered="0" branches-valid="0" complexity="0" version="1" timestamp="%">
+<coverage line-rate="0.0" branch-rate="0.0" lines-covered="0" lines-valid="9" branches-covered="0" branches-valid="0" complexity="0" version="1" timestamp="%">
 <sources>
 <source>package body ut3_develop.{p}</source>
 </sources>


### PR DESCRIPTION
with covered lines / total  total lines.
Rounding to 17 decimal places since that's what I found when looking at cobertura examples online.
Used an rpad to generate the format mask to avoid having a long string of 9s.

This was mentioned in #1107 but does not have an issue of its own.