### PR TITLE
`throws` works with uninitialized exception variables

### DIFF
--- a/docs/userguide/annotations.md
+++ b/docs/userguide/annotations.md
@@ -1783,7 +1783,7 @@ Please note that `NO_DATA_FOUND` exception is a special case in Oracle. To captu
 
 Syntax: `--%throws( [[schema.]package.]exception [, ... ])`
  
-The exception name can be provided with or without the schema and package name. The package name is required only when the exception variable is located in another package than the unti test package. The schema name is required only when the exception variable is located in a package in another schema.
+The exception name can be provided with or without the schema and package name. The package name is required only when the exception variable is located in another package than the unit test package. The schema name is required only when the exception variable is located in a package in another schema.
 
 Example:
 ```sql linenums="1"

--- a/docs/userguide/annotations.md
+++ b/docs/userguide/annotations.md
@@ -1765,8 +1765,8 @@ Keep in mind that when your test runs as autonomous transaction it will not see 
 The `--%throws` annotation allows you to specify a list of exceptions as one of:
 
 - number literals - example `--%throws(-20134)`
-- variables of type `exception` defined in a package specification - example `--%throws(exc_pkg.c_exception_No_variable)`
-- variables of type `number` defined in a package specification - example `--%throws(exc_pkg.c_some_exception)`
+- variables of type `exception` defined in a package specification - example `--%throws(exc_pkg.c_exception_no_variable)`
+- variables or constants of containing a valid negative exception number defined in a package specification - example `--%throws(exc_pkg.c_some_exception)`
 - [predefined oracle exceptions](https://docs.oracle.com/en//database/oracle/oracle-database/19/lnpls/predefined-exceptions.html) - example `--%throws(no_data_found)`
 
 The annotation is ignored when no valid arguments are provided. Examples of invalid annotations `--%throws()`,`--%throws`, `--%throws(abe, 723pf)`.
@@ -1783,23 +1783,27 @@ Please note that `NO_DATA_FOUND` exception is a special case in Oracle. To captu
 
 Syntax: `--%throws( [[schema.]package.]exception [, ... ])`
  
-So the exception name can be provided with or without the schema and package name. The package name is required only when the exception variable is located in another package. The schema name is required only when the exception variable is located in a pacakge in a nother schema.
+The exception name can be provided with or without the schema and package name. The package name is required only when the exception variable is located in another package than the unti test package. The schema name is required only when the exception variable is located in a package in another schema.
 
 Example:
 ```sql linenums="1"
 create or replace package exc_pkg is
   c_e_option1  constant number := -20200;
   c_e_option2  constant varchar2(10) := '-20201';
-  c_e_option3  number := -20202;
+  c_e_option3  integer := -20202;
           
-  e_option4 exception;
-  pragma exception_init(e_option4, -20203);
-          
+  e_initialized_exception    exception;
+  pragma exception_init(e_initialized_exception, -20203);
+
+  e_uninitialized_exception  exception;      
 end;
 /
 
 create or replace package example_pgk as
 
+  e_local_exception exception;
+  e_local_exception_num constant integer := -20123;
+    
   --%suite(Example Throws Annotation)
 
   --%test(Throws one of the listed exceptions)
@@ -1830,10 +1834,22 @@ create or replace package example_pgk as
   --%throws(exc_pkg.c_e_option3)
   procedure raised_option3_exception;
   
-  --%test(Throws package exception option4)
-  --%throws(exc_pkg.e_option4)
-  procedure raised_option4_exception;
+  --%test(Throws exception associated with exception number)
+  --%throws(exc_pkg.e_initialized_exception)
+  procedure raised_initialized_exception;
   
+  --%test(Throws uninitialized exception)
+  --%throws(exc_pkg.e_uninitialized_exception)
+  procedure raised_uninitialized_exception;
+  
+  --%test(Throws exception local to unit tests package)
+  --%throws(e_local_exception)
+  procedure raised_local_exception;
+      
+  --%test(Throws exception local to unit tests package with exception number)
+  --%throws(e_local_exception_num)
+  procedure raised_local_exception_num;
+      
   --%test(Raise name exception)
   --%throws(DUP_VAL_ON_INDEX)
   procedure raise_named_exc;
@@ -1844,6 +1860,7 @@ create or replace package example_pgk as
 
 end;  
 /
+
 create or replace package body example_pgk is
   procedure raised_one_listed_exception is
   begin
@@ -1880,11 +1897,28 @@ create or replace package body example_pgk is
       raise_application_error(exc_pkg.c_e_option3, 'Test error');
   end;
   
-  procedure raised_option4_exception is
+  procedure raised_initialized_exception is
   begin
-      raise exc_pkg.e_option4;
+      raise exc_pkg.e_initialized_exception;
   end;
   
+  procedure raised_uninitialized_exception is
+  begin
+      raise exc_pkg.e_uninitialized_exception;
+  end;
+  
+  procedure raised_local_exception is
+      pragma autonomous_transaction;
+  begin
+      raise e_local_exception;
+  end;
+  
+  procedure raised_local_exception_num is
+      pragma autonomous_transaction;
+  begin
+      raise_application_error(e_local_exception_num, 'Test error');
+  end;
+      
   procedure raise_named_exc is
   begin
       raise DUP_VAL_ON_INDEX;
