### PR TITLE
utPLSQL can be installed in editioned schema.

### DIFF
--- a/.github/scripts/create_test_users.sh
+++ b/.github/scripts/create_test_users.sh
@@ -18,6 +18,9 @@ PROMPT Creating UT3_TESTER - Power-user for testing internal framework code
 create user UT3_TESTER identified by "ut3" default tablespace $UT3_TABLESPACE quota unlimited on $UT3_TABLESPACE;
 grant create session, create procedure, create type, create table to UT3_TESTER;
 
+# Editioning is enable on test users to validate that utPLSQL works well with editioned schema
+alter user UT3_TESTER enable editions;
+
 grant execute on dbms_lock to UT3_TESTER;
 
 PROMPT Granting $UT3_DEVELOP_SCHEMA code to UT3_TESTER
@@ -51,6 +54,9 @@ PROMPT Creating UT3_USER - minimal privileges user for API testing
 
 create user UT3_USER identified by "ut3" default tablespace $UT3_TABLESPACE quota unlimited on $UT3_TABLESPACE;
 grant create session, create procedure, create type, create table to UT3_USER;
+
+# Editioning is enable on test users to validate that utPLSQL works well with editioned schema
+alter user UT3_USER enable editions;
 
 PROMPT Grants for starting a debugging session from UT3_USER
 grant debug connect session to UT3_USER;

--- a/.github/scripts/install.sh
+++ b/.github/scripts/install.sh
@@ -19,3 +19,13 @@ set verify off
 alter session set plsql_optimize_level=0;
 @${INSTALL_FILE} $UT3_DEVELOP_SCHEMA $UT3_DEVELOP_SCHEMA_PASSWORD
 SQL
+
+#Enable editioning on the UT3_DEVELOP schema
+time "$SQLCLI" sys/$ORACLE_PWD@//$CONNECTION_STR AS SYSDBA <<-SQL
+whenever sqlerror exit failure rollback
+set feedback off
+set verify off
+
+alter user $UT3_DEVELOP_SCHEMA enable editions;
+exit
+SQL

--- a/source/api/be_between.syn
+++ b/source/api/be_between.syn
@@ -1,1 +1,1 @@
-create synonym be_between for ut_be_between;
+create noneditionable synonymbe_between for ut_be_between;

--- a/source/api/be_between.syn
+++ b/source/api/be_between.syn
@@ -1,1 +1,1 @@
-create noneditionable synonymbe_between for ut_be_between;
+create noneditionable synonym be_between for ut_be_between;

--- a/source/api/be_empty.syn
+++ b/source/api/be_empty.syn
@@ -1,1 +1,1 @@
-create synonym be_empty for ut_be_empty;
+create noneditionable synonymbe_empty for ut_be_empty;

--- a/source/api/be_empty.syn
+++ b/source/api/be_empty.syn
@@ -1,1 +1,1 @@
-create noneditionable synonymbe_empty for ut_be_empty;
+create noneditionable synonym be_empty for ut_be_empty;

--- a/source/api/be_false.syn
+++ b/source/api/be_false.syn
@@ -1,1 +1,1 @@
-create noneditionable synonymbe_false for ut_be_false;
+create noneditionable synonym be_false for ut_be_false;

--- a/source/api/be_false.syn
+++ b/source/api/be_false.syn
@@ -1,1 +1,1 @@
-create synonym be_false for ut_be_false;
+create noneditionable synonymbe_false for ut_be_false;

--- a/source/api/be_greater_or_equal.syn
+++ b/source/api/be_greater_or_equal.syn
@@ -1,1 +1,1 @@
-create synonym be_greater_or_equal for ut_be_greater_or_equal;
+create noneditionable synonymbe_greater_or_equal for ut_be_greater_or_equal;

--- a/source/api/be_greater_or_equal.syn
+++ b/source/api/be_greater_or_equal.syn
@@ -1,1 +1,1 @@
-create noneditionable synonymbe_greater_or_equal for ut_be_greater_or_equal;
+create noneditionable synonym be_greater_or_equal for ut_be_greater_or_equal;

--- a/source/api/be_greater_than.syn
+++ b/source/api/be_greater_than.syn
@@ -1,1 +1,1 @@
-create noneditionable synonymbe_greater_than for ut_be_greater_than;
+create noneditionable synonym be_greater_than for ut_be_greater_than;

--- a/source/api/be_greater_than.syn
+++ b/source/api/be_greater_than.syn
@@ -1,1 +1,1 @@
-create synonym be_greater_than for ut_be_greater_than;
+create noneditionable synonymbe_greater_than for ut_be_greater_than;

--- a/source/api/be_less_or_equal.syn
+++ b/source/api/be_less_or_equal.syn
@@ -1,1 +1,1 @@
-create noneditionable synonymbe_less_or_equal for ut_be_less_or_equal;
+create noneditionable synonym be_less_or_equal for ut_be_less_or_equal;

--- a/source/api/be_less_or_equal.syn
+++ b/source/api/be_less_or_equal.syn
@@ -1,1 +1,1 @@
-create synonym be_less_or_equal for ut_be_less_or_equal;
+create noneditionable synonymbe_less_or_equal for ut_be_less_or_equal;

--- a/source/api/be_less_than.syn
+++ b/source/api/be_less_than.syn
@@ -1,1 +1,1 @@
-create synonym be_less_than for ut_be_less_than;
+create noneditionable synonymbe_less_than for ut_be_less_than;

--- a/source/api/be_less_than.syn
+++ b/source/api/be_less_than.syn
@@ -1,1 +1,1 @@
-create noneditionable synonymbe_less_than for ut_be_less_than;
+create noneditionable synonym be_less_than for ut_be_less_than;

--- a/source/api/be_like.syn
+++ b/source/api/be_like.syn
@@ -1,1 +1,1 @@
-create synonym be_like for ut_be_like;
+create noneditionable synonymbe_like for ut_be_like;

--- a/source/api/be_like.syn
+++ b/source/api/be_like.syn
@@ -1,1 +1,1 @@
-create noneditionable synonymbe_like for ut_be_like;
+create noneditionable synonym be_like for ut_be_like;

--- a/source/api/be_not_null.syn
+++ b/source/api/be_not_null.syn
@@ -1,1 +1,1 @@
-create noneditionable synonymbe_not_null for ut_be_not_null;
+create noneditionable synonym be_not_null for ut_be_not_null;

--- a/source/api/be_not_null.syn
+++ b/source/api/be_not_null.syn
@@ -1,1 +1,1 @@
-create synonym be_not_null for ut_be_not_null;
+create noneditionable synonymbe_not_null for ut_be_not_null;

--- a/source/api/be_null.syn
+++ b/source/api/be_null.syn
@@ -1,1 +1,1 @@
-create noneditionable synonymbe_null for ut_be_null;
+create noneditionable synonym be_null for ut_be_null;

--- a/source/api/be_null.syn
+++ b/source/api/be_null.syn
@@ -1,1 +1,1 @@
-create synonym be_null for ut_be_null;
+create noneditionable synonymbe_null for ut_be_null;

--- a/source/api/be_true.syn
+++ b/source/api/be_true.syn
@@ -1,1 +1,1 @@
-create synonym be_true for ut_be_true;
+create noneditionable synonymbe_true for ut_be_true;

--- a/source/api/be_true.syn
+++ b/source/api/be_true.syn
@@ -1,1 +1,1 @@
-create noneditionable synonymbe_true for ut_be_true;
+create noneditionable synonym be_true for ut_be_true;

--- a/source/api/be_within.syn
+++ b/source/api/be_within.syn
@@ -1,1 +1,1 @@
-create synonym be_within for ut_be_within;
+create noneditionable synonymbe_within for ut_be_within;

--- a/source/api/be_within.syn
+++ b/source/api/be_within.syn
@@ -1,1 +1,1 @@
-create noneditionable synonymbe_within for ut_be_within;
+create noneditionable synonym be_within for ut_be_within;

--- a/source/api/be_within_pct.syn
+++ b/source/api/be_within_pct.syn
@@ -1,1 +1,1 @@
-create synonym be_within_pct for ut_be_within_pct;
+create noneditionable synonymbe_within_pct for ut_be_within_pct;

--- a/source/api/be_within_pct.syn
+++ b/source/api/be_within_pct.syn
@@ -1,1 +1,1 @@
-create noneditionable synonymbe_within_pct for ut_be_within_pct;
+create noneditionable synonym be_within_pct for ut_be_within_pct;

--- a/source/api/contain.syn
+++ b/source/api/contain.syn
@@ -1,1 +1,1 @@
-create noneditionable synonymcontain for ut_contain;
+create noneditionable synonym contain for ut_contain;

--- a/source/api/contain.syn
+++ b/source/api/contain.syn
@@ -1,1 +1,1 @@
-create synonym contain for ut_contain;
+create noneditionable synonymcontain for ut_contain;

--- a/source/api/equal.syn
+++ b/source/api/equal.syn
@@ -1,1 +1,1 @@
-create noneditionable synonymequal for ut_equal;
+create noneditionable synonym equal for ut_equal;

--- a/source/api/equal.syn
+++ b/source/api/equal.syn
@@ -1,1 +1,1 @@
-create synonym equal for ut_equal;
+create noneditionable synonymequal for ut_equal;

--- a/source/api/have_count.syn
+++ b/source/api/have_count.syn
@@ -1,1 +1,1 @@
-create synonym have_count for ut_have_count;
+create noneditionable synonymhave_count for ut_have_count;

--- a/source/api/have_count.syn
+++ b/source/api/have_count.syn
@@ -1,1 +1,1 @@
-create noneditionable synonymhave_count for ut_have_count;
+create noneditionable synonym have_count for ut_have_count;

--- a/source/api/match.syn
+++ b/source/api/match.syn
@@ -1,1 +1,1 @@
-create synonym match for ut_match;
+create noneditionable synonymmatch for ut_match;

--- a/source/api/match.syn
+++ b/source/api/match.syn
@@ -1,1 +1,1 @@
-create noneditionable synonymmatch for ut_match;
+create noneditionable synonym match for ut_match;

