### PR TITLE
Feature/1082 failure when comparing nested objects

### DIFF
--- a/source/core/ut_utils.pkb
+++ b/source/core/ut_utils.pkb
@@ -882,12 +882,14 @@ create or replace package body ut_utils is
 
   function get_hash(a_data raw, a_hash_type binary_integer := dbms_crypto.hash_sh1) return t_hash is
   begin
-    return dbms_crypto.hash(a_data, a_hash_type);
+    --We cannot run hash on null
+    return case when a_data is null then null else dbms_crypto.hash(a_data, a_hash_type) end;
   end;
 
   function get_hash(a_data clob, a_hash_type binary_integer := dbms_crypto.hash_sh1) return t_hash is
   begin
-    return dbms_crypto.hash(a_data, a_hash_type);
+    --We cannot run hash on null
+    return case when a_data is null then null else dbms_crypto.hash(a_data, a_hash_type) end;
   end;
 
   function qualified_sql_name(a_name varchar2) return varchar2 is

--- a/source/expectations/data_values/ut_compound_data_helper.pkb
+++ b/source/expectations/data_values/ut_compound_data_helper.pkb
@@ -144,9 +144,7 @@ create or replace package body ut_compound_data_helper is
         l_index := a_pk_table.next(l_index);
       end loop;
     end if;  
-    if a_data_info.column_type in ('OBJECT') then    
-      null;  
-    elsif not(l_exists) then  
+    if not(l_exists) then  
       l_sql_stmt := ' (decode(a.'||a_data_info.transformed_name||','||' e.'||a_data_info.transformed_name||',1,0) = 0)';
     end if; 
     return l_sql_stmt;
@@ -163,9 +161,7 @@ create or replace package body ut_compound_data_helper is
     if l_pk_tab.count <> 0 then
     l_index:= l_pk_tab.first;
     loop
-      if a_data_info.column_type in ('OBJECT') then    
-          null;
-      elsif l_pk_tab(l_index) in (a_data_info.access_path, a_data_info.parent_name)  then
+      if l_pk_tab(l_index) in (a_data_info.access_path, a_data_info.parent_name)  then
         --When then table is nested and join is on whole table
         l_sql_stmt := l_sql_stmt ||' a.'||a_data_info.transformed_name||q'[ = ]'||' e.'||a_data_info.transformed_name;
       end if;
@@ -191,9 +187,7 @@ create or replace package body ut_compound_data_helper is
     if a_pk_table is not empty then
       l_index:= a_pk_table.first;
       loop
-        if a_data_info.column_type in ('OBJECT') then    
-          null;
-        elsif a_pk_table(l_index) in (a_data_info.access_path, a_data_info.parent_name) then
+        if a_pk_table(l_index) in (a_data_info.access_path, a_data_info.parent_name) then
           --When then table is nested and join is on whole table
           l_sql_stmt := l_sql_stmt ||a_alias||a_data_info.transformed_name;
         end if;        
@@ -201,11 +195,7 @@ create or replace package body ut_compound_data_helper is
         l_index := a_pk_table.next(l_index);
       end loop;
     else
-      if a_data_info.column_type in ('OBJECT') then    
-        null;   
-      else 
-       l_sql_stmt := a_alias||a_data_info.transformed_name;
-      end if;
+      l_sql_stmt := a_alias||a_data_info.transformed_name;
     end if;
     return l_sql_stmt; 
   end;   
@@ -216,9 +206,7 @@ create or replace package body ut_compound_data_helper is
     l_alias varchar2(10) := a_alias;
     l_col_syntax varchar2(4000);
   begin
-    if a_data_info.column_type in ('OBJECT') then    
-      null;
-    elsif a_data_info.is_sql_diffable = 0 then 
+    if a_data_info.is_sql_diffable = 0 then 
       l_col_syntax :=  'ut_utils.get_hash('||l_alias||a_data_info.transformed_name||'.getClobVal()) as '||a_data_info.transformed_name ;
     elsif a_data_info.is_sql_diffable = 1  and a_data_info.column_type = 'DATE' then
       l_col_syntax :=  'to_date('||l_alias||a_data_info.transformed_name||') as '|| a_data_info.transformed_name;
@@ -250,8 +238,6 @@ create or replace package body ut_compound_data_helper is
       --We cannot use a precision and scale as dbms_sql.describe_columns3 return precision 0 for dual table
       -- there is also no need for that as we not process data but only read and compare as they are stored
       l_col_type := a_data_info.column_type;
-    elsif a_data_info.column_type in ('OBJECT') then    
-      null;
     else 
       l_col_type := a_data_info.column_type
         ||case when a_data_info.column_len is not null
@@ -259,11 +245,7 @@ create or replace package body ut_compound_data_helper is
           else null
           end;
     end if;
