### PR TITLE
fix: prevent ora-21799 in ut_run()

### DIFF
--- a/source/api/ut_runner.pkb
+++ b/source/api/ut_runner.pkb
@@ -90,7 +90,7 @@ create or replace package body ut_runner is
     end if;
     ut_event_manager.add_listener( ut_session_info() );
 
-    ut_event_manager.trigger_event(ut_event_manager.gc_initialize);
+    ut_event_manager.trigger_event(ut_event_manager.gc_initialize, ut_run());
     ut_event_manager.trigger_event(ut_event_manager.gc_debug, ut_run_info());
 
     if a_random_test_order_seed is not null then


### PR DESCRIPTION
This PR addresses the _ORA-21799 duration not active_ error reported in https://forums.oracle.com/ords/apexds/post/ora-21779-duration-not-active-when-running-utplsql-on-23-26-4428

Initially I thought the error might be thrown during the transition to an autonomous transaction. The most suspicious spot in my investigation was crossing the autonomous boundary with object types in UT.RUN -> RUN_AUTONOMOUS (pragma autonomous_transaction) with a_reporter in out nocopy ut_reporter_base.

Turns out, that wasn't it. The RC appears earlier in the stack:

- The stack trace shows a failure at startup event: UT_RUNNER line 93 triggers gc_initialize (ut_runner.pkb (line 93))
- Event manager dispatches listener (ut_event_manager.pkb (line 70))
- Reporter handler does treat(a_event_item as ut_run) on initialize (ut_reporter_base.tpb (line 171))

For gc_initialize, a_event_item is passed as NULL (no event object). My suspicion is that the ORA-21779 occurs on object-duration/type-cast handling at event dispatch time.

I tried passing a real object in UT_RUNNER line 93:
```
ut_event_manager.trigger_event(ut_event_manager.gc_initialize, ut_run());
```

If the treat(NULL as ut_run) is the problem, that should fix the issue. It works on my machine. Kindly review and merge if applicable.