### PR TITLE
Address issue where the not_to(contain) not run correctly

### DIFF
--- a/source/expectations/matchers/ut_contain.tpb
+++ b/source/expectations/matchers/ut_contain.tpb
@@ -47,6 +47,7 @@ create or replace type body ut_contain as
 
   overriding member function run_matcher_negated(self in out nocopy ut_contain, a_actual ut_data_value) return boolean is
   begin
+    self.negated();
     return run_matcher(a_actual);
   end;
 

--- a/source/expectations/ut_expectation.tpb
+++ b/source/expectations/ut_expectation.tpb
@@ -686,7 +686,7 @@ create or replace type body ut_expectation as
   
   member procedure not_to_contain(self in ut_expectation, a_expected sys_refcursor) is
   begin
-    self.not_to( ut_contain(a_expected).negated() );
+    self.not_to( ut_contain(a_expected));
   end;
 
   member procedure to_contain(self in ut_expectation, a_expected anydata) is
@@ -696,7 +696,7 @@ create or replace type body ut_expectation as
   
   member procedure not_to_contain(self in ut_expectation, a_expected anydata) is
   begin
-    self.not_to( ut_contain(a_expected).negated() );
+    self.not_to( ut_contain(a_expected));
   end;
   
   member function to_be_within(a_dist number) return ut_be_within is

--- a/test/ut3_user/expectations/test_expectation_anydata.pkb
+++ b/test/ut3_user/expectations/test_expectation_anydata.pkb
@@ -957,6 +957,23 @@ Rows: [ 60 differences, showing first 20 ]
     ut.expect(ut3_tester_helper.main_helper.get_failed_expectations_num).to_equal(0); 
   end;  
   
+   procedure collection_not_to_contain is
+    l_actual           ut3_tester_helper.test_dummy_object_list;
+    l_expected         ut3_tester_helper.test_dummy_object_list;
+  begin
+    --Arrange
+    select ut3_tester_helper.test_dummy_object( rownum, 'Something2 '||rownum, rownum+100)
+      bulk collect into l_actual
+      from dual connect by level <=4;
+    select ut3_tester_helper.test_dummy_object( rownum, 'Something '||rownum, rownum)
+      bulk collect into l_expected
+      from dual connect by level <=2
+     order by rownum desc;
+    --Act
+    ut3_develop.ut.expect(anydata.convertCollection(l_actual)).not_to_contain(anydata.convertCollection(l_expected));
+    ut.expect(ut3_tester_helper.main_helper.get_failed_expectations_num).to_equal(0); 
+  end;  
+
   procedure object_to_contain is
   begin
   --Arrange
@@ -967,7 +984,7 @@ Rows: [ 60 differences, showing first 20 ]
     ut3_develop.ut.expect(g_test_actual).to_contain(g_test_expected);
     ut.expect(ut3_tester_helper.main_helper.get_failed_expectations_num).to_equal(0); 
   end;  
-   
+ 
   procedure arr_empty_eq_arr_empty_unord is
   begin
    --Arrange

--- a/test/ut3_user/expectations/test_expectation_anydata.pks
+++ b/test/ut3_user/expectations/test_expectation_anydata.pks
@@ -195,6 +195,9 @@ create or replace package test_expectation_anydata is
   --%test( Success when anydata collection contains data from another anydata collection)
   procedure collection_to_contain; 
   
+  --%test( Success when anydata collection not contains data from another anydata collection)
+  procedure collection_not_to_contain;  
+
   --%test( Success when anydata object contains data from another anydata)
   procedure object_to_contain;     
   

--- a/test/ut3_user/expectations/test_expectations_cursor.pkb
+++ b/test/ut3_user/expectations/test_expectations_cursor.pkb
@@ -2448,7 +2448,7 @@ Diff:%
     ut.expect(ut3_tester_helper.main_helper.get_failed_expectations_num).to_equal(0);
   end;
 
-  procedure not_cont_join_incl_cols_as_lst2 is
+  procedure not_con_join_incl_cols_as_lst2 is
     l_actual   sys_refcursor;
     l_expected sys_refcursor;
   begin
@@ -2474,7 +2474,7 @@ Diff:%
     ut.expect(ut3_tester_helper.main_helper.get_failed_expectations_num).to_equal(0);
   end;
 
-  procedure not_cont_join_excl_cols_as_lst2 is
+  procedure not_con_join_excl_cols_as_lst2 is
     l_actual   sys_refcursor;
     l_expected sys_refcursor;
   begin

--- a/test/ut3_user/expectations/test_expectations_cursor.pkb
+++ b/test/ut3_user/expectations/test_expectations_cursor.pkb
@@ -2329,6 +2329,23 @@ Diff:%
     ut.expect(ut3_tester_helper.main_helper.get_failed_expectations_num).to_equal(0);
   end;  
   