-    if a_data_info.column_type in ('OBJECT') then    
-      return null;
-    else
-      return  a_data_info.transformed_name||' '||l_col_type||q'[ PATH ']'||a_data_info.access_path||q'[']';
-    end if;
+    return  a_data_info.transformed_name||' '||l_col_type||q'[ PATH ']'||a_data_info.access_path||q'[']';
   end;
   
   procedure gen_sql_pieces_out_of_cursor(
@@ -296,7 +278,7 @@ create or replace package body ut_compound_data_helper is
   begin
     if a_data_info is not empty then
       for i in 1..a_data_info.count loop
-        if a_data_info(i).has_nested_col = 0 then
+        if a_data_info(i).has_nested_col = 0 and a_data_info(i).column_type <> 'OBJECT' then
           --Get XMLTABLE column list
           add_element_to_list(l_xmltab_list,generate_xmltab_stmt(a_data_info(i)));
           --Get Select statment list of columns

--- a/source/expectations/data_values/ut_compound_data_helper.pkb
+++ b/source/expectations/data_values/ut_compound_data_helper.pkb
@@ -575,7 +575,6 @@ create or replace package body ut_compound_data_helper is
     xmlelement( name "ROW", a_diff_tab(idx).act_item_data), a_diff_tab(idx).act_data_id,
     xmlelement( name "ROW", a_diff_tab(idx).exp_item_data), a_diff_tab(idx).exp_data_id,
     a_diff_tab(idx).item_no, a_diff_tab(idx).dup_no);
-
   exception
     when ut_utils.ex_failure_for_all then
       raise_application_error(ut_utils.gc_dml_for_all,'Failure to insert a diff tmp data.');

--- a/source/expectations/data_values/ut_cursor_column.tpb
+++ b/source/expectations/data_values/ut_cursor_column.tpb
@@ -28,12 +28,13 @@ create or replace type body ut_cursor_column as
                                  a_access_path||'/'||self.xml_valid_name 
                                end; --Access path used for XMLTABLE query   
       self.filter_path      := '/'||self.access_path; --Filter path will differ from access path in anydata type
+      --Transformed name needs to be build on full access path to avoid ambiguity when there is 3 or more levels of nesting.
       self.transformed_name := case when length(self.xml_valid_name) > 30 then
-                                 '"'||ut_compound_data_helper.get_fixed_size_hash(self.parent_name||self.xml_valid_name)||'"'
+                                 '"'||ut_compound_data_helper.get_fixed_size_hash(self.access_path)||'"'
                                when self.parent_name is null then 
                                  '"'||self.xml_valid_name||'"'
                                else 
-                                 '"'||ut_compound_data_helper.get_fixed_size_hash(self.parent_name||self.xml_valid_name)||'"'
+                                 '"'||ut_compound_data_helper.get_fixed_size_hash(self.access_path)||'"'
                                end; --when is nestd we need to hash name to make sure we dont exceed 30 char
       self.column_type      := a_col_type; --column type e.g. user_defined , varchar2
       self.column_schema    := a_col_schema_name; -- schema name

--- a/source/expectations/data_values/ut_cursor_column.tpb
+++ b/source/expectations/data_values/ut_cursor_column.tpb
@@ -14,8 +14,11 @@ create or replace type body ut_cursor_column as
       self.column_len       := a_col_max_len; --length of column
       self.column_precision := a_col_precision;
       self.column_scale     := a_col_scale;
-      self.column_name      := TRIM( BOTH '''' FROM a_col_name); --name of the column
       self.column_type_name := coalesce(a_col_type_name,a_col_type); --type name e.g. test_dummy_object or varchar2
+      self.column_name      := case when a_col_name is null and a_collection = 1 then 
+                                 self.column_type_name 
+                               else TRIM( BOTH '''' FROM a_col_name) 
+                               end;  --name of the column, however in nested object for collection name is not defined in cursor.
       self.xml_valid_name   := ut_utils.get_valid_xml_name(self.column_name);
       self.display_path     := case when a_access_path is null then 
                                  self.column_name 
@@ -25,7 +28,7 @@ create or replace type body ut_cursor_column as
       self.access_path      := case when a_access_path is null then 
                                  self.xml_valid_name 
                                else 
-                                 a_access_path||'/'||self.xml_valid_name 
+                                 a_access_path||'/'||self.xml_valid_name
                                end; --Access path used for XMLTABLE query   
       self.filter_path      := '/'||self.access_path; --Filter path will differ from access path in anydata type
       --Transformed name needs to be build on full access path to avoid ambiguity when there is 3 or more levels of nesting.

--- a/test/install_ut3_tester_helper.sql
+++ b/test/install_ut3_tester_helper.sql
@@ -6,6 +6,7 @@ alter session set plsql_optimize_level=0;
 --Install ut3_tester_helper
 @@ut3_tester_helper/test_dummy_object.tps
 @@ut3_tester_helper/other_dummy_object.tps
+@@ut3_tester_helper/test_dummy_nested_object.tps
 @@ut3_tester_helper/test_dummy_object_list.tps
 @@ut3_tester_helper/test_tab_varchar2.tps
 @@ut3_tester_helper/test_tab_varray.tps

--- a/test/install_ut3_tester_helper.sql
+++ b/test/install_ut3_tester_helper.sql
@@ -9,8 +9,10 @@ alter session set plsql_optimize_level=0;
 @@ut3_tester_helper/test_dummy_nested_object.tps
 @@ut3_tester_helper/test_dummy_double_nested_object.tps
 @@ut3_tester_helper/test_dummy_object_list.tps
+@@ut3_tester_helper/test_dummy_nested_object_list.tps
 @@ut3_tester_helper/test_tab_varchar2.tps
 @@ut3_tester_helper/test_tab_varray.tps
+@@ut3_tester_helper/test_nested_tab_varray.tps
 @@ut3_tester_helper/test_dummy_number.tps
 @@ut3_tester_helper/ut_test_table.sql
 @@ut3_tester_helper/test_event_object.tps

--- a/test/install_ut3_tester_helper.sql
+++ b/test/install_ut3_tester_helper.sql
@@ -10,6 +10,8 @@ alter session set plsql_optimize_level=0;
 @@ut3_tester_helper/test_dummy_double_nested_object.tps
 @@ut3_tester_helper/test_dummy_object_list.tps
 @@ut3_tester_helper/test_dummy_nested_object_list.tps
+@@ut3_tester_helper/test_dummy_double_nested_list.tps
+@@ut3_tester_helper/test_dummy_dble_nest_lst_obj.tps
 @@ut3_tester_helper/test_tab_varchar2.tps
 @@ut3_tester_helper/test_tab_varray.tps
 @@ut3_tester_helper/test_nested_tab_varray.tps

--- a/test/install_ut3_tester_helper.sql
+++ b/test/install_ut3_tester_helper.sql
@@ -7,6 +7,7 @@ alter session set plsql_optimize_level=0;
 @@ut3_tester_helper/test_dummy_object.tps
 @@ut3_tester_helper/other_dummy_object.tps
 @@ut3_tester_helper/test_dummy_nested_object.tps
+@@ut3_tester_helper/test_dummy_double_nested_object.tps
 @@ut3_tester_helper/test_dummy_object_list.tps
 @@ut3_tester_helper/test_tab_varchar2.tps
 @@ut3_tester_helper/test_tab_varray.tps

--- a/test/ut3_tester_helper/test_dummy_dble_nest_lst_obj.tps
+++ b/test/ut3_tester_helper/test_dummy_dble_nest_lst_obj.tps
@@ -1,0 +1,17 @@
+declare
+  l_exists integer;
+begin
+  select count(1) into l_exists from user_types where type_name = 'TEST_DUMMY_DBLE_NEST_LST_OBJ';
+  if l_exists > 0 then
+    execute immediate 'drop type test_dummy_dble_nest_lst_obj force';
+  end if;
+end;
+/
+
+CREATE TYPE test_dummy_dble_nest_lst_obj AS OBJECT 
+( 
+  some_number_id NUMBER, 
+  some_name VARCHAR2 (25), 
+  dummy_list test_dummy_double_nested_list 
+);
+/

--- a/test/ut3_tester_helper/test_dummy_double_nested_list.tps
+++ b/test/ut3_tester_helper/test_dummy_double_nested_list.tps
@@ -1,0 +1,13 @@
+declare
+  l_exists integer;
+begin
+  select count(1) into l_exists from user_types where type_name = 'TEST_DUMMY_DOUBLE_NESTED_LIST';
+  if l_exists > 0 then
+    execute immediate 'drop type test_dummy_double_nested_list force';
+  end if;
+end;
+/
+
+CREATE TYPE test_dummy_double_nested_list AS
+    TABLE OF test_dummy_nested_object_list;
+/

--- a/test/ut3_tester_helper/test_dummy_double_nested_object.tps
+++ b/test/ut3_tester_helper/test_dummy_double_nested_object.tps
@@ -1,14 +1,14 @@
 declare
   l_exists integer;
 begin
-  select count(1) into l_exists from user_types where type_name = 'TEST_DUMMY_DOUBLE_NESTED_OBJECT';
+  select count(1) into l_exists from user_types where type_name = 'TEST_DUMMY_DOUBLE_NESTED_OBJ';
   if l_exists > 0 then
-    execute immediate 'drop type test_dummy_double_nested_object force';
+    execute immediate 'drop type test_dummy_double_nested_obj force';
   end if;
 end;
 /
 
-create or replace type test_dummy_double_nested_object as object (
+create or replace type test_dummy_double_nested_obj as object (
   first_double_nested_obj test_dummy_nested_object,
   "Value" varchar2(30)
 )

--- a/test/ut3_tester_helper/test_dummy_double_nested_object.tps
+++ b/test/ut3_tester_helper/test_dummy_double_nested_object.tps
@@ -1,0 +1,15 @@
+declare
+  l_exists integer;
+begin
+  select count(1) into l_exists from user_types where type_name = 'TEST_DUMMY_DOUBLE_NESTED_OBJECT';
+  if l_exists > 0 then
+    execute immediate 'drop type test_dummy_double_nested_object force';
+  end if;
+end;
+/
+
+create or replace type test_dummy_double_nested_object as object (
+  first_double_nested_obj test_dummy_nested_object,
+  "Value" varchar2(30)
+)
+/

--- a/test/ut3_tester_helper/test_dummy_nested_object.tps
+++ b/test/ut3_tester_helper/test_dummy_nested_object.tps
@@ -1,0 +1,15 @@
+declare
+  l_exists integer;
+begin
+  select count(1) into l_exists from user_types where type_name = 'TEST_DUMMY_NESTED_OBJECT';
+  if l_exists > 0 then
+    execute immediate 'drop type test_dummy_nested_object force';
+  end if;
+end;
+/
+
+create or replace type test_dummy_nested_object as object (
+  first_nested_obj test_dummy_object,
+  sec_nested_obj test_dummy_object
+)
+/

--- a/test/ut3_tester_helper/test_dummy_nested_object_list.tps
+++ b/test/ut3_tester_helper/test_dummy_nested_object_list.tps
@@ -9,6 +9,7 @@ end;
 /
 
 create or replace type test_dummy_nested_object_list as object (
-  first_nested_obj test_dummy_object_list
+  first_nested_obj test_dummy_object_list,
+  somename varchar2(50)
 )
 /

--- a/test/ut3_tester_helper/test_dummy_nested_object_list.tps
+++ b/test/ut3_tester_helper/test_dummy_nested_object_list.tps
@@ -1,0 +1,14 @@
+declare
+  l_exists integer;
+begin
+  select count(1) into l_exists from user_types where type_name = 'TEST_DUMMY_NESTED_OBJECT_LIST';
+  if l_exists > 0 then
+    execute immediate 'drop type test_dummy_nested_object_list force';
+  end if;
+end;
+/
+
+create or replace type test_dummy_nested_object_list as object (
+  first_nested_obj test_dummy_object_list
+)
+/

--- a/test/ut3_tester_helper/test_dummy_object_list.tps
+++ b/test/ut3_tester_helper/test_dummy_object_list.tps
@@ -1,2 +1,12 @@
+declare
+  l_exists integer;
+begin
+  select count(1) into l_exists from user_types where type_name = 'TEST_DUMMY_OBJECT_LIST';
+  if l_exists > 0 then
+    execute immediate 'drop type test_dummy_object_list force';
+  end if;
+end;
+/
+
 create or replace type test_dummy_object_list as table of test_dummy_object
 /

--- a/test/ut3_tester_helper/test_nested_tab_varray.tps
+++ b/test/ut3_tester_helper/test_nested_tab_varray.tps
@@ -1,0 +1,14 @@
+declare
+  l_exists integer;
+begin
+  select count(1) into l_exists from user_types where type_name = 'TEST_NESTED_TAB_VARRAY';
+  if l_exists > 0 then
+    execute immediate 'drop type test_nested_tab_varray force';
+  end if;
+end;
+/
+
+create or replace type test_nested_tab_varray as object (
+  n_varray t_varray
+)
+/

--- a/test/ut3_user/expectations/test_expectation_anydata.pkb
+++ b/test/ut3_user/expectations/test_expectation_anydata.pkb
@@ -1130,7 +1130,7 @@ Rows: [ 60 differences, showing first 20 ]
     ut.expect(l_actual_message).to_be_like(l_expected_message);
   end;  
   
-  procedure user_defined_type_null_issue_1098 is
+  procedure user_def_type_null_issue_1098 is
     l_actual_message   varchar2(32767);
     l_expected_message varchar2(32767);  
     l_actual ut3_tester_helper.test_dummy_dble_nest_lst_obj;

--- a/test/ut3_user/expectations/test_expectation_anydata.pkb
+++ b/test/ut3_user/expectations/test_expectation_anydata.pkb
@@ -991,6 +991,25 @@ Rows: [ 60 differences, showing first 20 ]
    ut.expect(ut3_tester_helper.main_helper.get_failed_expectations_num).to_equal(0); 
 
   end;  
+
+  procedure failure_nesting_objects is
+    l_actual_message   varchar2(32767);
+    l_expected_message varchar2(32767);	  
+  begin
+  --Arrange
+    g_test_expected := anydata.convertObject( ut3_tester_helper.test_dummy_nested_object(ut3_tester_helper.test_dummy_object(1, 'A', '0'),ut3_tester_helper.test_dummy_object(1, 'B', '0') ));
+    g_test_actual   := anydata.convertObject( ut3_tester_helper.test_dummy_nested_object(ut3_tester_helper.test_dummy_object(1, 'A', '0'),ut3_tester_helper.test_dummy_object(1, 'C', '0') ));
+    --Act
+    l_expected_message := q'[%Actual: ut3_develop.some_item was expected to equal: ut3_develop.some_item
+%Diff:
+%Rows: [ 1 differences ]
+%Row No. 1 - Actual:   <SEC_NESTED_OBJ><ID>1</ID><name>B</name><Value>0</Value></SEC_NESTED_OBJ>
+%Row No. 1 - Expected: <SEC_NESTED_OBJ><ID>1</ID><name>C</name><Value>0</Value></SEC_NESTED_OBJ>]';
+    ut3_develop.ut.expect(g_test_actual).to_equal(g_test_expected);
+    l_actual_message := ut3_tester_helper.main_helper.get_failed_expectations(1);
+    --Assert
+    ut.expect(l_actual_message).to_be_like(l_expected_message);   
+  end;
   
 end;
 /

--- a/test/ut3_user/expectations/test_expectation_anydata.pkb
+++ b/test/ut3_user/expectations/test_expectation_anydata.pkb
@@ -1066,8 +1066,8 @@ Rows: [ 60 differences, showing first 20 ]
       from dual connect by level <=2
      order by rownum desc;
   --Arrange
-    g_test_expected := anydata.convertObject( ut3_tester_helper.test_dummy_nested_object_list(l_actual));
-    g_test_actual   := anydata.convertObject( ut3_tester_helper.test_dummy_nested_object_list(l_expected));
+    g_test_expected := anydata.convertObject( ut3_tester_helper.test_dummy_nested_object_list(l_actual,'Test'));
+    g_test_actual   := anydata.convertObject( ut3_tester_helper.test_dummy_nested_object_list(l_expected,'Test'));
     --Act
     l_expected_message := q'[%Actual: ut3_tester_helper.test_dummy_nested_object_list was expected to equal: ut3_tester_helper.test_dummy_nested_object_list
 %Diff:
@@ -1094,8 +1094,8 @@ Rows: [ 60 differences, showing first 20 ]
       from dual connect by level <=2
      order by rownum desc;
     --Arrange
-    g_test_expected := anydata.convertObject( ut3_tester_helper.test_dummy_nested_object_list(l_actual));
-    g_test_actual   := anydata.convertObject( ut3_tester_helper.test_dummy_nested_object_list(l_expected));
+    g_test_expected := anydata.convertObject( ut3_tester_helper.test_dummy_nested_object_list(l_actual,'Test'));
+    g_test_actual   := anydata.convertObject( ut3_tester_helper.test_dummy_nested_object_list(l_expected,'Test'));
     --Act
     ut3_develop.ut.expect( g_test_actual ).to_equal( g_test_expected );
     ut.expect(ut3_tester_helper.main_helper.get_failed_expectations_num).to_equal(0);
@@ -1128,6 +1128,88 @@ Rows: [ 60 differences, showing first 20 ]
     l_actual_message := ut3_tester_helper.main_helper.get_failed_expectations(1);
     --Assert
     ut.expect(l_actual_message).to_be_like(l_expected_message);
+  end;  
+  
+  procedure user_defined_type_null_issue_1098 is
+    l_actual_message   varchar2(32767);
+    l_expected_message varchar2(32767);  
+    l_actual ut3_tester_helper.test_dummy_dble_nest_lst_obj;
+    l_expected ut3_tester_helper.test_dummy_dble_nest_lst_obj;
+  begin
+    l_actual:= ut3_tester_helper.test_dummy_dble_nest_lst_obj(
+      1, 'North America', 
+        ut3_tester_helper.test_dummy_double_nested_list ( 
+            ut3_tester_helper.test_dummy_nested_object_list(
+                    ut3_tester_helper.test_dummy_object_list(
+					  ut3_tester_helper.test_dummy_object(1, '100 Broadway', 02474),
+				 	  ut3_tester_helper.test_dummy_object(2, '200 Indian School Rd', 85016)
+                    ),'USA'
+                ), 
+            ut3_tester_helper.test_dummy_nested_object_list(
+                    ut3_tester_helper.test_dummy_object_list(),'USA'
+            )
+        )
+    );
+
+	l_expected := ut3_tester_helper.test_dummy_dble_nest_lst_obj(
+					1,
+					'North America',
+					ut3_tester_helper.test_dummy_double_nested_list(ut3_tester_helper.test_dummy_nested_object_list(ut3_tester_helper.test_dummy_object_list(
+						ut3_tester_helper.test_dummy_object(1, '100 Broadway', 02474),
+						ut3_tester_helper.test_dummy_object(2, '200 Indian School Rd', 85016)
+					 ), 'USA'))
+				);
+    ut3_develop.ut.expect(anydata.convertObject(l_actual)).to_equal(anydata.convertObject(l_expected)).unordered;
+	
+    l_expected_message := q'[%Actual: ut3_tester_helper.test_dummy_dble_nest_lst_obj was expected to equal: ut3_tester_helper.test_dummy_dble_nest_lst_obj
+%Diff:
+%Rows: [ 2 differences ]
+%Extra:    <TEST_DUMMY_DBLE_NEST_LST_OBJ><SOME_NUMBER_ID>1</SOME_NUMBER_ID><SOME_NAME>North America</SOME_NAME><DUMMY_LIST><TEST_DUMMY_NESTED_OBJECT_LIST><FIRST_NESTED_OBJ><TEST_DUMMY_OBJECT><ID>1</ID><name>100 Broadway</name><Value>2474</Value></TEST_DUMMY_OBJECT><TEST_DUMMY_OBJECT><ID>2</ID><name>200 Indian School Rd</name><Value>85016</Value></TEST_DUMMY_OBJECT></FIRST_NESTED_OBJ><SOMENAME>USA</SOMENAME></TEST_DUMMY_NESTED_OBJECT_LIST><TEST_DUMMY_NESTED_OBJECT_LIST><FIRST_NESTED_OBJ/><SOMENAME>USA</SOMENAME></TEST_DUMMY_NESTED_OBJECT_LIST></DUMMY_LIST></TEST_DUMMY_DBLE_NEST_LST_OBJ>
+%Missing:  <TEST_DUMMY_DBLE_NEST_LST_OBJ><SOME_NUMBER_ID>1</SOME_NUMBER_ID><SOME_NAME>North America</SOME_NAME><DUMMY_LIST><TEST_DUMMY_NESTED_OBJECT_LIST><FIRST_NESTED_OBJ><TEST_DUMMY_OBJECT><ID>1</ID><name>100 Broadway</name><Value>2474</Value></TEST_DUMMY_OBJECT><TEST_DUMMY_OBJECT><ID>2</ID><name>200 Indian School Rd</name><Value>85016</Value></TEST_DUMMY_OBJECT></FIRST_NESTED_OBJ><SOMENAME>USA</SOMENAME></TEST_DUMMY_NESTED_OBJECT_LIST></DUMMY_LIST></TEST_DUMMY_DBLE_NEST_LST_OBJ>]';
+    l_actual_message := ut3_tester_helper.main_helper.get_failed_expectations(1);
+    --Assert
+    ut.expect(l_actual_message).to_be_like(l_expected_message);
+
+  end;
+  
+  procedure complex_nested_object_success is
+    l_actual_message   varchar2(32767);
+    l_expected_message varchar2(32767);  
+    l_actual ut3_tester_helper.test_dummy_dble_nest_lst_obj;
+    l_expected ut3_tester_helper.test_dummy_dble_nest_lst_obj;
+  begin
+    l_actual:= ut3_tester_helper.test_dummy_dble_nest_lst_obj(
+      1, 'North America', 
+        ut3_tester_helper.test_dummy_double_nested_list ( 
+            ut3_tester_helper.test_dummy_nested_object_list(
+                    ut3_tester_helper.test_dummy_object_list(
+					  ut3_tester_helper.test_dummy_object(1, '100 Broadway', 02474),
+				 	  ut3_tester_helper.test_dummy_object(2, '200 Indian School Rd', 85016)
+                    ),'USA'
+                ), 
+            ut3_tester_helper.test_dummy_nested_object_list(
+                    ut3_tester_helper.test_dummy_object_list(),'USA'
+            )
+        )
+    );
+
+	l_expected := ut3_tester_helper.test_dummy_dble_nest_lst_obj(
+      1, 'North America', 
+        ut3_tester_helper.test_dummy_double_nested_list ( 
+            ut3_tester_helper.test_dummy_nested_object_list(
+                    ut3_tester_helper.test_dummy_object_list(
+					  ut3_tester_helper.test_dummy_object(1, '100 Broadway', 02474),
+				 	  ut3_tester_helper.test_dummy_object(2, '200 Indian School Rd', 85016)
+                    ),'USA'
+                ), 
+            ut3_tester_helper.test_dummy_nested_object_list(
+                    ut3_tester_helper.test_dummy_object_list(),'USA'
+            )
+        )
+    );
+    ut3_develop.ut.expect(anydata.convertObject(l_actual)).to_equal(anydata.convertObject(l_expected)).unordered;
+	ut.expect(ut3_tester_helper.main_helper.get_failed_expectations_num).to_equal(0);
+
   end;  
 end;
 /

--- a/test/ut3_user/expectations/test_expectation_anydata.pkb
+++ b/test/ut3_user/expectations/test_expectation_anydata.pkb
@@ -1029,6 +1029,105 @@ Rows: [ 60 differences, showing first 20 ]
     --Assert
     ut.expect(l_actual_message).to_be_like(l_expected_message);   
   end;  
+ 
+  procedure success_nesting_objects is 
+  begin
+  --Arrange
+    g_test_expected := anydata.convertObject( ut3_tester_helper.test_dummy_nested_object(ut3_tester_helper.test_dummy_object(1, 'A', '0'),ut3_tester_helper.test_dummy_object(1, 'B', '0') ));
+    g_test_actual   := anydata.convertObject( ut3_tester_helper.test_dummy_nested_object(ut3_tester_helper.test_dummy_object(1, 'A', '0'),ut3_tester_helper.test_dummy_object(1, 'B', '0') ));
+   --Act
+   ut3_develop.ut.expect( g_test_actual ).to_equal( g_test_expected );
+   ut.expect(ut3_tester_helper.main_helper.get_failed_expectations_num).to_equal(0);
+  end;
   
+  procedure success_double_nested_objects is
+  begin
+  --Arrange
+    g_test_expected := anydata.convertObject( ut3_tester_helper.test_dummy_double_nested_obj(ut3_tester_helper.test_dummy_nested_object(ut3_tester_helper.test_dummy_object(1, 'A', '0'),ut3_tester_helper.test_dummy_object(1, 'B', '0') ),'Test'));
+    g_test_actual   := anydata.convertObject( ut3_tester_helper.test_dummy_double_nested_obj(ut3_tester_helper.test_dummy_nested_object(ut3_tester_helper.test_dummy_object(1, 'A', '0'),ut3_tester_helper.test_dummy_object(1, 'B', '0') ),'Test'));
+   --Act
+   ut3_develop.ut.expect( g_test_actual ).to_equal( g_test_expected );
+   ut.expect(ut3_tester_helper.main_helper.get_failed_expectations_num).to_equal(0);
+  end;  
+
+  procedure failure_nested_object_list is
+    l_actual_message   varchar2(32767);
+    l_expected_message varchar2(32767);	  
+    l_actual           ut3_tester_helper.test_dummy_object_list;
+    l_expected         ut3_tester_helper.test_dummy_object_list;
+  begin
+    --Arrange
+    select ut3_tester_helper.test_dummy_object( rownum + 1, 'Something '||rownum, rownum)
+      bulk collect into l_actual
+      from dual connect by level <=2
+	  order by rownum desc;
+    select ut3_tester_helper.test_dummy_object( rownum, 'Something '||rownum, rownum)
+      bulk collect into l_expected
+      from dual connect by level <=2
+     order by rownum desc;
+  --Arrange
+    g_test_expected := anydata.convertObject( ut3_tester_helper.test_dummy_nested_object_list(l_actual));
+    g_test_actual   := anydata.convertObject( ut3_tester_helper.test_dummy_nested_object_list(l_expected));
+    --Act
+    l_expected_message := q'[%Actual: ut3_tester_helper.test_dummy_nested_object_list was expected to equal: ut3_tester_helper.test_dummy_nested_object_list
+%Diff:
+%Rows: [ 1 differences ]
+%Row No. 1 - Actual:   <FIRST_NESTED_OBJ><TEST_DUMMY_OBJECT><ID>2</ID><name>Something 2</name><Value>2</Value></TEST_DUMMY_OBJECT><TEST_DUMMY_OBJECT><ID>1</ID><name>Something 1</name><Value>1</Value></TEST_DUMMY_OBJECT></FIRST_NESTED_OBJ>
+%Row No. 1 - Expected: <FIRST_NESTED_OBJ><TEST_DUMMY_OBJECT><ID>3</ID><name>Something 2</name><Value>2</Value></TEST_DUMMY_OBJECT><TEST_DUMMY_OBJECT><ID>2</ID><name>Something 1</name><Value>1</Value></TEST_DUMMY_OBJECT></FIRST_NESTED_OBJ>]';
+    ut3_develop.ut.expect(g_test_actual).to_equal(g_test_expected);
+    l_actual_message := ut3_tester_helper.main_helper.get_failed_expectations(1);
+    --Assert
+    ut.expect(l_actual_message).to_be_like(l_expected_message);   
+  end;
+ 
+  procedure success_nested_object_list is
+    l_actual           ut3_tester_helper.test_dummy_object_list;
+    l_expected         ut3_tester_helper.test_dummy_object_list;
+  begin
+    --Arrange
+    select ut3_tester_helper.test_dummy_object( rownum , 'Something '||rownum, rownum)
+      bulk collect into l_actual
+      from dual connect by level <=2
+      order by rownum desc;
+    select ut3_tester_helper.test_dummy_object( rownum, 'Something '||rownum, rownum)
+      bulk collect into l_expected
+      from dual connect by level <=2
+     order by rownum desc;
+    --Arrange
+    g_test_expected := anydata.convertObject( ut3_tester_helper.test_dummy_nested_object_list(l_actual));
+    g_test_actual   := anydata.convertObject( ut3_tester_helper.test_dummy_nested_object_list(l_expected));
+    --Act
+    ut3_develop.ut.expect( g_test_actual ).to_equal( g_test_expected );
+    ut.expect(ut3_tester_helper.main_helper.get_failed_expectations_num).to_equal(0);
+  end;
+
+ procedure nested_varray_same_data is
+  begin
+    --Arrange
+    g_test_expected := anydata.convertObject( ut3_tester_helper.test_nested_tab_varray(ut3_tester_helper.t_varray(1)) );
+    g_test_actual := anydata.convertObject( ut3_tester_helper.test_nested_tab_varray(ut3_tester_helper.t_varray(1)) );
+    --Act
+    ut3_develop.ut.expect( g_test_actual ).to_equal( g_test_expected );
+    ut.expect(ut3_tester_helper.main_helper.get_failed_expectations_num).to_equal(0);
+  end;
+
+  procedure nested_varray_diff_data is
+    l_actual_message   varchar2(32767);
+    l_expected_message varchar2(32767);
+  begin
+    --Arrange
+    g_test_expected := anydata.convertObject( ut3_tester_helper.test_nested_tab_varray(ut3_tester_helper.t_varray(1)) );
+    g_test_actual   := anydata.convertObject( ut3_tester_helper.test_nested_tab_varray(ut3_tester_helper.t_varray(2)) );
+    --Act
+    ut3_develop.ut.expect( g_test_actual ).to_equal( g_test_expected );
+    l_expected_message := q'[%Actual: ut3_tester_helper.test_nested_tab_varray was expected to equal: ut3_tester_helper.test_nested_tab_varray
+%Diff:
+%Rows: [ 1 differences ]
+%Row No. 1 - Actual:   <N_VARRAY><NUMBER>2</NUMBER></N_VARRAY>
+%Row No. 1 - Expected: <N_VARRAY><NUMBER>1</NUMBER></N_VARRAY>]';
+    l_actual_message := ut3_tester_helper.main_helper.get_failed_expectations(1);
+    --Assert
+    ut.expect(l_actual_message).to_be_like(l_expected_message);
+  end;  
 end;
 /

