### PR TITLE
Fix output length error and output buffer.

### DIFF
--- a/source/core/output_buffers/ut_output_buffer_base.tpb
+++ b/source/core/output_buffers/ut_output_buffer_base.tpb
@@ -24,7 +24,6 @@ create or replace type body ut_output_buffer_base is
     self.self_type := coalesce(a_self_type,self.self_type);
     self.output_id := coalesce(a_output_id, self.output_id, sys_guid());
     self.start_date := coalesce(self.start_date, sysdate);
-    self.last_write_message_id := 0;
     select /*+ no_parallel */ count(*) into l_exists from ut_output_buffer_info_tmp where output_id = self.output_id;
     if ( l_exists > 0 ) then
       update  /*+ no_parallel */ ut_output_buffer_info_tmp set start_date = self.start_date where output_id = self.output_id;

--- a/source/core/output_buffers/ut_output_buffer_base.tps
+++ b/source/core/output_buffers/ut_output_buffer_base.tps
@@ -19,7 +19,6 @@ create or replace type ut_output_buffer_base force authid definer as object(
   output_id                 raw(32),
   is_closed                 number(1,0),
   start_date                date,
-  last_write_message_id     number(38,0),
   lock_handle               varchar2(30  byte),
   self_type                 varchar2(250 byte),
   member procedure init(self in out nocopy ut_output_buffer_base, a_output_id raw := null, a_self_type varchar2 := null),

--- a/source/core/output_buffers/ut_output_buffer_tmp.sql
+++ b/source/core/output_buffers/ut_output_buffer_tmp.sql
@@ -30,3 +30,4 @@ create table ut_output_buffer_tmp(
 ) organization index nologging initrans 100
   overflow nologging initrans 100;
 
+create sequence ut_output_buffer_tmp_seq cache 20;

--- a/source/core/output_buffers/ut_output_bulk_buffer.tpb
+++ b/source/core/output_buffers/ut_output_bulk_buffer.tpb
@@ -34,9 +34,8 @@ create or replace type body ut_output_bulk_buffer is
           a_item_type
           );
       else
-        self.last_write_message_id := self.last_write_message_id + 1;
         insert /*+ no_parallel */ into ut_output_buffer_tmp(output_id, message_id, text, item_type)
-        values (self.output_id, self.last_write_message_id, a_text, a_item_type);
+        values (self.output_id, ut_output_buffer_tmp_seq.nextval, a_text, a_item_type);
       end if;
       commit;
     end if;
@@ -46,10 +45,9 @@ create or replace type body ut_output_bulk_buffer is
     pragma autonomous_transaction;
   begin
     insert /*+ no_parallel */ into ut_output_buffer_tmp(output_id, message_id, text, item_type)
-    select /*+ no_parallel */ self.output_id, self.last_write_message_id + rownum, t.column_value, a_item_type
+    select /*+ no_parallel */ self.output_id, ut_output_buffer_tmp_seq.nextval, t.column_value, a_item_type
       from table(a_text_list) t
      where t.column_value is not null or a_item_type is not null;
-    self.last_write_message_id := self.last_write_message_id + sql%rowcount;
     commit;
   end;
 
@@ -65,9 +63,8 @@ create or replace type body ut_output_bulk_buffer is
           a_item_type
           );
       else
-        self.last_write_message_id := self.last_write_message_id + 1;
         insert /*+ no_parallel */ into ut_output_buffer_tmp(output_id, message_id, text, item_type)
-        values (self.output_id, self.last_write_message_id, a_text, a_item_type);
+        values (self.output_id, ut_output_buffer_tmp_seq.nextval, a_text, a_item_type);
       end if;
       commit;
     end if;

--- a/source/core/output_buffers/ut_output_clob_buffer_tmp.sql
+++ b/source/core/output_buffers/ut_output_clob_buffer_tmp.sql
@@ -45,3 +45,5 @@ begin
   end;
 end;
 /
+
+create sequence ut_output_clob_buffer_tmp_seq cache 20;

--- a/source/core/ut_utils.pks
+++ b/source/core/ut_utils.pks
@@ -476,6 +476,11 @@ create or replace package ut_utils authid definer is
   * Return value of interval in plain english
   */    
   function interval_to_text(a_interval yminterval_unconstrained) return varchar2;
+
+  /*
+  * Return length of CLOB in bytes. Null for NULL
+  */
+  function lengthb_clob( a_clob clob) return integer;
   
 end ut_utils;
 /

--- a/source/uninstall_objects.sql
+++ b/source/uninstall_objects.sql
@@ -333,7 +333,11 @@ drop type ut_output_buffer_base force;
 
 drop table ut_output_buffer_tmp purge;
 