+  procedure cursor_not_to_contain2
+  as
+    l_actual   sys_refcursor;
+    l_expected sys_refcursor;
+  begin
+    open l_expected for select 'TEST' username, -600 user_id from dual;
+    
+    open l_actual for select username, user_id from all_users
+    union all
+    select 'TEST1' username, -601 user_id from dual;
+
+    --Act
+    ut3_develop.ut.expect(l_actual).not_to(ut3_develop.contain(l_expected));
+    --Assert
+    ut.expect(ut3_tester_helper.main_helper.get_failed_expectations_num).to_equal(0);
+  end;
+
   procedure cursor_not_to_contain_fail is
     l_actual   sys_refcursor;
     l_expected sys_refcursor;
@@ -2359,6 +2376,37 @@ Diff:%
     ut.expect(l_actual_message).to_be_like(l_expected_message);
   end;
 
+
+  procedure cursor_not_to_contain_fail2 is
+    l_actual   sys_refcursor;
+    l_expected sys_refcursor;
+    l_expected_message varchar2(32767);
+    l_actual_message   varchar2(32767);
+  begin
+    --Arrange
+    open l_expected for select 'TEST' username, -600 user_id from dual;
+    
+    open l_actual for select username, user_id from all_users
+    union all
+    select 'TEST' username, -600 user_id from dual;
+    
+    --Act
+    ut3_develop.ut.expect(l_actual).not_to(ut3_develop.contain(l_expected));
+    --Assert
+     l_expected_message := q'[%Actual: (refcursor [ count = % ])%
+%Data-types:%
+%<USERNAME>VARCHAR2</USERNAME><USER_ID>NUMBER</USER_ID>%
+%Data:%
+%was expected not to contain:(refcursor [ count = 1 ])%
+%Data-types:%
+%<USERNAME>CHAR</USERNAME><USER_ID>NUMBER</USER_ID>%
+%Data:%
+%<ROW><USERNAME>TEST</USERNAME><USER_ID>-600</USER_ID></ROW>%]';
+    l_actual_message := ut3_tester_helper.main_helper.get_failed_expectations(1);
+    --Assert
+    ut.expect(l_actual_message).to_be_like(l_expected_message);
+  end;
+
   procedure cursor_not_to_contain_joinby is
     l_actual   sys_refcursor;
     l_expected sys_refcursor;
@@ -2372,7 +2420,21 @@ Diff:%
     --Assert
     ut.expect(ut3_tester_helper.main_helper.get_failed_expectations_num).to_equal(0);
   end;
-  
+
+  procedure cursor_not_to_contain_joinby2 is
+    l_actual   sys_refcursor;
+    l_expected sys_refcursor;
+  begin
+    --Arrange
+    open l_actual for select username,rownum * 10 user_id from all_users where rownum < 5;
+    open l_expected for select username||to_char(rownum) username ,rownum user_id from all_users where rownum < 5;
+    
+    --Act
+    ut3_develop.ut.expect(l_actual).not_to(ut3_develop.contain(l_expected).join_by('USER_ID'));
+    --Assert
+    ut.expect(ut3_tester_helper.main_helper.get_failed_expectations_num).to_equal(0);
+  end;
+
   procedure not_cont_join_incl_cols_as_lst is
     l_actual   sys_refcursor;
     l_expected sys_refcursor;
@@ -2386,6 +2448,19 @@ Diff:%
     ut.expect(ut3_tester_helper.main_helper.get_failed_expectations_num).to_equal(0);
   end;
 
+  procedure not_cont_join_incl_cols_as_lst2 is
+    l_actual   sys_refcursor;
+    l_expected sys_refcursor;
+  begin
+    --Arrange
+    open l_actual   for select rownum as rn, 'b' as "A_Column", 'c' as A_COLUMN, 'x' SOME_COL, 'd' "Some_Col"  from dual a connect by level < 10;
+    open l_expected for select rownum  * 20 rn, 'a' as "A_Column", 'd' as A_COLUMN, 'x' SOME_COL, 'c' "Some_Col"  from dual a connect by level < 4;
+    --Act
+    ut3_develop.ut.expect(l_actual).not_to(ut3_develop.contain(l_expected).include(ut3_develop.ut_varchar2_list('RN','//A_Column','SOME_COL')).join_by('RN'));
+    --Assert
+    ut.expect(ut3_tester_helper.main_helper.get_failed_expectations_num).to_equal(0);
+  end;
+  
   procedure not_cont_join_excl_cols_as_lst is
     l_actual   sys_refcursor;
     l_expected sys_refcursor;
@@ -2395,6 +2470,19 @@ Diff:%
     open l_expected for select rownum * 20 as rn, 'a' as "A_Column", 'd' as A_COLUMN, 'x' SOME_COL, 'c' "Some_Col"  from dual a connect by level < 4;
     --Act
     ut3_develop.ut.expect(l_actual).not_to_contain(l_expected).exclude(ut3_develop.ut_varchar2_list('//Some_Col','A_COLUMN')).join_by('RN');
