### PR TITLE
Added disabledReason to `ut_realtime_reporter`

### DIFF
--- a/source/reporters/ut_realtime_reporter.tpb
+++ b/source/reporters/ut_realtime_reporter.tpb
@@ -43,6 +43,7 @@ create or replace type body ut_realtime_reporter is
       self.print_node('objectName', a_test.item.object_name);
       self.print_node('procedureName', a_test.item.procedure_name);
       self.print_node('disabled', case when a_test.get_disabled_flag() then 'true' else 'false' end);
+      self.print_node('disabledReason', a_test.disabled_reason);
       self.print_node('name', a_test.name);
       self.print_node('description',  a_test.description);
       self.print_node('testNumber', to_char(total_number_of_tests));

--- a/test/ut3_user/reporters/test_realtime_reporter.pks
+++ b/test/ut3_user/reporters/test_realtime_reporter.pks
@@ -57,6 +57,9 @@ create or replace package test_realtime_reporter as
   --%test(Escape nested CDATA sections in test output)
   procedure nested_cdata_output;
 
+  --%test(Provide reason disabled test)
+  procedure disabled_reason;
+
   --%afterall
   procedure remove_test_suites;
 


### PR DESCRIPTION
The `ut_realtime_reporter` used by utPLSQL-SQL-Developer-extension and utPLSQL-PLSQL-Developer-plugin  is now capable of providing reason for a disabled test.
The reason is provided as a tag `<disabledReason>reason</disabledReason>` in the `pre-run` event, describing the suites before run is started.

If no reason is provided, the tag is not present in the output.

Resolves: #1192 