@@ -1903,48 +1937,55 @@ exec ut3.ut.run('example_pgk');
 Running the test will give report:
 ```
 Example Throws Annotation
-  Throws one of the listed exceptions [.002 sec]
-  Throws different exception than expected [.002 sec] (FAILED - 1)
-  Throws different exception than listed [.003 sec] (FAILED - 2)
-  Gives failure when an exception is expected and nothing is thrown [.002 sec] (FAILED - 3)
-  Throws package exception option1 [.003 sec]
-  Throws package exception option2 [.002 sec]
-  Throws package exception option3 [.002 sec]
-  Throws package exception option4 [.002 sec]
-  Raise name exception [.002 sec]
-  Invalid throws annotation [.002 sec]
- 
+  Throws one of the listed exceptions [,026 sec]
+  Throws different exception than expected [,009 sec] (FAILED - 1)
+  Throws different exception than listed [,014 sec] (FAILED - 2)
+  Gives failure when an exception is expected and nothing is thrown [,016 sec] (FAILED - 3)
+  SUCCESS
+    Actual: 1 (number) was expected to equal: 1 (number)
+  Throws package exception option1 [,007 sec]
+  Throws package exception option2 [,008 sec]
+  Throws package exception option3 [,007 sec]
+  Throws exception associated with exception number [,006 sec]
+  Throws uninitialized exception [,006 sec]
+  Throws exception local to unit tests package [,009 sec]
+  Throws exception local to unit tests package with exception number [,011 sec]
+  Raise name exception [,006 sec]
+  Invalid throws annotation [,004 sec]
+
 Failures:
- 
+
   1) raised_different_exception
       Actual: -20143 was expected to equal: -20144
       ORA-20143: Test error
-      ORA-06512: at "UT3.EXAMPLE_PGK", line 9
-      ORA-06512: at "UT3.EXAMPLE_PGK", line 9
-      ORA-06512: at line 6
-       
+      ORA-06512: at "UT3_TESTER.EXAMPLE_PGK", line 9
+      ORA-06512: at "UT3_TESTER.EXAMPLE_PGK", line 9
+      ORA-06512: at line 7
+
   2) raised_unlisted_exception
       Actual: -20143 was expected to be one of: (-20144, -1, -20145)
       ORA-20143: Test error
-      ORA-06512: at "UT3.EXAMPLE_PGK", line 14
-      ORA-06512: at "UT3.EXAMPLE_PGK", line 14
-      ORA-06512: at line 6
-       
+      ORA-06512: at "UT3_TESTER.EXAMPLE_PGK", line 14
+      ORA-06512: at "UT3_TESTER.EXAMPLE_PGK", line 14
+      ORA-06512: at line 7
+
   3) nothing_thrown
       Expected one of exceptions (-20459, -20136, -20145) but nothing was raised.
-       
- 
+
+
 Warnings:
- 
-  1) example_pgk
+
+  1) example_pgk.raised_one_listed_exception
       Invalid parameter value "bad" for "--%throws" annotation. Parameter ignored.
-      at "UT3.EXAMPLE_PGK.RAISED_ONE_LISTED_EXCEPTION", line 6
+      at package "UT3_TESTER.EXAMPLE_PGK.RAISED_ONE_LISTED_EXCEPTION", line 8
+
   2) example_pgk
       "--%throws" annotation requires a parameter. Annotation ignored.
-      at "UT3.EXAMPLE_PGK.BAD_THROWS_ANNOTATION", line 42
- 
-Finished in .025784 seconds
-10 tests, 3 failed, 0 errored, 0 disabled, 2 warning(s)
+      at package "UT3_TESTER.EXAMPLE_PGK.BAD_THROWS_ANNOTATION", line 57
+
+Finished in ,138276 seconds
+13 tests, 3 failed, 0 errored, 0 disabled, 2 warning(s)
+
 ```
 
 ## Order of execution

--- a/source/core/types/ut_executable.tpb
+++ b/source/core/types/ut_executable.tpb
@@ -38,20 +38,30 @@ create or replace noneditionable type body ut_executable is
     return ut_metadata.form_name(l_owner_name, object_name, procedure_name);
   end;
 
-  member procedure do_execute(self in out nocopy ut_executable, a_item in out nocopy ut_suite_item) is
+  member procedure do_execute(
+    self in out nocopy ut_executable,
+    a_item in out nocopy ut_suite_item,
+    a_ignored_exception_names in ut_varchar2_rows := null,
+    a_ignored_exception_numbers in ut_varchar2_rows :=null)
+  is
     l_completed_without_errors  boolean;
   begin
-    l_completed_without_errors := self.do_execute(a_item);
+    l_completed_without_errors := self.do_execute(a_item, a_ignored_exception_names, a_ignored_exception_numbers);
   end do_execute;
 
-	member function do_execute(self in out nocopy ut_executable, a_item in out nocopy ut_suite_item) return boolean is
-    l_statement                varchar2(4000);
-    l_status                   number;
-    l_cursor_number            number;
-    l_completed_without_errors boolean := true;
-    l_failed_with_invalid_pck  boolean := true;
-    l_start_transaction_id     varchar2(250);
-    l_end_transaction_id     varchar2(250);
+  member function do_execute(
+    self in out nocopy ut_executable,
+    a_item in out nocopy ut_suite_item,
+    a_ignored_exception_names in ut_varchar2_rows := null,
+    a_ignored_exception_numbers in ut_varchar2_rows :=null)
+  return boolean is
+    l_statement                   varchar2(4000);
+    l_status                      number;
+    l_cursor_number               number;
+    l_completed_without_errors    boolean := true;
+    l_failed_with_invalid_pck     boolean := true;
+    l_start_transaction_id        varchar2(250);
+    l_end_transaction_id          varchar2(250);
 
     function is_defined return boolean is
       l_result boolean := false;