--- a/test/ut3_user/expectations/test_expectation_anydata.pkb
+++ b/test/ut3_user/expectations/test_expectation_anydata.pkb
@@ -1000,16 +1000,35 @@ Rows: [ 60 differences, showing first 20 ]
     g_test_expected := anydata.convertObject( ut3_tester_helper.test_dummy_nested_object(ut3_tester_helper.test_dummy_object(1, 'A', '0'),ut3_tester_helper.test_dummy_object(1, 'B', '0') ));
     g_test_actual   := anydata.convertObject( ut3_tester_helper.test_dummy_nested_object(ut3_tester_helper.test_dummy_object(1, 'A', '0'),ut3_tester_helper.test_dummy_object(1, 'C', '0') ));
     --Act
-    l_expected_message := q'[%Actual: ut3_develop.some_item was expected to equal: ut3_develop.some_item
+    l_expected_message := q'[%Actual: ut3_tester_helper.test_dummy_nested_object was expected to equal: ut3_tester_helper.test_dummy_nested_object
 %Diff:
 %Rows: [ 1 differences ]
-%Row No. 1 - Actual:   <SEC_NESTED_OBJ><ID>1</ID><name>B</name><Value>0</Value></SEC_NESTED_OBJ>
-%Row No. 1 - Expected: <SEC_NESTED_OBJ><ID>1</ID><name>C</name><Value>0</Value></SEC_NESTED_OBJ>]';
+%Row No. 1 - Actual:   <SEC_NESTED_OBJ><ID>1</ID><name>C</name><Value>0</Value></SEC_NESTED_OBJ>
+%Row No. 1 - Expected: <SEC_NESTED_OBJ><ID>1</ID><name>B</name><Value>0</Value></SEC_NESTED_OBJ>]';
     ut3_develop.ut.expect(g_test_actual).to_equal(g_test_expected);
     l_actual_message := ut3_tester_helper.main_helper.get_failed_expectations(1);
     --Assert
     ut.expect(l_actual_message).to_be_like(l_expected_message);   
   end;