+    --Assert
+    ut.expect(ut3_tester_helper.main_helper.get_failed_expectations_num).to_equal(0);
+  end;
+
+  procedure not_cont_join_excl_cols_as_lst2 is
+    l_actual   sys_refcursor;
+    l_expected sys_refcursor;
+  begin
+    --Arrange
+    open l_actual   for select rownum as rn, 'a' as "A_Column", 'c' as A_COLUMN, 'y' SOME_COL, 'd' "Some_Col"  from dual a connect by level < 10;
+    open l_expected for select rownum * 20 as rn, 'a' as "A_Column", 'd' as A_COLUMN, 'x' SOME_COL, 'c' "Some_Col"  from dual a connect by level < 4;
+    --Act
+    ut3_develop.ut.expect(l_actual).not_to(ut3_develop.contain(l_expected).exclude(ut3_develop.ut_varchar2_list('//Some_Col','A_COLUMN')).join_by('RN'));
     --Assert
     ut.expect(ut3_tester_helper.main_helper.get_failed_expectations_num).to_equal(0);
   end;
@@ -2440,6 +2528,16 @@ Diff:%
     ut.expect(l_actual_message).to_be_like(l_expected_message);
   end;
   
+  procedure to_not_contain_fails_1245 is
+    c1 sys_refcursor;
+    c2 sys_refcursor;
+  begin
+    open c1 for select 'a' as letter from dual union all select 'b' from dual;
+    open c2 for select 'c' as letter from dual;
+    ut3_develop.ut.expect(c1).not_to(ut3_develop.contain(c2));
+    ut.expect(ut3_tester_helper.main_helper.get_failed_expectations_num).to_equal(0);
+  end;
+
   procedure udt_messg_format_eq is
     l_actual   sys_refcursor;
     l_expected sys_refcursor;

--- a/test/ut3_user/expectations/test_expectations_cursor.pks
+++ b/test/ut3_user/expectations/test_expectations_cursor.pks
@@ -395,13 +395,13 @@ create or replace package test_expectations_cursor is
   procedure not_cont_join_incl_cols_as_lst;
   
   --%test(Cursor not_to[contain] data with of columns to include and join by value)
-  procedure not_cont_join_incl_cols_as_lst2;
+  procedure not_con_join_incl_cols_as_lst2;
 
   --%test(Cursor not contains data with of columns to exclude and join by value)
   procedure not_cont_join_excl_cols_as_lst; 
 
   --%test(Cursor not_to[contain] data with of columns to exclude and join by value)
-  procedure not_cont_join_excl_cols_as_lst2; 
+  procedure not_con_join_excl_cols_as_lst2; 
 
   --%test(Cursor to contain duplicates)
   procedure to_contain_duplicates;

--- a/test/ut3_user/expectations/test_expectations_cursor.pks
+++ b/test/ut3_user/expectations/test_expectations_cursor.pks
@@ -376,24 +376,42 @@ create or replace package test_expectations_cursor is
   --%test( Cursor not to contains data from another cursor)   
   procedure cursor_not_to_contain;
   
+  --%test( Cursor not_to[contain] data from another cursor)   
+  procedure cursor_not_to_contain2;
+
   --%test( Cursor fail not to contains data from another cursor)
   procedure cursor_not_to_contain_fail;
-  
+
+   --%test( Cursor fail not_to[contain] data from another cursor)
+  procedure cursor_not_to_contain_fail2;
+
   --%test( Cursor not contains data from another cursor with joinby clause)
   procedure cursor_not_to_contain_joinby;  
   
+  --%test( Cursor not_to[contain] data from another cursor with joinby clause)
+  procedure cursor_not_to_contain_joinby2;  
+
   --%test(Cursor not contains data with of columns to include and join by value)
   procedure not_cont_join_incl_cols_as_lst;
   
+  --%test(Cursor not_to[contain] data with of columns to include and join by value)
+  procedure not_cont_join_incl_cols_as_lst2;
+
   --%test(Cursor not contains data with of columns to exclude and join by value)
   procedure not_cont_join_excl_cols_as_lst; 
+
+  --%test(Cursor not_to[contain] data with of columns to exclude and join by value)
+  procedure not_cont_join_excl_cols_as_lst2; 
 
   --%test(Cursor to contain duplicates)
   procedure to_contain_duplicates;
   
   --%test(Cursor to contain duplicates fail)
   procedure to_contain_duplicates_fail;
-    
+
+  --%test(Cursor using not_to[contain] fails #1245)
+  procedure to_not_contain_fails_1245; 
+
   --%test(Display a message with a uer defined type with only type name not structure on equal)
   procedure udt_messg_format_eq; 
  


### PR DESCRIPTION
Address issue where the not_to(contain) executes a negated matcher wi…thout negated flag set causing refcursor compare sql generated inclusion comparision.
fixes #1245 