@@ -111,19 +121,33 @@ create or replace noneditionable type body ut_executable is
     if l_completed_without_errors then
       l_statement :=
       'declare' || chr(10) ||
-      '  l_error_stack varchar2(32767);' || chr(10) ||
-      '  l_error_backtrace varchar2(32767);' || chr(10) ||
+      '  l_error_stack                varchar2(32767);' || chr(10) ||
+      '  l_error_backtrace            varchar2(32767);' || chr(10) ||
+      '  l_ignored_exception_detected integer := 0;' || chr(10) ||
       'begin' || chr(10) ||
       '  begin' || chr(10) ||
       '    ' || self.form_name( a_skip_current_user_schema => true ) || ';' || chr(10) ||
       '  exception' || chr(10) ||
+              case when a_ignored_exception_names is not empty then
+      '    when ' || ut_utils.table_to_clob( a_ignored_exception_names, ' or ' ) || ' then ' || chr(10) ||
+      '      l_ignored_exception_detected := 1;'
+             end ||
       '    when others then ' || chr(10) ||
+            case when a_ignored_exception_numbers is not empty then
+      '      if sqlcode in (' || ut_utils.table_to_clob( a_ignored_exception_numbers, ', ' ) || ') then ' || chr(10) ||
+      '        l_ignored_exception_detected := 1; ' || chr(10) ||
+      '      else ' || chr(10) ||
+      '        l_error_stack := dbms_utility.format_error_stack;' || chr(10) ||
+      '        l_error_backtrace := dbms_utility.format_error_backtrace;' || chr(10) ||
+      '      end if;'
+            else
       '      l_error_stack := dbms_utility.format_error_stack;' || chr(10) ||
-      '      l_error_backtrace := dbms_utility.format_error_backtrace;' || chr(10) ||
-      '      --raise on ORA-04068, ORA-04061: existing state of packages has been discarded to avoid unrecoverable session exception' || chr(10) ||
+      '      l_error_backtrace := dbms_utility.format_error_backtrace;'
+            end || chr(10) ||
       '  end;' || chr(10) ||
       '  :a_error_stack := l_error_stack;' || chr(10) ||
       '  :a_error_backtrace := l_error_backtrace;' || chr(10) ||
+      '  :a_ignored_exception_detected := l_ignored_exception_detected;' || chr(10) ||
       'end;';
 
       ut_utils.debug_log('ut_executable.do_execute l_statement: ' || l_statement);
@@ -139,9 +163,11 @@ create or replace noneditionable type body ut_executable is
         dbms_sql.parse(l_cursor_number, statement => l_statement, language_flag => dbms_sql.native);
         dbms_sql.bind_variable(l_cursor_number, 'a_error_stack', to_char(null), 32767);
         dbms_sql.bind_variable(l_cursor_number, 'a_error_backtrace', to_char(null), 32767);
+        dbms_sql.bind_variable(l_cursor_number, 'a_ignored_exception_detected', to_number(null));
         l_status := dbms_sql.execute(l_cursor_number);
         dbms_sql.variable_value(l_cursor_number, 'a_error_stack', self.error_stack);
         dbms_sql.variable_value(l_cursor_number, 'a_error_backtrace', self.error_backtrace);
+        dbms_sql.variable_value(l_cursor_number, 'a_ignored_exception_detected', self.ignored_exception_detected);
         dbms_sql.close_cursor(l_cursor_number);
       exception 
         when ut_utils.ex_invalid_package then

--- a/source/core/types/ut_executable.tps
+++ b/source/core/types/ut_executable.tps
@@ -18,26 +18,37 @@ create or replace noneditionable type ut_executable under ut_event_item(
   /**
   * The name of the event to be executed before and after the executable is invoked
   */
-  executable_type       varchar2(250 char),
-  owner_name            varchar2(250 char),
-  object_name           varchar2(250 char),
-  procedure_name        varchar2(250 char),
-  error_backtrace       varchar2(4000),
-  error_stack           varchar2(4000),
-  serveroutput          clob,
+  executable_type            varchar2(250 char),
+  owner_name                 varchar2(250 char),
+  object_name                varchar2(250 char),
+  procedure_name             varchar2(250 char),
+  error_backtrace            varchar2(4000),
+  error_stack                varchar2(4000),
+  ignored_exception_detected integer,
+  serveroutput               clob,
   /**
   * Used for ordering of executables, as Oracle doesn not guarantee ordering of items in a nested table.
   */
   seq_no                integer,
 	constructor function ut_executable( self in out nocopy ut_executable, a_owner varchar2, a_package varchar2, a_procedure_name varchar2, a_executable_type varchar2) return self as result,
   member function form_name(a_skip_current_user_schema boolean := false) return varchar2,
-  member procedure do_execute(self in out nocopy ut_executable, a_item in out nocopy ut_suite_item),
+  member procedure do_execute(
+    self in out nocopy ut_executable,
+    a_item in out nocopy ut_suite_item,
+    a_ignored_exception_names in ut_varchar2_rows := null,
+    a_ignored_exception_numbers in ut_varchar2_rows := null
+  ),
   /**
   * executes the defines executable
   * returns true if executed without exceptions
   * returns false if exceptions were raised
   */
-  member function do_execute(self in out nocopy ut_executable, a_item in out nocopy ut_suite_item) return boolean,
+  member function do_execute(
+    self in out nocopy ut_executable,
+    a_item in out nocopy ut_suite_item,
+    a_ignored_exception_names in ut_varchar2_rows := null,
+    a_ignored_exception_numbers in ut_varchar2_rows :=null
+  ) return boolean,
   member function get_error_stack_trace return varchar2
 ) not final
 /