--- a/source/api/ut.pkb
+++ b/source/api/ut.pkb
@@ -1,4 +1,4 @@
-create or replace package body ut is
+create or replace noneditionable package body ut is
 
   /*
   utPLSQL - Version 3

--- a/source/api/ut.pks
+++ b/source/api/ut.pks
@@ -1,4 +1,4 @@
-create or replace package ut authid current_user as
+create or replace noneditionable package ut authid current_user as
 
   /*
   utPLSQL - Version 3

--- a/source/api/ut_runner.pkb
+++ b/source/api/ut_runner.pkb
@@ -1,4 +1,4 @@
-create or replace package body ut_runner is
+create or replace noneditionable package body ut_runner is
 
   /*
   utPLSQL - Version 3

--- a/source/api/ut_runner.pks
+++ b/source/api/ut_runner.pks
@@ -1,4 +1,4 @@
-create or replace package ut_runner authid current_user is
+create or replace noneditionable package ut_runner authid current_user is
 
   /*
   utPLSQL - Version 3

--- a/source/api/ut_suite_item_info.tpb
+++ b/source/api/ut_suite_item_info.tpb
@@ -1,4 +1,4 @@
-create or replace type body ut_suite_item_info is
+create or replace noneditionable type body ut_suite_item_info is
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/api/ut_suite_item_info.tps
+++ b/source/api/ut_suite_item_info.tps
@@ -1,4 +1,4 @@
-create or replace type ut_suite_item_info as object (
+create or replace noneditionable type ut_suite_item_info as object (
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/api/ut_suite_items_info.tps
+++ b/source/api/ut_suite_items_info.tps
@@ -1,4 +1,4 @@
-create or replace type ut_suite_items_info as
+create or replace noneditionable type ut_suite_items_info as
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/core/annotations/ut_annotated_object.tps
+++ b/source/core/annotations/ut_annotated_object.tps
@@ -1,4 +1,4 @@
-create type ut_annotated_object as object(
+create or replace noneditionable type( )ut_annotated_object as object(
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/core/annotations/ut_annotated_object.tps
+++ b/source/core/annotations/ut_annotated_object.tps
@@ -1,4 +1,4 @@
-create or replace noneditionable type( )ut_annotated_object as object(
+create or replace noneditionable type ut_annotated_object as object(
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/core/annotations/ut_annotated_objects.tps
+++ b/source/core/annotations/ut_annotated_objects.tps
@@ -1,4 +1,4 @@
-create type ut_annotated_objects as
+create or replace noneditionable type( )ut_annotated_objects as
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/core/annotations/ut_annotated_objects.tps
+++ b/source/core/annotations/ut_annotated_objects.tps
@@ -1,4 +1,4 @@
-create or replace noneditionable type( )ut_annotated_objects as
+create or replace noneditionable type ut_annotated_objects as
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/core/annotations/ut_annotation.tps
+++ b/source/core/annotations/ut_annotation.tps
@@ -1,4 +1,4 @@
-create or replace noneditionable type( )ut_annotation as object(
+create or replace noneditionable type ut_annotation as object(
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/core/annotations/ut_annotation.tps
+++ b/source/core/annotations/ut_annotation.tps
@@ -1,4 +1,4 @@
-create type ut_annotation as object(
+create or replace noneditionable type( )ut_annotation as object(
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/core/annotations/ut_annotation_cache_manager.pkb
+++ b/source/core/annotations/ut_annotation_cache_manager.pkb
@@ -1,4 +1,4 @@
-create or replace package body ut_annotation_cache_manager as
+create or replace noneditionable package body ut_annotation_cache_manager as
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/core/annotations/ut_annotation_cache_manager.pks
+++ b/source/core/annotations/ut_annotation_cache_manager.pks
@@ -1,4 +1,4 @@
-create or replace package ut_annotation_cache_manager authid definer as
+create or replace noneditionable package ut_annotation_cache_manager authid definer as
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/core/annotations/ut_annotation_manager.pkb
+++ b/source/core/annotations/ut_annotation_manager.pkb
@@ -1,4 +1,4 @@
-create or replace package body ut_annotation_manager as
+create or replace noneditionable package body ut_annotation_manager as
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/core/annotations/ut_annotation_manager.pks
+++ b/source/core/annotations/ut_annotation_manager.pks
@@ -1,4 +1,4 @@
-create or replace package ut_annotation_manager authid current_user as
+create or replace noneditionable package ut_annotation_manager authid current_user as
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/core/annotations/ut_annotation_obj_cache_info.tps
+++ b/source/core/annotations/ut_annotation_obj_cache_info.tps
@@ -1,4 +1,4 @@
-create or replace noneditionable type( )ut_annotation_obj_cache_info as object(
+create or replace noneditionable type ut_annotation_obj_cache_info as object(
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/core/annotations/ut_annotation_obj_cache_info.tps
+++ b/source/core/annotations/ut_annotation_obj_cache_info.tps
@@ -1,4 +1,4 @@
-create type ut_annotation_obj_cache_info as object(
+create or replace noneditionable type( )ut_annotation_obj_cache_info as object(
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/core/annotations/ut_annotation_objs_cache_info.tps
+++ b/source/core/annotations/ut_annotation_objs_cache_info.tps
@@ -1,4 +1,4 @@
-create or replace noneditionable type( )ut_annotation_objs_cache_info as
+create or replace noneditionable type ut_annotation_objs_cache_info as
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/core/annotations/ut_annotation_objs_cache_info.tps
+++ b/source/core/annotations/ut_annotation_objs_cache_info.tps
@@ -1,4 +1,4 @@
-create type ut_annotation_objs_cache_info as
+create or replace noneditionable type( )ut_annotation_objs_cache_info as
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/core/annotations/ut_annotation_parser.pkb
+++ b/source/core/annotations/ut_annotation_parser.pkb
@@ -1,4 +1,4 @@
-create or replace package body ut_annotation_parser as
+create or replace noneditionable package body ut_annotation_parser as
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/core/annotations/ut_annotation_parser.pks
+++ b/source/core/annotations/ut_annotation_parser.pks
@@ -1,4 +1,4 @@
-create or replace package ut_annotation_parser authid current_user as
+create or replace noneditionable package ut_annotation_parser authid current_user as
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/core/annotations/ut_annotations.tps
+++ b/source/core/annotations/ut_annotations.tps
@@ -1,4 +1,4 @@
-create or replace noneditionable type( )ut_annotations
+create or replace noneditionable type ut_annotations
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/core/annotations/ut_annotations.tps
+++ b/source/core/annotations/ut_annotations.tps
@@ -1,4 +1,4 @@
-create type ut_annotations
+create or replace noneditionable type( )ut_annotations
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/core/annotations/ut_trigger_check.pkb
+++ b/source/core/annotations/ut_trigger_check.pkb
@@ -1,4 +1,4 @@
-create or replace package body ut_trigger_check is
+create or replace noneditionable package body ut_trigger_check is
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/core/annotations/ut_trigger_check.pkb
+++ b/source/core/annotations/ut_trigger_check.pkb
@@ -22,7 +22,7 @@ create or replace noneditionable package body ut_trigger_check is
   function is_alive return boolean is
     pragma autonomous_transaction;
   begin
-    execute immediate 'create or replace synonym '||ut_utils.ut_owner||'.'||gc_check_object_name||' for no_object';
+    execute immediate 'create or replace noneditionable synonym '||ut_utils.ut_owner||'.'||gc_check_object_name||' for no_object';
     return g_is_trigger_live;
   end;
 

--- a/source/core/annotations/ut_trigger_check.pks
+++ b/source/core/annotations/ut_trigger_check.pks
@@ -1,4 +1,4 @@
-create or replace package ut_trigger_check authid definer is
+create or replace noneditionable package ut_trigger_check authid definer is
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/core/coverage/ut_coverage.pkb
+++ b/source/core/coverage/ut_coverage.pkb
@@ -1,4 +1,4 @@
-create or replace package body ut_coverage is
+create or replace noneditionable package body ut_coverage is
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/core/coverage/ut_coverage.pks
+++ b/source/core/coverage/ut_coverage.pks
@@ -1,4 +1,4 @@
-create or replace package ut_coverage authid current_user is
+create or replace noneditionable package ut_coverage authid current_user is
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/core/coverage/ut_coverage_block.pkb
+++ b/source/core/coverage/ut_coverage_block.pkb
@@ -1,4 +1,4 @@
-create or replace package body ut_coverage_block is
+create or replace noneditionable package body ut_coverage_block is
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/core/coverage/ut_coverage_block.pks
+++ b/source/core/coverage/ut_coverage_block.pks
@@ -1,4 +1,4 @@
-create or replace package ut_coverage_block authid current_user is
+create or replace noneditionable package ut_coverage_block authid current_user is
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/core/coverage/ut_coverage_helper.pkb
+++ b/source/core/coverage/ut_coverage_helper.pkb
@@ -1,4 +1,4 @@
-create or replace package body ut_coverage_helper is
+create or replace noneditionable package body ut_coverage_helper is
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/core/coverage/ut_coverage_helper.pks
+++ b/source/core/coverage/ut_coverage_helper.pks
@@ -1,4 +1,4 @@
-create or replace package ut_coverage_helper authid definer is
+create or replace noneditionable package ut_coverage_helper authid definer is
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/core/coverage/ut_coverage_helper_block.pkb
+++ b/source/core/coverage/ut_coverage_helper_block.pkb
@@ -1,4 +1,4 @@
-create or replace package body ut_coverage_helper_block is
+create or replace noneditionable package body ut_coverage_helper_block is
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/core/coverage/ut_coverage_helper_block.pks
+++ b/source/core/coverage/ut_coverage_helper_block.pks
@@ -1,4 +1,4 @@
-create or replace package ut_coverage_helper_block authid current_user is
+create or replace noneditionable package ut_coverage_helper_block authid current_user is
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/core/coverage/ut_coverage_helper_profiler.pkb
+++ b/source/core/coverage/ut_coverage_helper_profiler.pkb
@@ -1,4 +1,4 @@
-create or replace package body ut_coverage_helper_profiler is
+create or replace noneditionable package body ut_coverage_helper_profiler is
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/core/coverage/ut_coverage_helper_profiler.pks
+++ b/source/core/coverage/ut_coverage_helper_profiler.pks
@@ -1,4 +1,4 @@
-create or replace package ut_coverage_helper_profiler authid definer is
+create or replace noneditionable package ut_coverage_helper_profiler authid definer is
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/core/coverage/ut_coverage_profiler.pkb
+++ b/source/core/coverage/ut_coverage_profiler.pkb
@@ -1,4 +1,4 @@
-create or replace package body ut_coverage_profiler is
+create or replace noneditionable package body ut_coverage_profiler is
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/core/coverage/ut_coverage_profiler.pks
+++ b/source/core/coverage/ut_coverage_profiler.pks
@@ -1,4 +1,4 @@
-create or replace package ut_coverage_profiler authid current_user is
+create or replace noneditionable package ut_coverage_profiler authid current_user is
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/core/coverage/ut_coverage_reporter_base.tpb
+++ b/source/core/coverage/ut_coverage_reporter_base.tpb
@@ -1,4 +1,4 @@
-create or replace type body ut_coverage_reporter_base is
+create or replace noneditionable type body ut_coverage_reporter_base is
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/core/coverage/ut_coverage_reporter_base.tps
+++ b/source/core/coverage/ut_coverage_reporter_base.tps
@@ -1,4 +1,4 @@
-create or replace type ut_coverage_reporter_base under ut_output_reporter_base(
+create or replace noneditionable type ut_coverage_reporter_base under ut_output_reporter_base(
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/core/events/ut_event_item.tps
+++ b/source/core/events/ut_event_item.tps
@@ -1,4 +1,4 @@
-create or replace type ut_event_item authid current_user as object (
+create or replace noneditionable type ut_event_item authid current_user as object (
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/core/events/ut_event_listener.tps
+++ b/source/core/events/ut_event_listener.tps
@@ -1,4 +1,4 @@
-create or replace type ut_event_listener authid current_user as object (
+create or replace noneditionable type ut_event_listener authid current_user as object (
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/core/events/ut_event_manager.pkb
+++ b/source/core/events/ut_event_manager.pkb
@@ -1,4 +1,4 @@
-create or replace package body ut_event_manager  as
+create or replace noneditionable package body ut_event_manager  as
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/core/events/ut_event_manager.pks
+++ b/source/core/events/ut_event_manager.pks
@@ -1,4 +1,4 @@
-create or replace package ut_event_manager authid current_user as
+create or replace noneditionable package ut_event_manager authid current_user as
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/core/output_buffers/ut_output_buffer_base.tpb
+++ b/source/core/output_buffers/ut_output_buffer_base.tpb
@@ -1,4 +1,4 @@
-create or replace type body ut_output_buffer_base is
+create or replace noneditionable type body ut_output_buffer_base is
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/core/output_buffers/ut_output_buffer_base.tps
+++ b/source/core/output_buffers/ut_output_buffer_base.tps
@@ -1,4 +1,4 @@
-create or replace type ut_output_buffer_base force authid definer as object(
+create or replace noneditionable type ut_output_buffer_base force authid definer as object(
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/core/output_buffers/ut_output_bulk_buffer.tpb
+++ b/source/core/output_buffers/ut_output_bulk_buffer.tpb
@@ -1,4 +1,4 @@
-create or replace type body ut_output_bulk_buffer is
+create or replace noneditionable type body ut_output_bulk_buffer is
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/core/output_buffers/ut_output_bulk_buffer.tps
+++ b/source/core/output_buffers/ut_output_bulk_buffer.tps
@@ -1,4 +1,4 @@
-create or replace type ut_output_bulk_buffer under ut_output_buffer_base (
+create or replace noneditionable type ut_output_bulk_buffer under ut_output_buffer_base (
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/core/output_buffers/ut_output_clob_table_buffer.tpb
+++ b/source/core/output_buffers/ut_output_clob_table_buffer.tpb
@@ -1,4 +1,4 @@
-create or replace type body ut_output_clob_table_buffer is
+create or replace noneditionable type body ut_output_clob_table_buffer is
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/core/output_buffers/ut_output_clob_table_buffer.tps
+++ b/source/core/output_buffers/ut_output_clob_table_buffer.tps
@@ -1,4 +1,4 @@
-create or replace type ut_output_clob_table_buffer under ut_output_buffer_base (
+create or replace noneditionable type ut_output_clob_table_buffer under ut_output_buffer_base (
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/core/output_buffers/ut_output_data_row.tps
+++ b/source/core/output_buffers/ut_output_data_row.tps
@@ -1,4 +1,4 @@
-create or replace type ut_output_data_row as object (
+create or replace noneditionable type ut_output_data_row as object (
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/core/output_buffers/ut_output_data_rows.tps
+++ b/source/core/output_buffers/ut_output_data_rows.tps
@@ -1,4 +1,4 @@
-create or replace type ut_output_data_rows as
+create or replace noneditionable type ut_output_data_rows as
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/core/output_buffers/ut_output_table_buffer.tpb
+++ b/source/core/output_buffers/ut_output_table_buffer.tpb
@@ -1,4 +1,4 @@
-create or replace type body ut_output_table_buffer is
+create or replace noneditionable type body ut_output_table_buffer is
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/core/output_buffers/ut_output_table_buffer.tps
+++ b/source/core/output_buffers/ut_output_table_buffer.tps
@@ -1,4 +1,4 @@
-create or replace type ut_output_table_buffer under ut_output_buffer_base (
+create or replace noneditionable type ut_output_table_buffer under ut_output_buffer_base (
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/core/session_context/ut_session_context.pkb
+++ b/source/core/session_context/ut_session_context.pkb
@@ -1,4 +1,4 @@
-create or replace package body ut_session_context as
+create or replace noneditionable package body ut_session_context as
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/core/session_context/ut_session_context.pks
+++ b/source/core/session_context/ut_session_context.pks
@@ -1,4 +1,4 @@
-create or replace package ut_session_context as
+create or replace noneditionable package ut_session_context as
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/core/session_context/ut_session_info.tpb
+++ b/source/core/session_context/ut_session_info.tpb
@@ -1,4 +1,4 @@
-create or replace type body ut_session_info as
+create or replace noneditionable type body ut_session_info as
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/core/session_context/ut_session_info.tps
+++ b/source/core/session_context/ut_session_info.tps
@@ -1,4 +1,4 @@
-create or replace type ut_session_info under ut_event_listener (
+create or replace noneditionable type ut_session_info under ut_event_listener (
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/core/types/ut_console_reporter_base.tpb
+++ b/source/core/types/ut_console_reporter_base.tpb
@@ -1,4 +1,4 @@
-create or replace type body ut_console_reporter_base is
+create or replace noneditionable type body ut_console_reporter_base is
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/core/types/ut_console_reporter_base.tps
+++ b/source/core/types/ut_console_reporter_base.tps
@@ -1,4 +1,4 @@
-create or replace type ut_console_reporter_base under ut_output_reporter_base(
+create or replace noneditionable type ut_console_reporter_base under ut_output_reporter_base(
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/core/types/ut_coverage_options.tpb
+++ b/source/core/types/ut_coverage_options.tpb
@@ -1,4 +1,4 @@
-create or replace type body ut_coverage_options as
+create or replace noneditionable type body ut_coverage_options as
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/core/types/ut_coverage_options.tps
+++ b/source/core/types/ut_coverage_options.tps
@@ -1,4 +1,4 @@
-create or replace type ut_coverage_options force as object (
+create or replace noneditionable type ut_coverage_options force as object (
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/core/types/ut_executable.tpb
+++ b/source/core/types/ut_executable.tpb
@@ -1,4 +1,4 @@
-create or replace type body ut_executable is
+create or replace noneditionable type body ut_executable is
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/core/types/ut_executable.tps
+++ b/source/core/types/ut_executable.tps
@@ -1,4 +1,4 @@
-create or replace type ut_executable under ut_event_item(
+create or replace noneditionable type ut_executable under ut_event_item(
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/core/types/ut_executable_test.tpb
+++ b/source/core/types/ut_executable_test.tpb
@@ -1,4 +1,4 @@
-create or replace type body ut_executable_test as
+create or replace noneditionable type body ut_executable_test as
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/core/types/ut_executable_test.tps
+++ b/source/core/types/ut_executable_test.tps
@@ -1,4 +1,4 @@
-create or replace type ut_executable_test authid current_user under ut_executable (
+create or replace noneditionable type ut_executable_test authid current_user under ut_executable (
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/core/types/ut_executables.tps
+++ b/source/core/types/ut_executables.tps
@@ -1,4 +1,4 @@
-create or replace type ut_executables as
+create or replace noneditionable type ut_executables as
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/core/types/ut_expectation_result.tpb
+++ b/source/core/types/ut_expectation_result.tpb
@@ -1,4 +1,4 @@
-create or replace type body ut_expectation_result is
+create or replace noneditionable type body ut_expectation_result is
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/core/types/ut_expectation_result.tps
+++ b/source/core/types/ut_expectation_result.tps
@@ -1,4 +1,4 @@
-create or replace type ut_expectation_result under ut_event_item(
+create or replace noneditionable type ut_expectation_result under ut_event_item(
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/core/types/ut_expectation_results.tps
+++ b/source/core/types/ut_expectation_results.tps
@@ -1,4 +1,4 @@
-create or replace type ut_expectation_results as
+create or replace noneditionable type ut_expectation_results as
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/core/types/ut_file_mapping.tpb
+++ b/source/core/types/ut_file_mapping.tpb
@@ -1,4 +1,4 @@
-create or replace type body ut_file_mapping as
+create or replace noneditionable type body ut_file_mapping as
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/core/types/ut_file_mapping.tps
+++ b/source/core/types/ut_file_mapping.tps
@@ -1,4 +1,4 @@
-create or replace type ut_file_mapping as object(
+create or replace noneditionable type ut_file_mapping as object(
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/core/types/ut_file_mappings.tps
+++ b/source/core/types/ut_file_mappings.tps
@@ -1,4 +1,4 @@
-create or replace type ut_file_mappings as
+create or replace noneditionable type ut_file_mappings as
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/core/types/ut_integer_list.tps
+++ b/source/core/types/ut_integer_list.tps
@@ -1,4 +1,4 @@
-create or replace type ut_integer_list as
+create or replace noneditionable type ut_integer_list as
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/core/types/ut_key_value_pair.tps
+++ b/source/core/types/ut_key_value_pair.tps
@@ -1,4 +1,4 @@
-create or replace type ut_key_value_pair force as object(
+create or replace noneditionable type ut_key_value_pair force as object(
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/core/types/ut_key_value_pairs.tps
+++ b/source/core/types/ut_key_value_pairs.tps
@@ -1,4 +1,4 @@
-create or replace type ut_key_value_pairs as
+create or replace noneditionable type ut_key_value_pairs as
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/core/types/ut_logical_suite.tpb
+++ b/source/core/types/ut_logical_suite.tpb
@@ -1,4 +1,4 @@
-create or replace type body ut_logical_suite as
+create or replace noneditionable type body ut_logical_suite as
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/core/types/ut_logical_suite.tps
+++ b/source/core/types/ut_logical_suite.tps
@@ -1,4 +1,4 @@
-create or replace type ut_logical_suite force under ut_suite_item (
+create or replace noneditionable type ut_logical_suite force under ut_suite_item (
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/core/types/ut_object_name.tpb
+++ b/source/core/types/ut_object_name.tpb
@@ -1,4 +1,4 @@
-create or replace type body ut_object_name as
+create or replace noneditionable type body ut_object_name as
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/core/types/ut_object_name.tps
+++ b/source/core/types/ut_object_name.tps
@@ -1,4 +1,4 @@
-create or replace type ut_object_name as object (
+create or replace noneditionable type ut_object_name as object (
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/core/types/ut_object_names.tps
+++ b/source/core/types/ut_object_names.tps
@@ -1,4 +1,4 @@
-create or replace type ut_object_names as
+create or replace noneditionable type ut_object_names as
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/core/types/ut_output_reporter_base.tpb
+++ b/source/core/types/ut_output_reporter_base.tpb
@@ -1,4 +1,4 @@
-create or replace type body ut_output_reporter_base is
+create or replace noneditionable type body ut_output_reporter_base is
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/core/types/ut_output_reporter_base.tps
+++ b/source/core/types/ut_output_reporter_base.tps
@@ -1,4 +1,4 @@
-create or replace type ut_output_reporter_base under ut_reporter_base(
+create or replace noneditionable type ut_output_reporter_base under ut_reporter_base(
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/core/types/ut_path_item.tpb
+++ b/source/core/types/ut_path_item.tpb
@@ -1,4 +1,4 @@
-create or replace type body ut_path_item as
+create or replace noneditionable type body ut_path_item as
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/core/types/ut_path_item.tps
+++ b/source/core/types/ut_path_item.tps
@@ -1,4 +1,4 @@
-create or replace type ut_path_item as object (
+create or replace noneditionable type ut_path_item as object (
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/core/types/ut_path_items.tps
+++ b/source/core/types/ut_path_items.tps
@@ -1,4 +1,4 @@
-create or replace type ut_path_items as
+create or replace noneditionable type ut_path_items as
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/core/types/ut_reporter_base.tpb
+++ b/source/core/types/ut_reporter_base.tpb
@@ -1,4 +1,4 @@
-create or replace type body ut_reporter_base is
+create or replace noneditionable type body ut_reporter_base is
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/core/types/ut_reporter_base.tps
+++ b/source/core/types/ut_reporter_base.tps
@@ -1,4 +1,4 @@
-create or replace type ut_reporter_base under ut_event_listener (
+create or replace noneditionable type ut_reporter_base under ut_event_listener (
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/core/types/ut_reporter_info.tps
+++ b/source/core/types/ut_reporter_info.tps
@@ -1,4 +1,4 @@
-create or replace type ut_reporter_info as object (
+create or replace noneditionable type ut_reporter_info as object (
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/core/types/ut_reporters.tps
+++ b/source/core/types/ut_reporters.tps
@@ -1,4 +1,4 @@
-create or replace type ut_reporters as
+create or replace noneditionable type ut_reporters as
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/core/types/ut_reporters_info.tps
+++ b/source/core/types/ut_reporters_info.tps
@@ -1,4 +1,4 @@
-create or replace type ut_reporters_info as
+create or replace noneditionable type ut_reporters_info as
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/core/types/ut_results_counter.tpb
+++ b/source/core/types/ut_results_counter.tpb
@@ -1,4 +1,4 @@
-create or replace type body ut_results_counter as
+create or replace noneditionable type body ut_results_counter as
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/core/types/ut_results_counter.tps
+++ b/source/core/types/ut_results_counter.tps
@@ -1,4 +1,4 @@
-create or replace type ut_results_counter as object(
+create or replace noneditionable type ut_results_counter as object(
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/core/types/ut_run.tpb
+++ b/source/core/types/ut_run.tpb
@@ -1,4 +1,4 @@
-create or replace type body ut_run as
+create or replace noneditionable type body ut_run as
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/core/types/ut_run.tps
+++ b/source/core/types/ut_run.tps
@@ -1,4 +1,4 @@
-create or replace type ut_run under ut_suite_item (
+create or replace noneditionable type ut_run under ut_suite_item (
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/core/types/ut_run_info.tpb
+++ b/source/core/types/ut_run_info.tpb
@@ -1,4 +1,4 @@
-create or replace type body ut_run_info as
+create or replace noneditionable type body ut_run_info as
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/core/types/ut_run_info.tps
+++ b/source/core/types/ut_run_info.tps
@@ -1,4 +1,4 @@
-create or replace type ut_run_info under ut_event_item (
+create or replace noneditionable type ut_run_info under ut_event_item (
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/core/types/ut_stack.tpb
+++ b/source/core/types/ut_stack.tpb
@@ -1,4 +1,4 @@
-create or replace type body ut_stack as
+create or replace noneditionable type body ut_stack as
  /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/core/types/ut_stack.tps
+++ b/source/core/types/ut_stack.tps
@@ -1,4 +1,4 @@
-create or replace type ut_stack as object (
+create or replace noneditionable type ut_stack as object (
   top integer,
   tokens ut_varchar2_list,
   /*

--- a/source/core/types/ut_suite.tpb
+++ b/source/core/types/ut_suite.tpb
@@ -1,4 +1,4 @@
-create or replace type body ut_suite  as
+create or replace noneditionable type body ut_suite  as
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/core/types/ut_suite.tps
+++ b/source/core/types/ut_suite.tps
@@ -1,4 +1,4 @@
-create or replace type ut_suite  under ut_logical_suite (
+create or replace noneditionable type ut_suite  under ut_logical_suite (
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/core/types/ut_suite_cache_row.tps
+++ b/source/core/types/ut_suite_cache_row.tps
@@ -1,4 +1,4 @@
-create or replace type ut_suite_cache_row as object (
+create or replace noneditionable type ut_suite_cache_row as object (
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/core/types/ut_suite_cache_rows.tps
+++ b/source/core/types/ut_suite_cache_rows.tps
@@ -1,4 +1,4 @@
-create or replace noneditionable type( )ut_suite_cache_rows as
+create or replace noneditionable type ut_suite_cache_rows as
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/core/types/ut_suite_cache_rows.tps
+++ b/source/core/types/ut_suite_cache_rows.tps
@@ -1,4 +1,4 @@
-create type ut_suite_cache_rows as
+create or replace noneditionable type( )ut_suite_cache_rows as
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/core/types/ut_suite_context.tpb
+++ b/source/core/types/ut_suite_context.tpb
@@ -1,4 +1,4 @@
-create or replace type body ut_suite_context as
+create or replace noneditionable type body ut_suite_context as
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/core/types/ut_suite_context.tps
+++ b/source/core/types/ut_suite_context.tps
@@ -1,4 +1,4 @@
-create or replace type ut_suite_context under ut_suite (
+create or replace noneditionable type ut_suite_context under ut_suite (
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/core/types/ut_suite_item.tpb
+++ b/source/core/types/ut_suite_item.tpb
@@ -1,4 +1,4 @@
-create or replace type body ut_suite_item as
+create or replace noneditionable type body ut_suite_item as
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/core/types/ut_suite_item.tps
+++ b/source/core/types/ut_suite_item.tps
@@ -1,4 +1,4 @@
-create or replace type ut_suite_item force under ut_event_item (
+create or replace noneditionable type ut_suite_item force under ut_event_item (
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/core/types/ut_suite_items.tps
+++ b/source/core/types/ut_suite_items.tps
@@ -1,4 +1,4 @@
-create or replace type ut_suite_items as
+create or replace noneditionable type ut_suite_items as
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/core/types/ut_test.tpb
+++ b/source/core/types/ut_test.tpb
@@ -1,4 +1,4 @@
-create or replace type body ut_test as
+create or replace noneditionable type body ut_test as
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/core/types/ut_test.tps
+++ b/source/core/types/ut_test.tps
@@ -1,4 +1,4 @@
-create or replace type ut_test force under ut_suite_item (
+create or replace noneditionable type ut_test force under ut_suite_item (
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/core/types/ut_varchar2_list.tps
+++ b/source/core/types/ut_varchar2_list.tps
@@ -1,4 +1,4 @@
-create or replace type ut_varchar2_list as
+create or replace noneditionable type ut_varchar2_list as
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/core/types/ut_varchar2_rows.tps
+++ b/source/core/types/ut_varchar2_rows.tps
@@ -1,4 +1,4 @@
-create or replace type ut_varchar2_rows as
+create or replace noneditionable type ut_varchar2_rows as
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/core/ut_expectation_processor.pkb
+++ b/source/core/ut_expectation_processor.pkb
@@ -1,4 +1,4 @@
-create or replace package body ut_expectation_processor as
+create or replace noneditionable package body ut_expectation_processor as
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/core/ut_expectation_processor.pks
+++ b/source/core/ut_expectation_processor.pks
@@ -1,4 +1,4 @@
-create or replace package ut_expectation_processor authid current_user as
+create or replace noneditionable package ut_expectation_processor authid current_user as
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/core/ut_file_mapper.pkb
+++ b/source/core/ut_file_mapper.pkb
@@ -1,4 +1,4 @@
-create or replace package body ut_file_mapper is
+create or replace noneditionable package body ut_file_mapper is
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/core/ut_file_mapper.pks
+++ b/source/core/ut_file_mapper.pks
@@ -1,4 +1,4 @@
-create or replace package ut_file_mapper authid current_user is
+create or replace noneditionable package ut_file_mapper authid current_user is
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/core/ut_metadata.pkb
+++ b/source/core/ut_metadata.pkb
@@ -1,4 +1,4 @@
-create or replace package body ut_metadata as
+create or replace noneditionable package body ut_metadata as
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/core/ut_metadata.pks
+++ b/source/core/ut_metadata.pks
@@ -1,4 +1,4 @@
-create or replace package ut_metadata authid current_user as
+create or replace noneditionable package ut_metadata authid current_user as
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/core/ut_suite_builder.pkb
+++ b/source/core/ut_suite_builder.pkb
@@ -1,4 +1,4 @@
-create or replace package body ut_suite_builder is
+create or replace noneditionable package body ut_suite_builder is
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/core/ut_suite_builder.pks
+++ b/source/core/ut_suite_builder.pks
@@ -1,4 +1,4 @@
-create or replace package ut_suite_builder authid current_user is
+create or replace noneditionable package ut_suite_builder authid current_user is
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/core/ut_suite_cache_manager.pkb
+++ b/source/core/ut_suite_cache_manager.pkb
@@ -1,4 +1,4 @@
-create or replace package body ut_suite_cache_manager is
+create or replace noneditionable package body ut_suite_cache_manager is
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/core/ut_suite_cache_manager.pks
+++ b/source/core/ut_suite_cache_manager.pks
@@ -1,4 +1,4 @@
-create or replace package ut_suite_cache_manager authid definer is
+create or replace noneditionable package ut_suite_cache_manager authid definer is
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/core/ut_suite_manager.pkb
+++ b/source/core/ut_suite_manager.pkb
@@ -1,4 +1,4 @@
-create or replace package body ut_suite_manager is
+create or replace noneditionable package body ut_suite_manager is
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/core/ut_suite_manager.pks
+++ b/source/core/ut_suite_manager.pks
@@ -1,4 +1,4 @@
-create or replace package ut_suite_manager authid current_user is
+create or replace noneditionable package ut_suite_manager authid current_user is
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/core/ut_suite_tag_filter.pkb
+++ b/source/core/ut_suite_tag_filter.pkb
@@ -1,4 +1,4 @@
-create or replace package body ut_suite_tag_filter is
+create or replace noneditionable package body ut_suite_tag_filter is
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/core/ut_suite_tag_filter.pks
+++ b/source/core/ut_suite_tag_filter.pks
@@ -1,4 +1,4 @@
-create or replace package ut_suite_tag_filter authid definer is
+create or replace noneditionable package ut_suite_tag_filter authid definer is
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/core/ut_utils.pkb
+++ b/source/core/ut_utils.pkb
@@ -1,4 +1,4 @@
-create or replace package body ut_utils is
+create or replace noneditionable package body ut_utils is
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/core/ut_utils.pks
+++ b/source/core/ut_utils.pks
@@ -1,4 +1,4 @@
-create or replace package ut_utils authid definer is
+create or replace noneditionable package ut_utils authid definer is
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/create_synonyms.sql
+++ b/source/create_synonyms.sql
@@ -36,10 +36,10 @@ set termout off
 spool params.sql.tmp
 select
   case
-    when upper('&&ut3_user') = 'PUBLIC' then q'[define action_type='or replace public'
+    when upper('&&ut3_user') = 'PUBLIC' then q'[define action_type='or replace noneditionable public'
       ]'||q'[define ut3_user=''
       ]'||q'[define grantee='PUBLIC']'
-    else q'[define action_type='or replace'
+    else q'[define action_type='or replace noneditionable'
       ]'||q'[define grantee='&&ut3_user']
       ]'||q'[define ut3_user='&&ut3_user..']'
   end

--- a/source/expectations/data_values/ut_compound_data_helper.pkb
+++ b/source/expectations/data_values/ut_compound_data_helper.pkb
@@ -1,4 +1,4 @@
-create or replace package body ut_compound_data_helper is
+create or replace noneditionable package body ut_compound_data_helper is
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/expectations/data_values/ut_compound_data_helper.pks
+++ b/source/expectations/data_values/ut_compound_data_helper.pks
@@ -1,4 +1,4 @@
-create or replace package ut_compound_data_helper authid definer is
+create or replace noneditionable package ut_compound_data_helper authid definer is
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/expectations/data_values/ut_compound_data_value.tpb
+++ b/source/expectations/data_values/ut_compound_data_value.tpb
@@ -1,4 +1,4 @@
-create or replace type body ut_compound_data_value as
+create or replace noneditionable type body ut_compound_data_value as
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/expectations/data_values/ut_compound_data_value.tps
+++ b/source/expectations/data_values/ut_compound_data_value.tps
@@ -1,4 +1,4 @@
-create or replace type ut_compound_data_value force under ut_data_value(
+create or replace noneditionable type ut_compound_data_value force under ut_data_value(
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/expectations/data_values/ut_cursor_column.tpb
+++ b/source/expectations/data_values/ut_cursor_column.tpb
@@ -1,4 +1,4 @@
-create or replace type body ut_cursor_column as
+create or replace noneditionable type body ut_cursor_column as
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/expectations/data_values/ut_cursor_column.tps
+++ b/source/expectations/data_values/ut_cursor_column.tps
@@ -1,4 +1,4 @@
-create or replace type ut_cursor_column authid current_user as object (
+create or replace noneditionable type ut_cursor_column authid current_user as object (
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/expectations/data_values/ut_cursor_column_tab.tps
+++ b/source/expectations/data_values/ut_cursor_column_tab.tps
@@ -1,4 +1,4 @@
-create or replace type ut_cursor_column_tab as
+create or replace noneditionable type ut_cursor_column_tab as
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/expectations/data_values/ut_cursor_details.tpb
+++ b/source/expectations/data_values/ut_cursor_details.tpb
@@ -1,4 +1,4 @@
-create or replace type body ut_cursor_details as
+create or replace noneditionable type body ut_cursor_details as
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/expectations/data_values/ut_cursor_details.tps
+++ b/source/expectations/data_values/ut_cursor_details.tps
@@ -1,4 +1,4 @@
-create or replace type ut_cursor_details authid current_user as object (
+create or replace noneditionable type ut_cursor_details authid current_user as object (
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/expectations/data_values/ut_data_value.tpb
+++ b/source/expectations/data_values/ut_data_value.tpb
@@ -1,4 +1,4 @@
-create or replace type body ut_data_value as
+create or replace noneditionable type body ut_data_value as
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/expectations/data_values/ut_data_value.tps
+++ b/source/expectations/data_values/ut_data_value.tps
@@ -1,4 +1,4 @@
-create or replace type ut_data_value force authid current_user as object (
+create or replace noneditionable type ut_data_value force authid current_user as object (
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/expectations/data_values/ut_data_value_anydata.tpb
+++ b/source/expectations/data_values/ut_data_value_anydata.tpb
@@ -1,4 +1,4 @@
-create or replace type body ut_data_value_anydata as
+create or replace noneditionable type body ut_data_value_anydata as
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/expectations/data_values/ut_data_value_anydata.tps
+++ b/source/expectations/data_values/ut_data_value_anydata.tps
@@ -1,4 +1,4 @@
-create or replace type ut_data_value_anydata under ut_data_value_refcursor(
+create or replace noneditionable type ut_data_value_anydata under ut_data_value_refcursor(
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/expectations/data_values/ut_data_value_blob.tpb
+++ b/source/expectations/data_values/ut_data_value_blob.tpb
@@ -1,4 +1,4 @@
-create or replace type body ut_data_value_blob as
+create or replace noneditionable type body ut_data_value_blob as
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/expectations/data_values/ut_data_value_blob.tps
+++ b/source/expectations/data_values/ut_data_value_blob.tps
@@ -1,4 +1,4 @@
-create or replace type ut_data_value_blob under ut_data_value(
+create or replace noneditionable type ut_data_value_blob under ut_data_value(
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/expectations/data_values/ut_data_value_boolean.tpb
+++ b/source/expectations/data_values/ut_data_value_boolean.tpb
@@ -1,4 +1,4 @@
-create or replace type body ut_data_value_boolean as
+create or replace noneditionable type body ut_data_value_boolean as
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/expectations/data_values/ut_data_value_boolean.tps
+++ b/source/expectations/data_values/ut_data_value_boolean.tps
@@ -1,4 +1,4 @@
-create or replace type ut_data_value_boolean under ut_data_value(
+create or replace noneditionable type ut_data_value_boolean under ut_data_value(
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/expectations/data_values/ut_data_value_clob.tpb
+++ b/source/expectations/data_values/ut_data_value_clob.tpb
@@ -1,4 +1,4 @@
-create or replace type body ut_data_value_clob as
+create or replace noneditionable type body ut_data_value_clob as
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/expectations/data_values/ut_data_value_clob.tps
+++ b/source/expectations/data_values/ut_data_value_clob.tps
@@ -1,4 +1,4 @@
-create or replace type ut_data_value_clob under ut_data_value(
+create or replace noneditionable type ut_data_value_clob under ut_data_value(
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/expectations/data_values/ut_data_value_date.tpb
+++ b/source/expectations/data_values/ut_data_value_date.tpb
@@ -1,4 +1,4 @@
-create or replace type body ut_data_value_date as
+create or replace noneditionable type body ut_data_value_date as
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/expectations/data_values/ut_data_value_date.tps
+++ b/source/expectations/data_values/ut_data_value_date.tps
@@ -1,4 +1,4 @@
-create or replace type ut_data_value_date under ut_data_value(
+create or replace noneditionable type ut_data_value_date under ut_data_value(
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/expectations/data_values/ut_data_value_dsinterval.tpb
+++ b/source/expectations/data_values/ut_data_value_dsinterval.tpb
@@ -1,4 +1,4 @@
-create or replace type body ut_data_value_dsinterval as
+create or replace noneditionable type body ut_data_value_dsinterval as
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/expectations/data_values/ut_data_value_dsinterval.tps
+++ b/source/expectations/data_values/ut_data_value_dsinterval.tps
@@ -1,4 +1,4 @@
-create or replace type ut_data_value_dsinterval under ut_data_value(
+create or replace noneditionable type ut_data_value_dsinterval under ut_data_value(
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/expectations/data_values/ut_data_value_json.tpb
+++ b/source/expectations/data_values/ut_data_value_json.tpb
@@ -1,4 +1,4 @@
-create or replace type body ut_data_value_json as
+create or replace noneditionable type body ut_data_value_json as
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/expectations/data_values/ut_data_value_json.tps
+++ b/source/expectations/data_values/ut_data_value_json.tps
@@ -1,4 +1,4 @@
-create or replace type ut_data_value_json under ut_compound_data_value(
+create or replace noneditionable type ut_data_value_json under ut_compound_data_value(
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/expectations/data_values/ut_data_value_number.tpb
+++ b/source/expectations/data_values/ut_data_value_number.tpb
@@ -1,4 +1,4 @@
-create or replace type body ut_data_value_number as
+create or replace noneditionable type body ut_data_value_number as
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/expectations/data_values/ut_data_value_number.tps
+++ b/source/expectations/data_values/ut_data_value_number.tps
@@ -1,4 +1,4 @@
-create or replace type ut_data_value_number under ut_data_value(
+create or replace noneditionable type ut_data_value_number under ut_data_value(
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/expectations/data_values/ut_data_value_refcursor.tpb
+++ b/source/expectations/data_values/ut_data_value_refcursor.tpb
@@ -1,4 +1,4 @@
-create or replace type body ut_data_value_refcursor as
+create or replace noneditionable type body ut_data_value_refcursor as
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/expectations/data_values/ut_data_value_refcursor.tps
+++ b/source/expectations/data_values/ut_data_value_refcursor.tps
@@ -1,4 +1,4 @@
-create or replace type ut_data_value_refcursor under ut_compound_data_value(
+create or replace noneditionable type ut_data_value_refcursor under ut_compound_data_value(
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/expectations/data_values/ut_data_value_timestamp.tpb
+++ b/source/expectations/data_values/ut_data_value_timestamp.tpb
@@ -1,4 +1,4 @@
-create or replace type body ut_data_value_timestamp as
+create or replace noneditionable type body ut_data_value_timestamp as
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/expectations/data_values/ut_data_value_timestamp.tps
+++ b/source/expectations/data_values/ut_data_value_timestamp.tps
@@ -1,4 +1,4 @@
-create or replace type ut_data_value_timestamp under ut_data_value(
+create or replace noneditionable type ut_data_value_timestamp under ut_data_value(
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/expectations/data_values/ut_data_value_timestamp_ltz.tpb
+++ b/source/expectations/data_values/ut_data_value_timestamp_ltz.tpb
@@ -1,4 +1,4 @@
-create or replace type body ut_data_value_timestamp_ltz as
+create or replace noneditionable type body ut_data_value_timestamp_ltz as
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/expectations/data_values/ut_data_value_timestamp_ltz.tps
+++ b/source/expectations/data_values/ut_data_value_timestamp_ltz.tps
@@ -1,4 +1,4 @@
-create or replace type ut_data_value_timestamp_ltz under ut_data_value(
+create or replace noneditionable type ut_data_value_timestamp_ltz under ut_data_value(
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/expectations/data_values/ut_data_value_timestamp_tz.tpb
+++ b/source/expectations/data_values/ut_data_value_timestamp_tz.tpb
@@ -1,4 +1,4 @@
-create or replace type body ut_data_value_timestamp_tz as
+create or replace noneditionable type body ut_data_value_timestamp_tz as
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/expectations/data_values/ut_data_value_timestamp_tz.tps
+++ b/source/expectations/data_values/ut_data_value_timestamp_tz.tps
@@ -1,4 +1,4 @@
-create or replace type ut_data_value_timestamp_tz under ut_data_value(
+create or replace noneditionable type ut_data_value_timestamp_tz under ut_data_value(
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/expectations/data_values/ut_data_value_varchar2.tpb
+++ b/source/expectations/data_values/ut_data_value_varchar2.tpb
@@ -1,4 +1,4 @@
-create or replace type body ut_data_value_varchar2 as
+create or replace noneditionable type body ut_data_value_varchar2 as
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/expectations/data_values/ut_data_value_varchar2.tps
+++ b/source/expectations/data_values/ut_data_value_varchar2.tps
@@ -1,4 +1,4 @@
-create or replace type ut_data_value_varchar2 under ut_data_value(
+create or replace noneditionable type ut_data_value_varchar2 under ut_data_value(
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/expectations/data_values/ut_data_value_xmltype.tpb
+++ b/source/expectations/data_values/ut_data_value_xmltype.tpb
@@ -1,4 +1,4 @@
-create or replace type body ut_data_value_xmltype as
+create or replace noneditionable type body ut_data_value_xmltype as
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/expectations/data_values/ut_data_value_xmltype.tps
+++ b/source/expectations/data_values/ut_data_value_xmltype.tps
@@ -1,4 +1,4 @@
-create or replace type ut_data_value_xmltype under ut_data_value(
+create or replace noneditionable type ut_data_value_xmltype under ut_data_value(
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/expectations/data_values/ut_data_value_yminterval.tpb
+++ b/source/expectations/data_values/ut_data_value_yminterval.tpb
@@ -1,4 +1,4 @@
-create or replace type body ut_data_value_yminterval as
+create or replace noneditionable type body ut_data_value_yminterval as
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/expectations/data_values/ut_data_value_yminterval.tps
+++ b/source/expectations/data_values/ut_data_value_yminterval.tps
@@ -1,4 +1,4 @@
-create or replace type ut_data_value_yminterval under ut_data_value(
+create or replace noneditionable type ut_data_value_yminterval under ut_data_value(
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/expectations/data_values/ut_json_leaf.tpb
+++ b/source/expectations/data_values/ut_json_leaf.tpb
@@ -1,4 +1,4 @@
-create or replace type body ut_json_leaf as
+create or replace noneditionable type body ut_json_leaf as
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/expectations/data_values/ut_json_leaf.tps
+++ b/source/expectations/data_values/ut_json_leaf.tps
@@ -1,4 +1,4 @@
-create or replace type ut_json_leaf authid current_user as object (
+create or replace noneditionable type ut_json_leaf authid current_user as object (
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/expectations/data_values/ut_json_leaf_tab.tps
+++ b/source/expectations/data_values/ut_json_leaf_tab.tps
@@ -1,4 +1,4 @@
-create or replace type ut_json_leaf_tab as
+create or replace noneditionable type ut_json_leaf_tab as
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/expectations/data_values/ut_json_tree_details.tpb
+++ b/source/expectations/data_values/ut_json_tree_details.tpb
@@ -1,4 +1,4 @@
-create or replace type body ut_json_tree_details as
+create or replace noneditionable type body ut_json_tree_details as
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/expectations/data_values/ut_json_tree_details.tps
+++ b/source/expectations/data_values/ut_json_tree_details.tps
@@ -1,4 +1,4 @@
-create or replace type ut_json_tree_details force as object (
+create or replace noneditionable type ut_json_tree_details force as object (
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/expectations/data_values/ut_key_anyval_pair.tps
+++ b/source/expectations/data_values/ut_key_anyval_pair.tps
@@ -1,4 +1,4 @@
-create or replace type ut_key_anyval_pair force as object(
+create or replace noneditionable type ut_key_anyval_pair force as object(
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/expectations/data_values/ut_key_anyval_pairs.tps
+++ b/source/expectations/data_values/ut_key_anyval_pairs.tps
@@ -1,4 +1,4 @@
-create or replace type ut_key_anyval_pairs as
+create or replace noneditionable type ut_key_anyval_pairs as
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/expectations/data_values/ut_key_anyvalues.tpb
+++ b/source/expectations/data_values/ut_key_anyvalues.tpb
@@ -1,4 +1,4 @@
-create or replace type body ut_key_anyvalues as
+create or replace noneditionable type body ut_key_anyvalues as
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/expectations/data_values/ut_key_anyvalues.tps
+++ b/source/expectations/data_values/ut_key_anyvalues.tps
@@ -1,4 +1,4 @@
-create or replace type ut_key_anyvalues under ut_event_item (
+create or replace noneditionable type ut_key_anyvalues under ut_event_item (
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/expectations/json_objects_specs.sql
+++ b/source/expectations/json_objects_specs.sql
@@ -2,13 +2,13 @@ BEGIN
   null;
   $if dbms_db_version.version < 21 $then
     dbms_output.put_line('Installing json structures specs for native json.');
-    execute immediate  q'[create or replace TYPE JSON FORCE AUTHID CURRENT_USER AS OBJECT(
+    execute immediate  q'[create or replace noneditionable TYPE JSON FORCE AUTHID CURRENT_USER AS OBJECT(
    dummyobjt NUMBER
 ) NOT FINAL NOT INSTANTIABLE;]';   
   $end
   $if dbms_db_version.version = 12 and dbms_db_version.release = 1 or dbms_db_version.version < 12 $then
     dbms_output.put_line('Installing json structures specs.');
-    execute immediate  q'[create or replace TYPE JSON_Element_T FORCE AUTHID CURRENT_USER AS OBJECT(
+    execute immediate  q'[create or replace noneditionable TYPE JSON_Element_T FORCE AUTHID CURRENT_USER AS OBJECT(
    dummyobjt NUMBER,
    STATIC FUNCTION  parse(jsn VARCHAR2) RETURN JSON_Element_T,
    STATIC FUNCTION  parse(jsn CLOB) RETURN JSON_Element_T,
@@ -34,9 +34,9 @@ BEGIN
    MEMBER FUNCTION  get_Size(self IN JSON_ELEMENT_T) RETURN NUMBER
 ) NOT FINAL NOT INSTANTIABLE;]';
 
-    execute immediate  q'[create or replace TYPE JSON_KEY_LIST FORCE AS VARRAY(32767) OF VARCHAR2(4000);]';
+    execute immediate  q'[create or replace noneditionable TYPE JSON_KEY_LIST FORCE AS VARRAY(32767) OF VARCHAR2(4000);]';
     
-    execute immediate  q'[create or replace TYPE JSON_Array_T FORCE AUTHID CURRENT_USER UNDER JSON_Element_T(
+    execute immediate  q'[create or replace noneditionable TYPE JSON_Array_T FORCE AUTHID CURRENT_USER UNDER JSON_Element_T(
    CONSTRUCTOR FUNCTION JSON_Array_T RETURN SELF AS RESULT,
    MEMBER      FUNCTION  get(pos NUMBER) RETURN JSON_Element_T,
    MEMBER      FUNCTION  get_String(pos NUMBER) RETURN VARCHAR2,
@@ -51,7 +51,7 @@ BEGIN
    MEMBER      FUNCTION  get_Type(pos NUMBER) RETURN VARCHAR2
 ) FINAL;]';
     
-    execute immediate  q'[create or replace TYPE JSON_Object_T AUTHID CURRENT_USER UNDER JSON_Element_T(
+    execute immediate  q'[create or replace noneditionable TYPE JSON_Object_T AUTHID CURRENT_USER UNDER JSON_Element_T(
    CONSTRUCTOR FUNCTION JSON_Object_T RETURN SELF AS RESULT,
    MEMBER      FUNCTION  get(key VARCHAR2) RETURN JSON_Element_T,
    MEMBER      FUNCTION  get_Object(key VARCHAR2) RETURN JSON_OBJECT_T,

--- a/source/expectations/matchers/ut_be_between.tpb
+++ b/source/expectations/matchers/ut_be_between.tpb
@@ -1,4 +1,4 @@
-create or replace type body ut_be_between is
+create or replace noneditionable type body ut_be_between is
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/expectations/matchers/ut_be_between.tps
+++ b/source/expectations/matchers/ut_be_between.tps
@@ -1,4 +1,4 @@
-create or replace type ut_be_between under ut_matcher(
+create or replace noneditionable type ut_be_between under ut_matcher(
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/expectations/matchers/ut_be_empty.tpb
+++ b/source/expectations/matchers/ut_be_empty.tpb
@@ -1,4 +1,4 @@
-create or replace type body ut_be_empty as
+create or replace noneditionable type body ut_be_empty as
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/expectations/matchers/ut_be_empty.tps
+++ b/source/expectations/matchers/ut_be_empty.tps
@@ -1,4 +1,4 @@
-create or replace type ut_be_empty under ut_matcher(
+create or replace noneditionable type ut_be_empty under ut_matcher(
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/expectations/matchers/ut_be_false.tpb
+++ b/source/expectations/matchers/ut_be_false.tpb
@@ -1,4 +1,4 @@
-create or replace type body ut_be_false as
+create or replace noneditionable type body ut_be_false as
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/expectations/matchers/ut_be_false.tps
+++ b/source/expectations/matchers/ut_be_false.tps
@@ -1,4 +1,4 @@
-create or replace type ut_be_false under ut_matcher(
+create or replace noneditionable type ut_be_false under ut_matcher(
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/expectations/matchers/ut_be_greater_or_equal.tpb
+++ b/source/expectations/matchers/ut_be_greater_or_equal.tpb
@@ -1,4 +1,4 @@
-create or replace type body ut_be_greater_or_equal AS
+create or replace noneditionable type body ut_be_greater_or_equal AS
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/expectations/matchers/ut_be_greater_or_equal.tps
+++ b/source/expectations/matchers/ut_be_greater_or_equal.tps
@@ -1,4 +1,4 @@
-create or replace type ut_be_greater_or_equal under ut_comparison_matcher(
+create or replace noneditionable type ut_be_greater_or_equal under ut_comparison_matcher(
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/expectations/matchers/ut_be_greater_than.tpb
+++ b/source/expectations/matchers/ut_be_greater_than.tpb
@@ -1,4 +1,4 @@
-create or replace type body ut_be_greater_than AS
+create or replace noneditionable type body ut_be_greater_than AS
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/expectations/matchers/ut_be_greater_than.tps
+++ b/source/expectations/matchers/ut_be_greater_than.tps
@@ -1,4 +1,4 @@
-create or replace type ut_be_greater_than under ut_comparison_matcher(
+create or replace noneditionable type ut_be_greater_than under ut_comparison_matcher(
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/expectations/matchers/ut_be_less_or_equal.tpb
+++ b/source/expectations/matchers/ut_be_less_or_equal.tpb
@@ -1,4 +1,4 @@
-create or replace type body ut_be_less_or_equal AS
+create or replace noneditionable type body ut_be_less_or_equal AS
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/expectations/matchers/ut_be_less_or_equal.tps
+++ b/source/expectations/matchers/ut_be_less_or_equal.tps
@@ -1,4 +1,4 @@
-create or replace type ut_be_less_or_equal under ut_comparison_matcher(
+create or replace noneditionable type ut_be_less_or_equal under ut_comparison_matcher(
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/expectations/matchers/ut_be_less_than.tpb
+++ b/source/expectations/matchers/ut_be_less_than.tpb
@@ -1,4 +1,4 @@
-create or replace type body ut_be_less_than as
+create or replace noneditionable type body ut_be_less_than as
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/expectations/matchers/ut_be_less_than.tps
+++ b/source/expectations/matchers/ut_be_less_than.tps
@@ -1,4 +1,4 @@
-create or replace type ut_be_less_than under ut_comparison_matcher(
+create or replace noneditionable type ut_be_less_than under ut_comparison_matcher(
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/expectations/matchers/ut_be_like.tpb
+++ b/source/expectations/matchers/ut_be_like.tpb
@@ -1,4 +1,4 @@
-create or replace type body ut_be_like as
+create or replace noneditionable type body ut_be_like as
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/expectations/matchers/ut_be_like.tps
+++ b/source/expectations/matchers/ut_be_like.tps
@@ -1,4 +1,4 @@
-create or replace type ut_be_like under ut_matcher(
+create or replace noneditionable type ut_be_like under ut_matcher(
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/expectations/matchers/ut_be_not_null.tpb
+++ b/source/expectations/matchers/ut_be_not_null.tpb
@@ -1,4 +1,4 @@
-create or replace type body ut_be_not_null as
+create or replace noneditionable type body ut_be_not_null as
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/expectations/matchers/ut_be_not_null.tps
+++ b/source/expectations/matchers/ut_be_not_null.tps
@@ -1,4 +1,4 @@
-create or replace type ut_be_not_null under ut_matcher(
+create or replace noneditionable type ut_be_not_null under ut_matcher(
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/expectations/matchers/ut_be_null.tpb
+++ b/source/expectations/matchers/ut_be_null.tpb
@@ -1,4 +1,4 @@
-create or replace type body ut_be_null as
+create or replace noneditionable type body ut_be_null as
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/expectations/matchers/ut_be_null.tps
+++ b/source/expectations/matchers/ut_be_null.tps
@@ -1,4 +1,4 @@
-create or replace type ut_be_null under ut_matcher(
+create or replace noneditionable type ut_be_null under ut_matcher(
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/expectations/matchers/ut_be_true.tpb
+++ b/source/expectations/matchers/ut_be_true.tpb
@@ -1,4 +1,4 @@
-create or replace type body ut_be_true as
+create or replace noneditionable type body ut_be_true as
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/expectations/matchers/ut_be_true.tps
+++ b/source/expectations/matchers/ut_be_true.tps
@@ -1,4 +1,4 @@
-create or replace type ut_be_true under ut_matcher(
+create or replace noneditionable type ut_be_true under ut_matcher(
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/expectations/matchers/ut_be_within.tpb
+++ b/source/expectations/matchers/ut_be_within.tpb
@@ -1,4 +1,4 @@
-create or replace type body ut_be_within as
+create or replace noneditionable type body ut_be_within as
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/expectations/matchers/ut_be_within.tps
+++ b/source/expectations/matchers/ut_be_within.tps
@@ -1,4 +1,4 @@
-create or replace type ut_be_within force under ut_be_within_pct(
+create or replace noneditionable type ut_be_within force under ut_be_within_pct(
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/expectations/matchers/ut_be_within_helper.pkb
+++ b/source/expectations/matchers/ut_be_within_helper.pkb
@@ -1,4 +1,4 @@
-create or replace package body ut_be_within_helper as
+create or replace noneditionable package body ut_be_within_helper as
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/expectations/matchers/ut_be_within_helper.pks
+++ b/source/expectations/matchers/ut_be_within_helper.pks
@@ -1,4 +1,4 @@
-create or replace package ut_be_within_helper authid definer as
+create or replace noneditionable package ut_be_within_helper authid definer as
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/expectations/matchers/ut_be_within_pct.tpb
+++ b/source/expectations/matchers/ut_be_within_pct.tpb
@@ -1,4 +1,4 @@
-create or replace type body ut_be_within_pct as
+create or replace noneditionable type body ut_be_within_pct as
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/expectations/matchers/ut_be_within_pct.tps
+++ b/source/expectations/matchers/ut_be_within_pct.tps
@@ -1,4 +1,4 @@
-create or replace type ut_be_within_pct force under ut_comparison_matcher(
+create or replace noneditionable type ut_be_within_pct force under ut_comparison_matcher(
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/expectations/matchers/ut_comparison_matcher.tpb
+++ b/source/expectations/matchers/ut_comparison_matcher.tpb
@@ -1,4 +1,4 @@
-create or replace type body ut_comparison_matcher as
+create or replace noneditionable type body ut_comparison_matcher as
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/expectations/matchers/ut_comparison_matcher.tps
+++ b/source/expectations/matchers/ut_comparison_matcher.tps
@@ -1,4 +1,4 @@
-create or replace type ut_comparison_matcher under ut_matcher(
+create or replace noneditionable type ut_comparison_matcher under ut_matcher(
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/expectations/matchers/ut_contain.tpb
+++ b/source/expectations/matchers/ut_contain.tpb
@@ -1,4 +1,4 @@
-create or replace type body ut_contain as
+create or replace noneditionable type body ut_contain as
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/expectations/matchers/ut_contain.tps
+++ b/source/expectations/matchers/ut_contain.tps
@@ -1,4 +1,4 @@
-create or replace type ut_contain under ut_equal(
+create or replace noneditionable type ut_contain under ut_equal(
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/expectations/matchers/ut_equal.tpb
+++ b/source/expectations/matchers/ut_equal.tpb
@@ -1,4 +1,4 @@
-create or replace type body ut_equal as
+create or replace noneditionable type body ut_equal as
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/expectations/matchers/ut_equal.tps
+++ b/source/expectations/matchers/ut_equal.tps
@@ -1,4 +1,4 @@
-create or replace type ut_equal force under ut_comparison_matcher(
+create or replace noneditionable type ut_equal force under ut_comparison_matcher(
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/expectations/matchers/ut_have_count.tpb
+++ b/source/expectations/matchers/ut_have_count.tpb
@@ -1,4 +1,4 @@
-create or replace type body ut_have_count as
+create or replace noneditionable type body ut_have_count as
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/expectations/matchers/ut_have_count.tps
+++ b/source/expectations/matchers/ut_have_count.tps
@@ -1,4 +1,4 @@
-create or replace type ut_have_count under ut_matcher(
+create or replace noneditionable type ut_have_count under ut_matcher(
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/expectations/matchers/ut_match.tpb
+++ b/source/expectations/matchers/ut_match.tpb
@@ -1,4 +1,4 @@
-create or replace type body ut_match as
+create or replace noneditionable type body ut_match as
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/expectations/matchers/ut_match.tps
+++ b/source/expectations/matchers/ut_match.tps
@@ -1,4 +1,4 @@
-create or replace type ut_match under ut_matcher(
+create or replace noneditionable type ut_match under ut_matcher(
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/expectations/matchers/ut_matcher.tpb
+++ b/source/expectations/matchers/ut_matcher.tpb
@@ -1,4 +1,4 @@
-create or replace type body ut_matcher as
+create or replace noneditionable type body ut_matcher as
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/expectations/matchers/ut_matcher.tps
+++ b/source/expectations/matchers/ut_matcher.tps
@@ -1,4 +1,4 @@
-create or replace type ut_matcher under ut_matcher_base(
+create or replace noneditionable type ut_matcher under ut_matcher_base(
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/expectations/matchers/ut_matcher_base.tps
+++ b/source/expectations/matchers/ut_matcher_base.tps
@@ -1,4 +1,4 @@
-create or replace type ut_matcher_base force authid current_user as object(
+create or replace noneditionable type ut_matcher_base force authid current_user as object(
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/expectations/matchers/ut_matcher_options.tpb
+++ b/source/expectations/matchers/ut_matcher_options.tpb
@@ -1,4 +1,4 @@
-create or replace type body ut_matcher_options as
+create or replace noneditionable type body ut_matcher_options as
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/expectations/matchers/ut_matcher_options.tps
+++ b/source/expectations/matchers/ut_matcher_options.tps
@@ -1,4 +1,4 @@
-create or replace type ut_matcher_options authid current_user as object(
+create or replace noneditionable type ut_matcher_options authid current_user as object(
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/expectations/matchers/ut_matcher_options_items.tpb
+++ b/source/expectations/matchers/ut_matcher_options_items.tpb
@@ -1,4 +1,4 @@
-create or replace type body ut_matcher_options_items is
+create or replace noneditionable type body ut_matcher_options_items is
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/expectations/matchers/ut_matcher_options_items.tps
+++ b/source/expectations/matchers/ut_matcher_options_items.tps
@@ -1,4 +1,4 @@
-create or replace type ut_matcher_options_items authid current_user as object(
+create or replace noneditionable type ut_matcher_options_items authid current_user as object(
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/expectations/ut_expectation.tpb
+++ b/source/expectations/ut_expectation.tpb
@@ -1,4 +1,4 @@
-create or replace type body ut_expectation as
+create or replace noneditionable type body ut_expectation as
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/expectations/ut_expectation.tps
+++ b/source/expectations/ut_expectation.tps
@@ -1,4 +1,4 @@
-create or replace type ut_expectation force under ut_expectation_base(
+create or replace noneditionable type ut_expectation force under ut_expectation_base(
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/expectations/ut_expectation_base.tpb
+++ b/source/expectations/ut_expectation_base.tpb
@@ -1,4 +1,4 @@
-create or replace type body ut_expectation_base as
+create or replace noneditionable type body ut_expectation_base as
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/expectations/ut_expectation_base.tps
+++ b/source/expectations/ut_expectation_base.tps
@@ -1,4 +1,4 @@
-create or replace type ut_expectation_base authid current_user as object(
+create or replace noneditionable type ut_expectation_base authid current_user as object(
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/expectations/ut_expectation_compound.tpb
+++ b/source/expectations/ut_expectation_compound.tpb
@@ -1,4 +1,4 @@
-create or replace type body ut_expectation_compound as
+create or replace noneditionable type body ut_expectation_compound as
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/expectations/ut_expectation_compound.tps
+++ b/source/expectations/ut_expectation_compound.tps
@@ -1,4 +1,4 @@
-create or replace type ut_expectation_compound under ut_expectation(
+create or replace noneditionable type ut_expectation_compound under ut_expectation(
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/expectations/ut_expectation_json.tpb
+++ b/source/expectations/ut_expectation_json.tpb
@@ -1,4 +1,4 @@
-create or replace type body ut_expectation_json as
+create or replace noneditionable type body ut_expectation_json as
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/expectations/ut_expectation_json.tps
+++ b/source/expectations/ut_expectation_json.tps
@@ -1,4 +1,4 @@
-create or replace type ut_expectation_json under ut_expectation(
+create or replace noneditionable type ut_expectation_json under ut_expectation(
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/reporters/ut_ansiconsole_helper.pkb
+++ b/source/reporters/ut_ansiconsole_helper.pkb
@@ -1,4 +1,4 @@
-create or replace package body ut_ansiconsole_helper as
+create or replace noneditionable package body ut_ansiconsole_helper as
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/reporters/ut_ansiconsole_helper.pks
+++ b/source/reporters/ut_ansiconsole_helper.pks
@@ -1,4 +1,4 @@
-create or replace package ut_ansiconsole_helper as
+create or replace noneditionable package ut_ansiconsole_helper as
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/reporters/ut_coverage_cobertura_reporter.tpb
+++ b/source/reporters/ut_coverage_cobertura_reporter.tpb
@@ -1,4 +1,4 @@
-create or replace type body ut_coverage_cobertura_reporter is
+create or replace noneditionable type body ut_coverage_cobertura_reporter is
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/reporters/ut_coverage_cobertura_reporter.tps
+++ b/source/reporters/ut_coverage_cobertura_reporter.tps
@@ -1,4 +1,4 @@
-create or replace type ut_coverage_cobertura_reporter under ut_coverage_reporter_base(
+create or replace noneditionable type ut_coverage_cobertura_reporter under ut_coverage_reporter_base(
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/reporters/ut_coverage_html_reporter.tpb
+++ b/source/reporters/ut_coverage_html_reporter.tpb
@@ -1,4 +1,4 @@
-create or replace type body ut_coverage_html_reporter is
+create or replace noneditionable type body ut_coverage_html_reporter is
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/reporters/ut_coverage_html_reporter.tps
+++ b/source/reporters/ut_coverage_html_reporter.tps
@@ -1,4 +1,4 @@
-create or replace type ut_coverage_html_reporter under ut_coverage_reporter_base(
+create or replace noneditionable type ut_coverage_html_reporter under ut_coverage_reporter_base(
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/reporters/ut_coverage_report_html_helper.pkb
+++ b/source/reporters/ut_coverage_report_html_helper.pkb
@@ -1,4 +1,4 @@
-create or replace package body ut_coverage_report_html_helper is
+create or replace noneditionable package body ut_coverage_report_html_helper is
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/reporters/ut_coverage_report_html_helper.pks
+++ b/source/reporters/ut_coverage_report_html_helper.pks
@@ -1,4 +1,4 @@
-create or replace package ut_coverage_report_html_helper authid current_user is
+create or replace noneditionable package ut_coverage_report_html_helper authid current_user is
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/reporters/ut_coverage_sonar_reporter.tpb
+++ b/source/reporters/ut_coverage_sonar_reporter.tpb
@@ -1,4 +1,4 @@
-create or replace type body ut_coverage_sonar_reporter is
+create or replace noneditionable type body ut_coverage_sonar_reporter is
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/reporters/ut_coverage_sonar_reporter.tps
+++ b/source/reporters/ut_coverage_sonar_reporter.tps
@@ -1,4 +1,4 @@
-create or replace type ut_coverage_sonar_reporter under ut_coverage_reporter_base(
+create or replace noneditionable type ut_coverage_sonar_reporter under ut_coverage_reporter_base(
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/reporters/ut_coveralls_reporter.tpb
+++ b/source/reporters/ut_coveralls_reporter.tpb
@@ -1,4 +1,4 @@
-create or replace type body ut_coveralls_reporter is
+create or replace noneditionable type body ut_coveralls_reporter is
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/reporters/ut_coveralls_reporter.tps
+++ b/source/reporters/ut_coveralls_reporter.tps
@@ -1,4 +1,4 @@
-create or replace type ut_coveralls_reporter under ut_coverage_reporter_base(
+create or replace noneditionable type ut_coveralls_reporter under ut_coverage_reporter_base(
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/reporters/ut_debug_reporter.tpb
+++ b/source/reporters/ut_debug_reporter.tpb
@@ -1,4 +1,4 @@
-create or replace type body ut_debug_reporter is
+create or replace noneditionable type body ut_debug_reporter is
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/reporters/ut_debug_reporter.tps
+++ b/source/reporters/ut_debug_reporter.tps
@@ -1,4 +1,4 @@
-create or replace type ut_debug_reporter under ut_output_reporter_base(
+create or replace noneditionable type ut_debug_reporter under ut_output_reporter_base(
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/reporters/ut_documentation_reporter.tpb
+++ b/source/reporters/ut_documentation_reporter.tpb
@@ -1,4 +1,4 @@
-create or replace type body ut_documentation_reporter is
+create or replace noneditionable type body ut_documentation_reporter is
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/reporters/ut_documentation_reporter.tps
+++ b/source/reporters/ut_documentation_reporter.tps
@@ -1,4 +1,4 @@
-create or replace type ut_documentation_reporter under ut_console_reporter_base(
+create or replace noneditionable type ut_documentation_reporter under ut_console_reporter_base(
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/reporters/ut_junit_reporter.tpb
+++ b/source/reporters/ut_junit_reporter.tpb
@@ -1,4 +1,4 @@
-create or replace type body ut_junit_reporter is
+create or replace noneditionable type body ut_junit_reporter is
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/reporters/ut_junit_reporter.tps
+++ b/source/reporters/ut_junit_reporter.tps
@@ -1,4 +1,4 @@
-create or replace type ut_junit_reporter force under ut_output_reporter_base(
+create or replace noneditionable type ut_junit_reporter force under ut_output_reporter_base(
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/reporters/ut_realtime_reporter.tpb
+++ b/source/reporters/ut_realtime_reporter.tpb
@@ -1,4 +1,4 @@
-create or replace type body ut_realtime_reporter is
+create or replace noneditionable type body ut_realtime_reporter is
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/reporters/ut_realtime_reporter.tps
+++ b/source/reporters/ut_realtime_reporter.tps
@@ -1,4 +1,4 @@
-create or replace type ut_realtime_reporter force under ut_output_reporter_base(
+create or replace noneditionable type ut_realtime_reporter force under ut_output_reporter_base(
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/reporters/ut_sonar_test_reporter.tpb
+++ b/source/reporters/ut_sonar_test_reporter.tpb
@@ -1,4 +1,4 @@
-create or replace type body ut_sonar_test_reporter is
+create or replace noneditionable type body ut_sonar_test_reporter is
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/reporters/ut_sonar_test_reporter.tps
+++ b/source/reporters/ut_sonar_test_reporter.tps
@@ -1,4 +1,4 @@
-create or replace type ut_sonar_test_reporter under ut_output_reporter_base(
+create or replace noneditionable type ut_sonar_test_reporter under ut_output_reporter_base(
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/reporters/ut_tap_reporter.tpb
+++ b/source/reporters/ut_tap_reporter.tpb
@@ -1,4 +1,4 @@
-create or replace type body ut_tap_reporter is
+create or replace noneditionable type body ut_tap_reporter is
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/reporters/ut_tap_reporter.tps
+++ b/source/reporters/ut_tap_reporter.tps
@@ -1,4 +1,4 @@
-create or replace type ut_tap_reporter under ut_documentation_reporter(
+create or replace noneditionable type ut_tap_reporter under ut_documentation_reporter(
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/reporters/ut_teamcity_reporter.tpb
+++ b/source/reporters/ut_teamcity_reporter.tpb
@@ -1,4 +1,4 @@
-create or replace type body ut_teamcity_reporter is
+create or replace noneditionable type body ut_teamcity_reporter is
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/reporters/ut_teamcity_reporter.tps
+++ b/source/reporters/ut_teamcity_reporter.tps
@@ -1,4 +1,4 @@
-create or replace type ut_teamcity_reporter under ut_output_reporter_base(
+create or replace noneditionable type ut_teamcity_reporter under ut_output_reporter_base(
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/reporters/ut_teamcity_reporter_helper.pkb
+++ b/source/reporters/ut_teamcity_reporter_helper.pkb
@@ -1,4 +1,4 @@
-create or replace package body ut_teamcity_reporter_helper is
+create or replace noneditionable package body ut_teamcity_reporter_helper is
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/reporters/ut_teamcity_reporter_helper.pks
+++ b/source/reporters/ut_teamcity_reporter_helper.pks
@@ -1,4 +1,4 @@
-create or replace package ut_teamcity_reporter_helper is
+create or replace noneditionable package ut_teamcity_reporter_helper is
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/reporters/ut_tfs_junit_reporter.tpb
+++ b/source/reporters/ut_tfs_junit_reporter.tpb
@@ -1,4 +1,4 @@
-create or replace type body ut_tfs_junit_reporter is
+create or replace noneditionable type body ut_tfs_junit_reporter is
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/reporters/ut_tfs_junit_reporter.tps
+++ b/source/reporters/ut_tfs_junit_reporter.tps
@@ -1,4 +1,4 @@
-create or replace type ut_tfs_junit_reporter under ut_output_reporter_base(
+create or replace noneditionable type ut_tfs_junit_reporter under ut_output_reporter_base(
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/reporters/ut_xunit_reporter.tpb
+++ b/source/reporters/ut_xunit_reporter.tpb
@@ -1,4 +1,4 @@
-create or replace type body ut_xunit_reporter is
+create or replace noneditionable type body ut_xunit_reporter is
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project

--- a/source/reporters/ut_xunit_reporter.tps
+++ b/source/reporters/ut_xunit_reporter.tps
@@ -1,4 +1,4 @@
-create or replace type ut_xunit_reporter under ut_junit_reporter(
+create or replace noneditionable type ut_xunit_reporter under ut_junit_reporter(
   /*
   utPLSQL - Version 3
   Copyright 2016 - 2026 utPLSQL Project


### PR DESCRIPTION
All utPLSQL objects are now explicitly defined as non-editionable. The framework can be installed into editioned schema without issues.

Resolves: #1161