### PR TITLE
Suite cache should not be saved for packages that are not suites

### DIFF
--- a/source/core/ut_suite_cache_manager.pkb
+++ b/source/core/ut_suite_cache_manager.pkb
@@ -306,7 +306,7 @@ create or replace package body ut_suite_cache_manager is
     l_object_owner      varchar2(250) := upper(a_object_owner);
     l_object_name       varchar2(250) := upper(a_object_name);
   begin
-    if a_suite_items is not null and a_suite_items.count = 0 then
+    if a_suite_items is null or a_suite_items.count = 0 then
 
       delete from ut_suite_cache t
        where t.object_owner = l_object_owner

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -4,6 +4,8 @@ set -ev
 #goto git root directory
 git rev-parse && cd "$(git rev-parse --show-cdup)"
 
+export NLS_LANG=AMERICAN_AMERICA.AL32UTF8
+
 time utPLSQL-cli/bin/utplsql run UT3_TESTER_HELPER/ut3@//${CONNECTION_STR} -D \
 -source_path=source -owner=ut3_develop \
 -p='ut3_tester,ut3_user' \

--- a/test/ut3_tester/core/test_suite_manager.pks
+++ b/test/ut3_tester/core/test_suite_manager.pks
@@ -163,7 +163,7 @@ create or replace package test_suite_manager is
 
   --%context(get_schema_ut_packages)
 
-  --%test(returns list of all unit test packages in given schema)
+  --%test(returns list of all unit test packages in given schema excluding packages that are not suites)
   --%beforetest(create_ut3_suite)
   --%aftertest(drop_ut3_suite)
   procedure test_get_schema_ut_packages;

--- a/test/ut3_tester_helper/run_helper.pkb
+++ b/test/ut3_tester_helper/run_helper.pkb
@@ -856,11 +856,22 @@ create or replace package body run_helper is
         procedure some_test;
 
       end;]';
+    execute immediate q'[
+      create or replace package ut3_develop.package_that_is_not_a_test
+      as
+        --%parameter(a comment inside)
+        --%parameters( description )
+
+        --%test
+        procedure some_test;
+
+      end;]';
   end;
 
   procedure drop_ut3_suite is
     pragma autonomous_transaction;
   begin
+    execute immediate q'[drop package ut3_develop.package_that_is_not_a_test]';
     execute immediate q'[drop package ut3_develop.some_test_package]';
   end;
   


### PR DESCRIPTION
There was a bug in `ut_suite_cache_manager` that was causing packages that had comments captured as annotations ( the `--%`) to be saved in suite cache and considered as test suites.
Those packages were then getting excluded form coverage report.

Only packages that contain suite information should be considered test suites and should eb added to suite cahge.
The annotation parsing remains independent from suite constriction and therefore all lines with comment `--%` are still saved in annotation cache.

Resolves #1278