--- a/source/core/types/ut_executable_test.tpb
+++ b/source/core/types/ut_executable_test.tpb
@@ -74,6 +74,7 @@ create or replace noneditionable type body ut_executable_test as
         return remap_no_data_found(
  coalesce(
                 get_exception_no(a_exception_var),
+                get_exception_no(a_item.object_name||'.'||a_exception_var),
                 get_exception_no(a_item.object_owner||'.'||a_exception_var),
                 get_exception_no(a_item.object_owner||'.'||a_item.object_name||'.'||a_exception_var)
           )
@@ -93,6 +94,7 @@ create or replace noneditionable type body ut_executable_test as
       begin
         return coalesce(
                 verify_name(a_exception_var),
+                verify_name(a_item.object_name||'.'||a_exception_var),
                 verify_name(a_item.object_owner||'.'||a_exception_var),
                 verify_name(a_item.object_owner||'.'||a_item.object_name||'.'||a_exception_var)
         );

--- a/source/core/types/ut_executable_test.tpb
+++ b/source/core/types/ut_executable_test.tpb
@@ -136,7 +136,7 @@ create or replace noneditionable type body ut_executable_test as
       end if;
     end;
 
-    function get_exception_failure_message(a_expected_errors_list ut_varchar2_rows) return varchar is
+    function get_exception_failure_message(a_expected_errors_list ut_varchar2_rows) return varchar2 is
       l_actual_error_no      integer;
       l_expected_errors      varchar2(4000);
       l_fail_message         varchar2(4000);

--- a/source/core/types/ut_executable_test.tpb
+++ b/source/core/types/ut_executable_test.tpb
@@ -31,147 +31,127 @@ create or replace noneditionable type body ut_executable_test as
 
   member procedure do_execute(
     self in out nocopy ut_executable_test, a_item in out nocopy ut_suite_item,
-    a_expected_error_codes in ut_varchar2_rows
+    a_expected_errors in ut_varchar2_rows
   ) is
     l_completed_without_errors  boolean;
   begin
-    l_completed_without_errors := self.do_execute(a_item, a_expected_error_codes);
+    l_completed_without_errors := self.do_execute(a_item, a_expected_errors);
   end do_execute;
 
   member function do_execute(
     self in out nocopy ut_executable_test, a_item in out nocopy ut_suite_item,
-    a_expected_error_codes in ut_varchar2_rows
+    a_expected_errors in ut_varchar2_rows
   ) return boolean is
-    l_expected_except_message  varchar2(4000);
-    l_expected_error_numbers   ut_integer_list;
+    l_failure_message          varchar2(32767);
+    l_expected_error_names     ut_varchar2_rows;
+    l_expected_error_numbers   ut_varchar2_rows;
+    l_all_expected_errors      ut_varchar2_rows;
 
-    function build_exception_numbers_list(
-      a_item                 in out nocopy ut_suite_item,
-      a_expected_error_codes in ut_varchar2_rows
-    ) return ut_integer_list is
+    procedure build_expected_exceptions(
+      a_item                   in out nocopy ut_suite_item,
+      a_exception_definitions  in ut_varchar2_rows,
+      a_exception_names_list   out ut_varchar2_rows,
+      a_exception_numbers_list out ut_varchar2_rows
+    ) is
       l_exception_number        integer;
-      l_exception_number_list   ut_integer_list := ut_integer_list();
-      c_regexp_for_exception_no constant varchar2(30) := '^-?[[:digit:]]{1,5}$';
-
-      c_integer_exception       constant varchar2(1) := 'I';
-      c_named_exception         constant varchar2(1) := 'N';
-
-      function is_valid_qualified_name (a_name varchar2) return boolean is
-        l_name varchar2(500);
-      begin
-        l_name := dbms_assert.qualified_sql_name(a_name);
-        return true;
-      exception when others then
-        return false;
-      end;
-
-      function to_exception_number(a_exception_name in varchar2) return integer is
-        l_exception_type varchar2(100);
-        l_exc_no integer;
-      begin
-
-        --check if it is a predefined exception
+      l_exception_name          varchar2(128);
+      function to_exception_number (a_exception_var in varchar2, a_item ut_suite_item) return integer is
+        function get_exception_no(a_exception_var in varchar2) return integer is
+          l_exc_no integer;
         begin
-          execute immediate 'begin null; exception when '||a_exception_name||' then null; end;';
-          l_exception_type := c_named_exception;
+          execute immediate 'declare l_exception integer; begin :l_exception := '||a_exception_var||'; end;'
+            using out l_exc_no;
+          return l_exc_no;
         exception
           when others then
-            if dbms_utility.format_error_stack() like '%PLS-00485%' then
-              declare
-                e_invalid_number exception;
-                pragma exception_init ( e_invalid_number, -6502 );
-              begin
-                execute immediate 'declare x integer := '||a_exception_name||'; begin null; end;';
-                l_exception_type := c_integer_exception;
-              exception
-                when others then
-                  null;
-              end;
-              end if;
+              return null;
         end;
-
-        execute immediate
-          case l_exception_type
-          when c_integer_exception then
-            'declare l_exception number; begin :l_exception := '||a_exception_name||'; end;'
-          when c_named_exception then
-            'begin raise '||a_exception_name||'; exception when others then :l_exception := sqlcode; end;'
-          else
-            'begin :l_exception := null; end;'
-          end
-          using out l_exc_no;
-        return l_exc_no;
-      end;
-
-      function get_exception_number (a_exception_var in varchar2, a_item ut_suite_item) return integer is
-        l_exc_no   integer;
-        l_exc_type varchar2(50);
         function remap_no_data_found (a_number integer) return integer is
         begin
           return case a_number when 100 then -1403 else a_number end;
         end;
       begin
-        l_exc_no := coalesce(
-                to_exception_number(a_exception_var),
-                to_exception_number(a_item.object_owner||'.'||a_exception_var),
-                to_exception_number(a_item.object_owner||'.'||a_item.object_name||'.'||a_exception_var)
+        return remap_no_data_found(
+ coalesce(
+                get_exception_no(a_exception_var),
+                get_exception_no(a_item.object_owner||'.'||a_exception_var),
+                get_exception_no(a_item.object_owner||'.'||a_item.object_name||'.'||a_exception_var)
+          )
+        );
+      end;
+
+      function to_exception_name (a_exception_var in varchar2, a_item ut_suite_item) return varchar2 is
+        function verify_name(a_exception_name in varchar2) return varchar2 is
+        begin
+          --check if it is an existing, named exception
+          execute immediate 'begin null; exception when '||a_exception_name||' then null; end;';
+          return a_exception_name;
+        exception
+          when others then
+              return null;
+        end;
+      begin
+        return coalesce(
+                verify_name(a_exception_var),
+                verify_name(a_item.object_owner||'.'||a_exception_var),
+                verify_name(a_item.object_owner||'.'||a_item.object_name||'.'||a_exception_var)
         );
 
-        return remap_no_data_found(l_exc_no);
       end;
 
     begin
-      if a_expected_error_codes is not empty then
-        for i in 1 .. a_expected_error_codes.count loop
-          /**
-          * Check if its a valid qualified name and if so try to resolve name to an exception number
-          */
-          if is_valid_qualified_name(a_expected_error_codes(i)) then
-            l_exception_number := get_exception_number(a_expected_error_codes(i), a_item);
-          elsif regexp_like(a_expected_error_codes(i), c_regexp_for_exception_no) then
-            l_exception_number := a_expected_error_codes(i);
-          end if;
+      a_exception_names_list   := ut_varchar2_rows();
+      a_exception_numbers_list := ut_varchar2_rows();
+      if a_exception_definitions is not empty then
+        for i in 1 .. a_exception_definitions.count loop
+          l_exception_number :=
+            coalesce(
+              to_exception_number(a_exception_definitions(i), a_item),
+              to_number(a_exception_definitions(i) default null on conversion error )
+          );
+          l_exception_name := to_exception_name(a_exception_definitions(i), a_item);
 
-          if l_exception_number is null then
+          if l_exception_number is null and l_exception_name is null then
             a_item.put_warning(
-              'Invalid parameter value "'||a_expected_error_codes(i)||'" for "--%throws" annotation. Parameter ignored.',
+              'Invalid parameter value "'||a_exception_definitions(i)||'" for "--%throws" annotation. Parameter ignored.',
               self.procedure_name,
               a_item.line_no
             );
           elsif l_exception_number >= 0 then
             a_item.put_warning(
-              'Invalid parameter value "'||a_expected_error_codes(i)||'" for "--%throws" annotation. Exception value must be a negative integer. Parameter ignored.',
+              'Invalid parameter value "'||a_exception_definitions(i)||'" for "--%throws" annotation. Exception value must be a negative integer. Parameter ignored.',
               self.procedure_name,
               a_item.line_no
               );
-          else
-            l_exception_number_list.extend;
-            l_exception_number_list(l_exception_number_list.last) := l_exception_number;
+          elsif l_exception_number is not null then
+            a_exception_numbers_list.extend;
+            a_exception_numbers_list(a_exception_numbers_list.last) := l_exception_number;
+          elsif l_exception_name is not null then
+            a_exception_names_list.extend;
+            a_exception_names_list(a_exception_names_list.last) := l_exception_name;
           end if;
-          l_exception_number := null;
         end loop;
       end if;
-
-      return l_exception_number_list;
     end;
-    function failed_expec_errnum_message(a_expected_error_codes in ut_integer_list) return varchar is
+
+    function get_exception_failure_message(a_expected_errors_list ut_varchar2_rows) return varchar is
       l_actual_error_no      integer;
-      l_expected_error_codes varchar2(4000);
+      l_expected_errors      varchar2(4000);
       l_fail_message         varchar2(4000);
     begin
       --Convert the ut_varchar2_list to string to can construct the message
-      l_expected_error_codes := ut_utils.table_to_clob(a_expected_error_codes, ', ');
+      l_expected_errors := ut_utils.table_to_clob(a_expected_errors_list, ', ');
 
       if self.error_stack is null then
-        l_fail_message := 'Expected one of exceptions ('||l_expected_error_codes||') but nothing was raised.';
+        l_fail_message := 'Expected one of exceptions ('|| l_expected_errors|| ') but nothing was raised.';
       else
         l_actual_error_no := regexp_substr(self.error_stack, '^[[:alpha:]]{3}(-[0-9]+)', subexpression=>1);
-        if not l_actual_error_no member of a_expected_error_codes or l_actual_error_no is null then
+        if not l_actual_error_no member of a_expected_errors_list or l_actual_error_no is null then
           l_fail_message := 'Actual: '||l_actual_error_no||' was expected to ';
-          if cardinality(a_expected_error_codes) > 1 then
-            l_fail_message := l_fail_message || 'be one of: ('||l_expected_error_codes||')';
+          if cardinality(a_expected_errors_list) > 1 then
+            l_fail_message := l_fail_message || 'be one of: ('|| l_expected_errors|| ')';
           else
-            l_fail_message := l_fail_message || 'equal: '||l_expected_error_codes;
+            l_fail_message := l_fail_message || 'equal: '||l_expected_errors;
           end if;
           l_fail_message := substr( l_fail_message||chr(10)||self.error_stack||chr(10)||self.error_backtrace, 1, 4000 );
         end if;
@@ -181,14 +161,16 @@ create or replace noneditionable type body ut_executable_test as
     end;
   begin
     --Create a ut_executable object and call do_execute after that get the data to know the test's execution result
-    self.do_execute(a_item);
-    l_expected_error_numbers := build_exception_numbers_list(a_item, a_expected_error_codes);
-    if l_expected_error_numbers is not null and l_expected_error_numbers is not empty then
-      l_expected_except_message := failed_expec_errnum_message( l_expected_error_numbers );
+    build_expected_exceptions(a_item, a_expected_errors, l_expected_error_names, l_expected_error_numbers );
 
-      if l_expected_except_message is not null then
+    self.do_execute(a_item, l_expected_error_names, l_expected_error_numbers);
+    l_all_expected_errors := l_expected_error_names multiset union all l_expected_error_numbers;
+    if l_all_expected_errors is not empty and self.ignored_exception_detected = 0 then
+      l_failure_message := get_exception_failure_message( l_all_expected_errors);
+
+      if l_failure_message is not null then
         ut_expectation_processor.add_expectation_result(
-          ut_expectation_result(ut_utils.gc_failure, null, l_expected_except_message, false)
+          ut_expectation_result(ut_utils.gc_failure, null, l_failure_message, false)
         );
       end if;
       self.error_stack := null;

--- a/source/core/types/ut_executable_test.tps
+++ b/source/core/types/ut_executable_test.tps
@@ -22,12 +22,12 @@ create or replace noneditionable type ut_executable_test authid current_user und
   
   member procedure do_execute(
     self in out nocopy ut_executable_test, a_item in out nocopy ut_suite_item, 
-    a_expected_error_codes in ut_varchar2_rows
+    a_expected_errors in ut_varchar2_rows
   ),
   
   member function do_execute(
     self in out nocopy ut_executable_test, a_item in out nocopy ut_suite_item, 
-    a_expected_error_codes in ut_varchar2_rows
+    a_expected_errors in ut_varchar2_rows
   ) return boolean
   
 ) final;

--- a/test/ut3_tester/core/annotations/test_annot_throws_exception.pkb
+++ b/test/ut3_tester/core/annotations/test_annot_throws_exception.pkb
@@ -152,6 +152,10 @@ is
         --%throws(e_uninitialized_exception_variable)
         procedure referencing_uninitialized_exception;
 
+        --%test(Failure report shows all expected exceptions)
+        --%throws(c_local_error_no,e_some_local_exception,e_uninitialized_exception_variable)
+        procedure not_throwing_expected_exceptions;
+
       end;
     ]';
 
