### PR TITLE
Add COVERAGE_RUN_ID to utPLSQL context 

### DIFF
--- a/docs/userguide/annotations.md
+++ b/docs/userguide/annotations.md
@@ -2121,7 +2121,8 @@ It can be accessed from any procecure invoked as part of utPLSQL test execution.
 > For example if utPLSQL is installed into `HR` schema, the context name will be `HR_INFO`
 
 Following attributes are populated:
-- Always:
+- For entire duration of the test-run:
+    - `sys_context( 'UT3_INFO', 'COVERAGE_RUN_ID' );` - Value of COVERAGE_RUN_ID used by utPLSQL internally for coverage gathering 
     - `sys_context( 'UT3_INFO', 'RUN_PATHS' );` - list of suitepaths / suitenames used as input parameters for call to `ut.run(...)` or `ut_runner.run(...)`
     - `sys_context( 'UT3_INFO', 'SUITE_DESCRIPTION' );` - the description of test suite that is currently being executed
     - `sys_context( 'UT3_INFO', 'SUITE_PACKAGE' );` -  the owner and name of test suite package that is currently being executed

--- a/source/core/session_context/ut_session_info.tpb
+++ b/source/core/session_context/ut_session_info.tpb
@@ -28,12 +28,14 @@ create or replace type body ut_session_info as
   member procedure before_calling_run(self in out nocopy ut_session_info, a_run in ut_run) is
   begin
     ut_session_context.set_context( 'run_paths', ut_utils.to_string( ut_utils.table_to_clob( a_run.run_paths,',' ), null ) );
+    ut_session_context.set_context( 'coverage_run_id', rawtohex( a_run.coverage_options.coverage_run_id ) );
     dbms_application_info.set_module( 'utPLSQL', null );
   end;
 
   member procedure after_calling_run(self in out nocopy ut_session_info, a_run in ut_run) is
   begin
     ut_session_context.clear_context( 'run_paths' );
+    ut_session_context.clear_context( 'coverage_run_id' );
     dbms_application_info.set_module( module, action );
     dbms_application_info.set_client_info( client_info );
   end;

--- a/test/ut3_user/api/test_ut_run.pkb
+++ b/test/ut3_user/api/test_ut_run.pkb
@@ -1268,7 +1268,8 @@ Failures:%
   procedure sys_ctx_on_suite_beforeall is
   begin
     ut.expect(g_context_test_results).to_be_like(
-      '%BEFORE_SUITE:CURRENT_EXECUTABLE_NAME='||gc_owner||'.check_context.before_suite'
+      '%BEFORE_SUITE:COVERAGE_RUN_ID=________________________________%'
+        ||'%BEFORE_SUITE:CURRENT_EXECUTABLE_NAME='||gc_owner||'.check_context.before_suite'
         ||'%BEFORE_SUITE:CURRENT_EXECUTABLE_TYPE=beforeall'
         ||'%BEFORE_SUITE:RUN_PATHS=check_context'
         ||'%BEFORE_SUITE:SUITE_DESCRIPTION=Suite description'


### PR DESCRIPTION
This will allow for more accurate coverage reporting when running tests against the coverage module of the framework.

With this, in the test, we can get the current `coverage_run_id` and pass it to the JOB that runs utPLSQL in separate session.
After the JOB is finished, we can then copy the output from `ut3_develop` coverage tables into `ut3` coverage tables.
That way, we will get a full picture of the coverage gathered in the course of utPLSQL test-run with coverage enabled.

Most of the setup is already in place in our tests. The only missing peace was the ability to tie the current `ut3` test-run with the coverage gathered by jobs.
So now, after each test JOB, we can copy the coverage over to `ut3`.
I suggest using negative-id's when performing the copy from `ut3_develop` profiler/dbms_plsql_cov tables.
That way we can:
- avoid conflicts on `run_id`
- identify data from core run vs test-job run