+  
+  procedure failure_double_nested_objects is
+    l_actual_message   varchar2(32767);
+    l_expected_message varchar2(32767);	  
+  begin
+  --Arrange
+    g_test_expected := anydata.convertObject( ut3_tester_helper.test_dummy_double_nested_object(ut3_tester_helper.test_dummy_nested_object(ut3_tester_helper.test_dummy_object(1, 'A', '0'),ut3_tester_helper.test_dummy_object(1, 'B', '0') ),'Test'));
+    g_test_actual   := anydata.convertObject( ut3_tester_helper.test_dummy_double_nested_object(ut3_tester_helper.test_dummy_nested_object(ut3_tester_helper.test_dummy_object(1, 'A', '0'),ut3_tester_helper.test_dummy_object(1, 'C', '0') ),'Test'));
+    --Act
+    l_expected_message := q'[%Actual: ut3_tester_helper.test_dummy_double_nested_object was expected to equal: ut3_tester_helper.test_dummy_double_nested_object
+%Diff:
+%Rows: [ 1 differences ]
+%Row No. 1 - Actual:   <FIRST_DOUBLE_NESTED_OBJ><FIRST_NESTED_OBJ><ID>1</ID><name>A</name><Value>0</Value></FIRST_NESTED_OBJ><SEC_NESTED_OBJ><ID>1</ID><name>C</name><Value>0</Value></SEC_NESTED_OBJ></FIRST_DOUBLE_NESTED_OBJ>
+%Row No. 1 - Expected: <FIRST_DOUBLE_NESTED_OBJ><FIRST_NESTED_OBJ><ID>1</ID><name>A</name><Value>0</Value></FIRST_NESTED_OBJ><SEC_NESTED_OBJ><ID>1</ID><name>B</name><Value>0</Value></SEC_NESTED_OBJ></FIRST_DOUBLE_NESTED_OBJ>]';
+    ut3_develop.ut.expect(g_test_actual).to_equal(g_test_expected);
+    l_actual_message := ut3_tester_helper.main_helper.get_failed_expectations(1);
+    --Assert
+    ut.expect(l_actual_message).to_be_like(l_expected_message);   
+  end;  
   
 end;
 /