@@ -296,6 +300,11 @@ is
         procedure referencing_uninitialized_exception is
         begin
           raise e_uninitialized_exception_variable;
+        end;
+
+        procedure not_throwing_expected_exceptions is
+        begin
+          raise_application_error(-20143, ''Test error'');
         end;
       end;
     ';
@@ -495,6 +504,12 @@ is
     l_actual := ut3_develop.ut_utils.table_to_clob(l_test_results);
     ut.expect(l_actual).to_match('^\s*Uninitialized exception variable can be used successfully in a test \[[,\.0-9]+ sec\]\s*$','m');
     ut.expect(l_actual).not_to_match('referencing_uninitialized_exception');
+  end;
+
+  procedure not_throwing_expected_exceptions is
+  begin
+    ut.expect(g_tests_results).to_match('not_throwing_expected_exceptions');
+    ut.expect(g_tests_results).to_match('Actual: -20143 was expected to be one of: \(annotated_package_with_throws.e_some_local_exception, annotated_package_with_throws.e_uninitialized_exception_variable, -20211\)');
   end;
 
 end;

--- a/test/ut3_tester/core/annotations/test_annot_throws_exception.pkb
+++ b/test/ut3_tester/core/annotations/test_annot_throws_exception.pkb
@@ -36,6 +36,8 @@ is
         e_some_local_exception exception;
         pragma exception_init(e_some_local_exception, -20212);
 