+drop table ut_output_buffer_tmp_seq purge;
+
 drop table ut_output_clob_buffer_tmp purge;
+
+drop table ut_output_clob_buffer_tmp_seq purge;
 
 drop table ut_output_buffer_info_tmp purge;
 

--- a/source/uninstall_objects.sql
+++ b/source/uninstall_objects.sql
@@ -333,11 +333,11 @@ drop type ut_output_buffer_base force;
 
 drop table ut_output_buffer_tmp purge;
 
-drop table ut_output_buffer_tmp_seq purge;
+drop sequence ut_output_buffer_tmp_seq;
 
 drop table ut_output_clob_buffer_tmp purge;
 
-drop table ut_output_clob_buffer_tmp_seq purge;
+drop sequence ut_output_clob_buffer_tmp_seq;
 
 drop table ut_output_buffer_info_tmp purge;
 

--- a/test/ut3_tester/core/test_output_buffer.pks
+++ b/test/ut3_tester/core/test_output_buffer.pks
@@ -47,5 +47,11 @@ create or replace package test_output_buffer is
   --%test(Purges clob buffer data older than one day and leaves the rest)
   procedure test_purge_clob_buffer;
 
+  --%test(Successfully sends multibyte long line into text buffer)
+  procedure text_buffer_send_multibyte;
+
+  --%test(Successfully sends multibyte long clob line into text buffer)
+  procedure text_buffer_send_clob_multib;
+
 end test_output_buffer;
 /

--- a/test/ut3_tester/core/test_ut_utils.pkb
+++ b/test/ut3_tester/core/test_ut_utils.pkb
@@ -505,7 +505,7 @@ end;
     l_clob clob;
   begin
     l_clob := '❤';
-    ut.expect(ut3_develop.ut_utils.lengthb_clob(l_clob)).to_equal(3);
+    ut.expect(ut3_develop.ut_utils.lengthb_clob(l_clob)).to_be_greater_than(1);
   end;
 end test_ut_utils;
 /

--- a/test/ut3_tester/core/test_ut_utils.pkb
+++ b/test/ut3_tester/core/test_ut_utils.pkb
@@ -489,5 +489,23 @@ end;
     ut.expect(l_expected).to_equal(l_actual);
   end;   
 
+  procedure convert_collection_multibyte is
+    l_input ut3_develop.ut_varchar2_list;
+    l_max_len integer := ut3_develop.ut_utils.gc_max_storage_varchar2_len;
+  begin
+    --Arrange
+    l_input := ut3_develop.ut_varchar2_list( rpad( '❤', l_max_len, 'a' ) );
+    ut.expect( lengthb( l_input( 1 ) ) ).to_be_greater_than(l_max_len);
+
+    --Act
+    ut.expect( lengthb( ut3_develop.ut_utils.convert_collection(l_input)(1) ) ).to_be_less_or_equal(l_max_len);
+  end;
+
+  procedure lengthb_gives_length_in_bytes is
+    l_clob clob;
+  begin
+    l_clob := '❤';
+    ut.expect(ut3_develop.ut_utils.lengthb_clob(l_clob)).to_equal(3);
+  end;
 end test_ut_utils;
 /

--- a/test/ut3_tester/core/test_ut_utils.pks
+++ b/test/ut3_tester/core/test_ut_utils.pks
@@ -152,10 +152,15 @@ create or replace package test_ut_utils is
   procedure int_conv_ym_month; 
     
    --%test(returns text representation of interval year to month for custom interval)  
-  procedure int_conv_ym_date;   
-  
-  
+  procedure int_conv_ym_date;
+
   --%endcontext
-  
+
+  --%test(convert_collection does not fail on multibyte strings - Issue #1245 )
+  procedure convert_collection_multibyte;
+
+  --%test(lengthb returns length of a CLOB in bytes )
+  procedure lengthb_gives_length_in_bytes;
+
 end test_ut_utils;
 /


### PR DESCRIPTION
When dealing with multibyte strings, the substring limit of 4000 **chars** is not correct. We need to apply a limit of 4000 **bytes** to both VARCHAR2 and to CLOB data types. This means we need to have a function to calculate lenght of CLOB in bytes. This is now added and all the conversions/trimming/string-splitting is done using the string length in **bytes**

Additionally, a different approach (with sequences) was introduced into output buffers to avoid the sometime occurring PK violation on the output buffer tables. The new approach may add a but overhead on reading from / saving into buffer, but will definitely address the threat of PK errors.

Resolves #1254
Resolves #1128
