### PR TITLE
Replace inactive Slack invitation link

### DIFF
--- a/docs/about/project-details.md
+++ b/docs/about/project-details.md
@@ -4,7 +4,7 @@
 
 [![chat](http://img.shields.io/badge/GitHub_Project-Active-blue.svg)](https://github.com/utPLSQL/utPLSQL)
 [![license](http://img.shields.io/badge/license-apache%202.0-blue.svg)](https://www.apache.org/licenses/LICENSE-2.0)
-[![chat](http://img.shields.io/badge/chat-slack-blue.svg)](https://join.slack.com/t/utplsql/shared_invite/zt-d6zor80g-WWqAhbLWioJZUtLYeXetzA)
+[![chat](http://img.shields.io/badge/chat-slack-blue.svg)](https://join.slack.com/t/utplsql/shared_invite/zt-xwm68udy-4cF_3PNEyczYEbWr38W5ww)
 [![twitter](https://img.shields.io/twitter/follow/utPLSQL.svg?style=social&label=Follow)](https://twitter.com/utPLSQL)
 
 

--- a/docs/about/support.md
+++ b/docs/about/support.md
@@ -3,4 +3,4 @@
 # How to get support
 
 - Feel free to post questions, bugs or issues in the [issues area of GitHub](https://github.com/utPLSQL/utPLSQL/issues)
-- [Join](https://join.slack.com/t/utplsql/shared_invite/zt-d6zor80g-WWqAhbLWioJZUtLYeXetzA) developers team on utPLSQL [Slack](https://utplsql.slack.com/)
+- [Join](https://join.slack.com/t/utplsql/shared_invite/zt-xwm68udy-4cF_3PNEyczYEbWr38W5ww) developers team on utPLSQL [Slack](https://utplsql.slack.com/)

--- a/readme.md
+++ b/readme.md
@@ -162,7 +162,7 @@ We welcome new developers to join our community and contribute to the utPLSQL pr
 If you are interested in helping please read our [guide to contributing](CONTRIBUTING.md)
 The best place to start is to read the documentation and get familiar with the existing code base.
 A [slack chat](https://utplsql.slack.com/) is the place to go if you want to talk with team members.
-To sign up to the chat use [this link](https://join.slack.com/t/utplsql/shared_invite/zt-d6zor80g-WWqAhbLWioJZUtLYeXetzA).
+To sign up to the chat use [this link](https://join.slack.com/t/utplsql/shared_invite/zt-xwm68udy-4cF_3PNEyczYEbWr38W5ww).
 
 
 ----------
@@ -182,7 +182,7 @@ __Project Directories__
 
 ----------
 
-If you have a great feature in mind, that you would like to see in utPLSQL v3 please create an [issue on GitHub](https://github.com/utPLSQL/utPLSQL/issues) or discuss it with us in the [slack chat rooms](https://utplsql.slack.com/). Use [invite link](https://join.slack.com/t/utplsql/shared_invite/zt-d6zor80g-WWqAhbLWioJZUtLYeXetzA) to join the chat.  
+If you have a great feature in mind, that you would like to see in utPLSQL v3 please create an [issue on GitHub](https://github.com/utPLSQL/utPLSQL/issues) or discuss it with us in the [slack chat rooms](https://utplsql.slack.com/). Use [invite link](https://join.slack.com/t/utplsql/shared_invite/zt-xwm68udy-4cF_3PNEyczYEbWr38W5ww) to join the chat.  
 
 
 # Version 2 to Version 3 Comparison


### PR DESCRIPTION
I used the link from the ![obraz](https://user-images.githubusercontent.com/53443372/148128014-80a58484-5217-4006-bf81-b6962c717495.png) badge in `readme.md`. The replaced link is no longer active.
