### PR TITLE
Add explicit grants for public packages

### DIFF
--- a/source/create_utplsql_owner.sql
+++ b/source/create_utplsql_owner.sql
@@ -41,6 +41,11 @@ end;
 /
 
 grant execute on dbms_crypto to &ut3_owner_schema;
+grant execute on dbms_lob    to &ut3_owner_schema;
+grant execute on dbms_xmlgen to &ut3_owner_schema;
+grant execute on dbms_sql    to &ut3_owner_schema;
+grant execute on dbms_random to &ut3_owner_schema;
+
 
 grant alter session to &ut3_owner_schema;
 


### PR DESCRIPTION
The privileges on the referenced packages are often revoked from PUBLIC as database hardening. Not relying on these grants being available makes the install script more robust.

See also issue #1229