### PR TITLE
The line-rate is not recorded for packages and classes in cobertura coverage reporter

### DIFF
--- a/test/ut3_user/reporters/test_coverage/test_cov_cobertura_reporter.pkb
+++ b/test/ut3_user/reporters/test_coverage/test_cov_cobertura_reporter.pkb
@@ -25,9 +25,9 @@ create or replace package body test_cov_cobertura_reporter is
 <source>]'||l_file_path||q'[</source>
 </sources>
 <packages>
-<package name="]'||upper(l_name)||q'[" line-rate="0.0" branch-rate="0.0" complexity="0.0">
+<package name="]'||upper(l_name)||q'[" line-rate="0.5" branch-rate="0.0" complexity="0.0">
 <classes>
-<class name="]'||upper(l_name)||q'[" filename="]'||l_file_path||q'[" line-rate="0.0" branch-rate="0.0" complexity="0.0">
+<class name="]'||upper(l_name)||q'[" filename="]'||l_file_path||q'[" line-rate="0.5" branch-rate="0.0" complexity="0.0">
 <lines>
 ]'||l_block_cov||q'[
 <line number="6" hits="0" branch="false"/>

--- a/test/ut3_user/reporters/test_coverage/test_coverage_standalone.pkb
+++ b/test/ut3_user/reporters/test_coverage/test_coverage_standalone.pkb
@@ -20,9 +20,9 @@ create or replace package body test_coverage_standalone is
 <source>]'||l_file_path||q'[</source>
 </sources>
 <packages>
-<package name="]'||upper(a_object_name)||q'[" line-rate="0.0" branch-rate="0.0" complexity="0.0">
+<package name="]'||upper(a_object_name)||q'[" line-rate="1.0" branch-rate="0.0" complexity="0.0">
 <classes>
-<class name="]'||upper(a_object_name)||q'[" filename="]'||l_file_path||q'[" line-rate="0.0" branch-rate="0.0" complexity="0.0">
+<class name="]'||upper(a_object_name)||q'[" filename="]'||l_file_path||q'[" line-rate="1.0" branch-rate="0.0" complexity="0.0">
 <lines>
 ]'||l_block_cov||q'[
 <line number="6" hits="1" branch="false"/>


### PR DESCRIPTION
Fixes #1268

Currently the cobertura coverage reported set the line-rate for class and packages to 0. This seems to have impact on some of new versions of publish reporters.