### PR TITLE
Fix issue with `UT_TAP_REPORTER` on Oracle 23.26

### DIFF
--- a/source/reporters/ut_tap_reporter.tpb
+++ b/source/reporters/ut_tap_reporter.tpb
@@ -25,7 +25,7 @@ create or replace type body ut_tap_reporter is
 
   member procedure print_comment(self in out nocopy ut_tap_reporter, a_comment clob) as
   begin
-    self.print_clob(regexp_replace(a_comment, '^', '# ', 1, 0, 'm'));
+    self.print_clob(regexp_replace(a_comment, '^(.+)', '# \1', 1, 0, 'm'));
   end print_comment;
 
   member function escape_special_chars(self in out nocopy ut_tap_reporter, a_string_to_escape clob) return clob as


### PR DESCRIPTION
Tap reporter does not add '#' on empty lines anymore. 
Resolves: #1358