### PR TITLE
Grant execute on dbms_lob

### DIFF
--- a/source/create_utplsql_owner.sql
+++ b/source/create_utplsql_owner.sql
@@ -42,5 +42,7 @@ end;
 
 grant execute on dbms_crypto to &ut3_owner_schema;
 
+grant execute on dbms_lob to &ut3_owner_schema;
+
 grant alter session to &ut3_owner_schema;
 


### PR DESCRIPTION
In certain environments public access to dbms_lob is restricted so add an explicit grant