+        e_uninitialized_exception_variable exception;
+
         --%suite(Dummy package to test annotation throws)
 
         --%test(Throws same annotated exception)
@@ -145,6 +147,11 @@ is
         --%test(Bad exception constant)
         --%throws(exc_pkg.c_e_dummy);
         procedure bad_exc_const;
+
+        --%test(Uninitialized exception variable can be used successfully in a test)
+        --%throws(e_uninitialized_exception_variable)
+        procedure referencing_uninitialized_exception;
+
       end;
     ]';
 
@@ -286,6 +293,10 @@ is
           raise_application_error(-20143, ''Test error'');
         end;
            
+        procedure referencing_uninitialized_exception is
+        begin
+          raise e_uninitialized_exception_variable;
+        end;
       end;
     ';
 
@@ -298,6 +309,14 @@ is
 
     g_tests_results := ut3_develop.ut_utils.table_to_clob(l_test_results);
   end;
+
+  procedure drop_test_package is
+    pragma autonomous_transaction;
+  begin
+    execute immediate 'drop package annotated_package_with_throws';
+    execute immediate 'drop package exc_pkg';
+  end;
+
 
   procedure throws_same_annotated_except is
   begin
@@ -409,26 +428,26 @@ is
 
   procedure named_exc_pragma_run_from_another_schema is
   begin
