### PR TITLE
Gather coverage on code calling DBMS_STATS.

### DIFF
--- a/source/core/coverage/ut_coverage_helper_block.pkb
+++ b/source/core/coverage/ut_coverage_helper_block.pkb
@@ -39,6 +39,14 @@ create or replace package body ut_coverage_helper_block is
     $else
       null;
     $end
+  exception
+    when others then
+      if sqlcode = -08402 then
+        dbms_output.put_line('Unable to finish gathering coverage with DBMS_PLSQL_CODE_COVERAGE. ');
+        dbms_output.put_line('Encountered exception `ORA-08402` when calling procedure `DBMS_PLSQL_CODE_COVERAGE.STOP_COVERAGE()`.');
+        dbms_output.put_line('Coverage report will only include line-level code-coverage (without branches).');
+        dbms_output.put_line('Please reference following issue for details on possible causes: https://github.com/utPLSQL/utPLSQL/issues/1097 ');
+      end if;
   end;
 
   function block_results(a_object ut_coverage_helper.t_tmp_table_object, a_coverage_run_id raw) return t_block_rows is

--- a/source/core/ut_utils.pkb
+++ b/source/core/ut_utils.pkb
@@ -787,9 +787,9 @@ create or replace package body ut_utils is
  
   /**
   * Change string into unicode to match xmlgen format _00<unicode>_
+  * See the section of Oracle documentation called: Escape of Characters in Generated XML Data
   * https://docs.oracle.com/en/database/oracle/oracle-database/12.2/adxdb/generation-of-XML-data-from-relational-data.html#GUID-5BE09A7D-80D8-4734-B9AF-4A61F27FA9B2
-  * secion v3.1.12.3796-develop
-  */  
+  */
   function char_to_xmlgen_unicode(a_character varchar2) return varchar2 is
   begin
     return '_x00'||rawtohex(utl_raw.cast_to_raw(a_character))||'_';

--- a/test/ut3_tester_helper/coverage_helper.pkb
+++ b/test/ut3_tester_helper/coverage_helper.pkb
@@ -123,6 +123,50 @@ create or replace package body coverage_helper is
     begin execute immediate q'[drop package ut3_develop.test_dummy_coverage_1]'; exception when others then null; end;
   end;
 
+  procedure create_cov_with_dbms_stats is
+    pragma autonomous_transaction;
+  begin
+    execute immediate q'[create table ut3_develop.table_to_test_stats as select * from user_objects]';
+
+    execute immediate q'[create or replace package ut3_develop.stats is
+      procedure gather;
+    end;]';
+
+    execute immediate q'[create or replace package body ut3_develop.stats is
+      procedure gather is
+      begin
+        dbms_Stats.gather_table_stats('UT3_DEVELOP','TABLE_TO_TEST_STATS');
+      end;
+    end;]';
+
+    execute immediate q'[create or replace package ut3_develop.test_stats is
+      --%suite(stats gathering coverage test)
+      --%suitepath(coverage_testing)
+
+      --%test
+      procedure test_stats_gather;
+
+    end;]';
+
+    execute immediate q'[create or replace package body ut3_develop.test_stats is
+      procedure test_stats_gather is
+      begin
+        stats.gather;
+        ut.expect(1).to_equal(1);
+      end;
+    end;]';
+
+  end;
+
+  procedure drop_cov_with_dbms_stats is
+    pragma autonomous_transaction;
+  begin
+    begin execute immediate q'[drop package ut3_develop.test_stats]';    exception when others then null; end;
+    begin execute immediate q'[drop package ut3_develop.stats]'; exception when others then null; end;
+    begin execute immediate q'[drop table ut3_develop.table_to_test_stats]'; exception when others then null; end;
+  end;
+
+
   procedure run_standalone_coverage(a_coverage_run_id raw, a_input integer) is
   begin
     ut3_develop.ut_runner.coverage_start(a_coverage_run_id);

--- a/test/ut3_tester_helper/coverage_helper.pks
+++ b/test/ut3_tester_helper/coverage_helper.pks
@@ -14,6 +14,9 @@ create or replace package coverage_helper is
   procedure create_dummy_coverage_1;
   procedure drop_dummy_coverage_1;
 
+  procedure create_cov_with_dbms_stats;
+  procedure drop_cov_with_dbms_stats;
+
   procedure run_standalone_coverage(a_coverage_run_id raw, a_input integer);
   procedure run_coverage_job(a_coverage_run_id raw, a_input integer);
 

--- a/test/ut3_user/reporters/test_coverage/test_extended_coverage.pkb
+++ b/test/ut3_user/reporters/test_coverage/test_extended_coverage.pkb
@@ -83,5 +83,28 @@ create or replace package body test_extended_coverage is
     ut.expect(l_actual).to_be_like(l_expected);
   end;
 
+  procedure coverage_with_dbms_stats is
+    l_expected  clob;
+    l_actual    clob;
+  begin
+    --Arrange
+    l_expected := '%<file path="package body ut3_develop.stats">' ||
+      '%<lineToCover lineNumber="4" covered="true"/>%';
+    --Act
+    l_actual :=
+      ut3_tester_helper.coverage_helper.run_tests_as_job(
+        q'[
+            ut3_develop.ut.run(
+              a_path => 'ut3_develop.test_stats',
+              a_reporter=> ut3_develop.ut_coverage_sonar_reporter( ),
+              a_coverage_schemes => ut3_develop.ut_varchar2_list( 'ut3_develop' ),
+              a_include_objects => ut3_develop.ut_varchar2_list('stats')
+            )
+          ]'
+        );
+    --Assert
+    ut.expect(l_actual).to_be_like(l_expected);
+  end;
+
 end;
 /

--- a/test/ut3_user/reporters/test_coverage/test_extended_coverage.pks
+++ b/test/ut3_user/reporters/test_coverage/test_extended_coverage.pks
@@ -11,6 +11,12 @@ create or replace package test_extended_coverage is
 
   --%test(Coverage is gathered for specified file - extended coverage type)
   procedure coverage_for_file;
+
+  --%beforetest(ut3_tester_helper.coverage_helper.create_cov_with_dbms_stats)
+  --%aftertest(ut3_tester_helper.coverage_helper.drop_cov_with_dbms_stats)
+  --%tags(#1097,#1094)
+  --%test(Extended coverage does not fail the test run then tested code calls DBMS_STATS)
+  procedure coverage_with_dbms_stats;
   
 end;
 /


### PR DESCRIPTION
Implemented a workaround that allows for running utPLSQL tests with code coverage on source with calls to DBMS_STATS.
Resolves: #1097
Resolves: #1094