--- a/test/ut3_user/expectations/test_expectation_anydata.pkb
+++ b/test/ut3_user/expectations/test_expectation_anydata.pkb
@@ -1016,10 +1016,10 @@ Rows: [ 60 differences, showing first 20 ]
     l_expected_message varchar2(32767);	  
   begin
   --Arrange
-    g_test_expected := anydata.convertObject( ut3_tester_helper.test_dummy_double_nested_object(ut3_tester_helper.test_dummy_nested_object(ut3_tester_helper.test_dummy_object(1, 'A', '0'),ut3_tester_helper.test_dummy_object(1, 'B', '0') ),'Test'));
-    g_test_actual   := anydata.convertObject( ut3_tester_helper.test_dummy_double_nested_object(ut3_tester_helper.test_dummy_nested_object(ut3_tester_helper.test_dummy_object(1, 'A', '0'),ut3_tester_helper.test_dummy_object(1, 'C', '0') ),'Test'));
+    g_test_expected := anydata.convertObject( ut3_tester_helper.test_dummy_double_nested_obj(ut3_tester_helper.test_dummy_nested_object(ut3_tester_helper.test_dummy_object(1, 'A', '0'),ut3_tester_helper.test_dummy_object(1, 'B', '0') ),'Test'));
+    g_test_actual   := anydata.convertObject( ut3_tester_helper.test_dummy_double_nested_obj(ut3_tester_helper.test_dummy_nested_object(ut3_tester_helper.test_dummy_object(1, 'A', '0'),ut3_tester_helper.test_dummy_object(1, 'C', '0') ),'Test'));
     --Act