-    ut.expect(g_results_other_schema).to_match('^\s*Success referencing an exception variable when running from another schema \[[,\.0-9]+ sec\]\s*$','m');
-    ut.expect(g_results_other_schema).not_to_match('named_exc_pragma_run_from_another_schema');
+      ut.expect(g_results_other_schema).to_match('^\s*Success referencing an exception variable when running from another schema \[[,\.0-9]+ sec\]\s*$', 'm');
+      ut.expect(g_results_other_schema).not_to_match('named_exc_pragma_run_from_another_schema');
   end;
 
   procedure named_exc_pragma_run_from_another_schema_no_package_name is
   begin
-    ut.expect(g_results_other_schema).to_match('^\s*Success referencing an exception variable without package name when running from another schema \[[,\.0-9]+ sec\]\s*$','m');
-    ut.expect(g_results_other_schema).not_to_match('named_exc_pragma_run_from_another_schema_no_package_name');
+      ut.expect(g_results_other_schema).to_match('^\s*Success referencing an exception variable without package name when running from another schema \[[,\.0-9]+ sec\]\s*$', 'm');
+      ut.expect(g_results_other_schema).not_to_match('named_exc_pragma_run_from_another_schema_no_package_name');
   end;
 
   procedure exc_number_var_run_from_another_schema_no_package_name is
   begin
-    ut.expect(g_results_other_schema).to_match('^\s*Success referencing a numeric exception variable without package name when running from another schema \[[,\.0-9]+ sec\]\s*$','m');
-    ut.expect(g_results_other_schema).not_to_match('exc_number_var_run_from_another_schema_no_package_name');
+      ut.expect(g_results_other_schema).to_match('^\s*Success referencing a numeric exception variable without package name when running from another schema \[[,\.0-9]+ sec\]\s*$', 'm');
+      ut.expect(g_results_other_schema).not_to_match('exc_number_var_run_from_another_schema_no_package_name');
   end;
 
   procedure exc_number_var_run_from_another_schema is
   begin
-    ut.expect(g_results_other_schema).to_match('^\s*Success referencing a numeric exception variable when running from another schema \[[,\.0-9]+ sec\]\s*$','m');
-    ut.expect(g_results_other_schema).not_to_match('exc_number_var_run_from_another_schema');
+      ut.expect(g_results_other_schema).to_match('^\s*Success referencing a numeric exception variable when running from another schema \[[,\.0-9]+ sec\]\s*$', 'm');
+      ut.expect(g_results_other_schema).not_to_match('exc_number_var_run_from_another_schema');
   end;
 
   procedure named_exc_ora is
@@ -465,13 +484,17 @@ is
   begin
     ut.expect(g_tests_results).to_match('^\s*Bad exception constant \[[,\.0-9]+ sec\] \(FAILED - [0-9]+\)\s*$','m');
     ut.expect(g_tests_results).to_match('bad_exc_const\s*ORA-20143: Test error\s*ORA-06512: at "UT3_TESTER.ANNOTATED_PACKAGE_WITH_THROWS"');
-  end; 
-  
-  procedure drop_test_package is
-    pragma autonomous_transaction;
+  end;
+
+  procedure referencing_uninitialized_exception is
+      l_test_results ut3_develop.ut_varchar2_list;
+      l_actual clob;
   begin
-    execute immediate 'drop package annotated_package_with_throws';
-    execute immediate 'drop package exc_pkg';
+    select * bulk collect into l_test_results from table(ut3_develop.ut.run(('annotated_package_with_throws.referencing_uninitialized_exception')));
+
+    l_actual := ut3_develop.ut_utils.table_to_clob(l_test_results);
+    ut.expect(l_actual).to_match('^\s*Uninitialized exception variable can be used successfully in a test \[[,\.0-9]+ sec\]\s*$','m');
+    ut.expect(l_actual).not_to_match('referencing_uninitialized_exception');
   end;
 
 end;

--- a/test/ut3_tester/core/annotations/test_annot_throws_exception.pks
+++ b/test/ut3_tester/core/annotations/test_annot_throws_exception.pks
@@ -40,7 +40,7 @@ is
   --%test(Detects a valid exception number within many invalid ones)
   procedure one_valid_exception_number;
   
-  --%test(Gives failure when a exception is expected and nothing is thrown)
+  --%test(Gives failure when an exception is expected and nothing is thrown)
   procedure nothing_thrown;
 
   --%test(Single exception defined as a constant number in package)
@@ -49,13 +49,13 @@ is
   --%test(Gives success when one of annotated exception using constant is thrown)
   procedure list_of_exc_constant;  
 
-  --%test(Gives failure when the raised exception is different that the annotated one using variable)
+  --%test(Gives failure when the raised exception is different than the annotated one using variable)
   procedure fail_not_match_exc;  
   
-  --%test(Success when one of exception from mixed list of number and constant is thrown) 
+  --%test(Success when one of exception from a mixed list of number and constant is thrown)
   procedure mixed_exc_list; 
     