-    l_expected_message := q'[%Actual: ut3_tester_helper.test_dummy_double_nested_object was expected to equal: ut3_tester_helper.test_dummy_double_nested_object
+    l_expected_message := q'[%Actual: ut3_tester_helper.test_dummy_double_nested_obj was expected to equal: ut3_tester_helper.test_dummy_double_nested_obj
 %Diff:
 %Rows: [ 1 differences ]
 %Row No. 1 - Actual:   <FIRST_DOUBLE_NESTED_OBJ><FIRST_NESTED_OBJ><ID>1</ID><name>A</name><Value>0</Value></FIRST_NESTED_OBJ><SEC_NESTED_OBJ><ID>1</ID><name>C</name><Value>0</Value></SEC_NESTED_OBJ></FIRST_DOUBLE_NESTED_OBJ>

--- a/test/ut3_user/expectations/test_expectation_anydata.pks
+++ b/test/ut3_user/expectations/test_expectation_anydata.pks
@@ -229,7 +229,7 @@ create or replace package test_expectation_anydata is
   procedure nested_varray_diff_data; 
   
   --%test ( Comparision won't fail on user_defined type that is null as per issue 1098 )
-  procedure user_defined_type_null_issue_1098;
+  procedure user_def_type_null_issue_1098;
   
   --%test ( Reports success when comparing complex nested objects )
   procedure complex_nested_object_success;      

--- a/test/ut3_user/expectations/test_expectation_anydata.pks
+++ b/test/ut3_user/expectations/test_expectation_anydata.pks
@@ -206,6 +206,9 @@ create or replace package test_expectation_anydata is
   
   --%test ( Failure of comparing nesting objects )
   procedure failure_nesting_objects;
+ 
+  --%test ( Failure of comparing double nested objects ) 
+  procedure failure_double_nested_objects;
   
 end;
 /

--- a/test/ut3_user/expectations/test_expectation_anydata.pks
+++ b/test/ut3_user/expectations/test_expectation_anydata.pks
@@ -204,11 +204,28 @@ create or replace package test_expectation_anydata is
   --%test ( Empty Array not equal array with space )
   procedure arr_empty_nqua_arr_e_unord;  
   
-  --%test ( Failure of comparing nesting objects )
+  --%test ( Failure of comparing nested objects )
   procedure failure_nesting_objects;
  
   --%test ( Failure of comparing double nested objects ) 
   procedure failure_double_nested_objects;
   
+  --%test ( Success of comparing nested objects )
+  procedure success_nesting_objects;
+  
+  --%test ( Success of comparing double nested objects ) 
+  procedure success_double_nested_objects;  
+ 
+  --%test ( Failure of comparing nested object list )
+  procedure failure_nested_object_list;
+ 
+  --%test ( Success of comparing nested object list )
+  procedure success_nested_object_list;
+  
+  --%test(Nested VARRAYS with same data)
+  procedure nested_varray_same_data;
+  
+  --%test(Nested VARRAYS with different data)
+  procedure nested_varray_diff_data;  
 end;
 /

--- a/test/ut3_user/expectations/test_expectation_anydata.pks
+++ b/test/ut3_user/expectations/test_expectation_anydata.pks
@@ -226,6 +226,12 @@ create or replace package test_expectation_anydata is
   procedure nested_varray_same_data;
   
   --%test ( Reports diff between two not equal nested VARRAYS )
-  procedure nested_varray_diff_data;  
+  procedure nested_varray_diff_data; 
+  
+  --%test ( Comparision won't fail on user_defined type that is null as per issue 1098 )
+  procedure user_defined_type_null_issue_1098;
+  
+  --%test ( Reports success when comparing complex nested objects )
+  procedure complex_nested_object_success;      
 end;
 /

--- a/test/ut3_user/expectations/test_expectation_anydata.pks
+++ b/test/ut3_user/expectations/test_expectation_anydata.pks
@@ -203,5 +203,9 @@ create or replace package test_expectation_anydata is
  
   --%test ( Empty Array not equal array with space )
   procedure arr_empty_nqua_arr_e_unord;  
+  
+  --%test ( Failure of comparing nesting objects )
+  procedure failure_nesting_objects;
+  
 end;
 /

--- a/test/ut3_user/expectations/test_expectation_anydata.pks
+++ b/test/ut3_user/expectations/test_expectation_anydata.pks
@@ -204,28 +204,28 @@ create or replace package test_expectation_anydata is
   --%test ( Empty Array not equal array with space )
   procedure arr_empty_nqua_arr_e_unord;  
   
-  --%test ( Failure of comparing nested objects )
+  --%test ( Reports diff between not equal nested objects )
   procedure failure_nesting_objects;
  
-  --%test ( Failure of comparing double nested objects ) 
+  --%test ( Reports diff between not equal double nested objects ) 
   procedure failure_double_nested_objects;
   
-  --%test ( Success of comparing nested objects )
+  --%test (Reports success when comparing identical nested object )
   procedure success_nesting_objects;
   
-  --%test ( Success of comparing double nested objects ) 
+  --%test ( Reports success when comparing identical double nested object )
   procedure success_double_nested_objects;  
  
-  --%test ( Failure of comparing nested object list )
+  --%test ( Reports diff between two not equal nested object list )
   procedure failure_nested_object_list;
  
-  --%test ( Success of comparing nested object list )
+  --%test ( Reports success when comparing identical nested object list )
   procedure success_nested_object_list;
   
-  --%test(Nested VARRAYS with same data)
+  --%test ( Reports success when comparing identical nested VARRAYS )
   procedure nested_varray_same_data;
   
-  --%test(Nested VARRAYS with different data)
+  --%test ( Reports diff between two not equal nested VARRAYS )
   procedure nested_varray_diff_data;  
 end;
 /


### PR DESCRIPTION
Fixing issue where code was failing on the nested objects due to "object" type being pulled into dynamic SQL as datatype to extract into. 

Fixing issue when null value was passed to get_hash function causing compare to fail 

Address a possible scenario when more than 2 levels of nesting for same objects caused ambiguity of the column name.

Closing #1082 
Closing #1098 
Closing #1083 