-  --%test(Success when match exception even if other variable on list dont exists)  
+  --%test(Success when match exception even if another variable on list doesn't exists)
   procedure mixed_list_notexi;
     
   --%test(Success resolve and match named exception defined in pragma exception init)  
@@ -81,6 +81,9 @@ is
 
   --%test(Uninitialized exception variable can be used successfully in a test)
   procedure referencing_uninitialized_exception;
+
+  --%test(a Failure report shows all expected exceptions)
+  procedure not_throwing_expected_exceptions;
   
   --%context(referencing exceptions when running from another schema)
 

--- a/test/ut3_tester/core/annotations/test_annot_throws_exception.pks
+++ b/test/ut3_tester/core/annotations/test_annot_throws_exception.pks
@@ -5,7 +5,11 @@ is
     
   --%beforeall
   procedure recollect_tests_results;
-  
+
+  --%afterall
+  procedure drop_test_package;
+
+
   --%test(Gives success when annotated number exception is thrown)
   procedure throws_same_annotated_except;
 
@@ -73,11 +77,11 @@ is
   procedure non_existing_const;   
   
   --%test(Bad exception constant)  
-  procedure bad_exc_const;     
-  
-  --%afterall
-  procedure drop_test_package;
+  procedure bad_exc_const;
 
+  --%test(Uninitialized exception variable can be used successfully in a test)
+  procedure referencing_uninitialized_exception;
+  
   --%context(referencing exceptions when running from another schema)
 
     --%beforeall

--- a/test/ut3_tester/core/test_ut_suite_tag_filter.pkb
+++ b/test/ut3_tester/core/test_ut_suite_tag_filter.pkb
@@ -101,7 +101,7 @@ create or replace package body test_ut_suite_tag_filter is
             ut3_develop.ut_varchar2_rows('context_tag'), null),
           ut3_develop.ut_suite_cache_row(
             3, 'UT_TEST', 'some.path.test_tags.nested_context_#1.create_new_mapping', 'TEST_USER', 'TEST_TAGS', 'CREATE_NEW_MAPPING', 11, timestamp '2026-05-06 10:23:38.461299', NULL, NULL, 0, NULL, null,  null, null, null, null, null, null, null,
-            ut3_develop.ut_varchar2_rows('test_tag'), ut3_develop.ut_executable_test('UT_EXECUTABLE_TEST', 'test', 'TEST_USER', 'test_tags', 'create_new_mapping', NULL, NULL, NULL, NULL))
+            ut3_develop.ut_varchar2_rows('test_tag'), ut3_develop.ut_executable_test('UT_EXECUTABLE_TEST', 'test', 'TEST_USER', 'test_tags', 'create_new_mapping', NULL, NULL, NULL, NULL, NULL))
       );
 
       ut.expect(ut3_develop.ut_suite_tag_filter.apply( l_input_data, 'slow').count).to_equal(3 );

--- a/test/ut3_user/api/test_ut_run.pkb
+++ b/test/ut3_user/api/test_ut_run.pkb
@@ -551,7 +551,7 @@ Failures:%
       ORA-04068: existing state of packages (DB_LOOPBACK%) has been discarded
       ORA-04061: existing state of package body "%.STATEFUL_PACKAGE" has been invalidated
       ORA-04065: not executed, altered or dropped package body "%.STATEFUL_PACKAGE"%
-      ORA-06512: at line 6%
+      ORA-06512: at line 7%
 1 tests, 0 failed, 1 errored, 0 disabled, 0 warning(s)%';
 
     --Act

--- a/test/ut3_user/reporters/test_documentation_reporter.pkb
+++ b/test/ut3_user/reporters/test_documentation_reporter.pkb
@@ -38,7 +38,7 @@ Failures:
   2) erroring_test
       ORA-06502: PL/SQL: %: character to number conversion error
       ORA-06512: at "UT3_USER.TEST_REPORTERS", line 44%
-      ORA-06512: at line 6
+      ORA-06512: at line 7
 Finished in % seconds
 5 tests, 1 failed, 1 errored, 2 disabled, 0 warning(s)%]';
 

--- a/test/ut3_user/reporters/test_realtime_reporter.pkb
+++ b/test/ut3_user/reporters/test_realtime_reporter.pkb
@@ -410,7 +410,7 @@ create or replace package body test_realtime_reporter as
            = 'realtime_reporting.check_realtime_reporting3.test_6_with_runtime_error';
     ut3_tester_helper.main_helper.append_to_list(l_expected_list, '<![CDATA[ORA-00942: table or view %does not exist');
     ut3_tester_helper.main_helper.append_to_list(l_expected_list, 'ORA-06512: at "%.CHECK_REALTIME_REPORTING3", line 5');
-    ut3_tester_helper.main_helper.append_to_list(l_expected_list, '%ORA-06512: at line 6]]>');
+    ut3_tester_helper.main_helper.append_to_list(l_expected_list, '%ORA-06512: at line 7]]>');
     l_expected := ut3_tester_helper.main_helper.table_to_clob(l_expected_list);
     ut.expect(l_actual).to_be_like(l_expected);
   end error_stack_of_test;
@@ -427,7 +427,7 @@ create or replace package body test_realtime_reporter as
            = 'realtime_reporting.check_realtime_reporting3';
     ut3_tester_helper.main_helper.append_to_list(l_expected_list, '<![CDATA[ORA-01403: no data found');
     ut3_tester_helper.main_helper.append_to_list(l_expected_list, 'ORA-06512: at "%.CHECK_REALTIME_REPORTING3", line 21');
-    ut3_tester_helper.main_helper.append_to_list(l_expected_list, '%ORA-06512: at line 6]]>');
+    ut3_tester_helper.main_helper.append_to_list(l_expected_list, '%ORA-06512: at line 7]]>');
     l_expected := ut3_tester_helper.main_helper.table_to_clob(l_expected_list);
     ut.expect(l_actual).to_be_like(l_expected);
   end error_stack_of_testsuite;


### PR DESCRIPTION
It is now possible to reference an uninitialized exception variable name.
utPLSQL will handle the exception properly.

Resolves: #1340